### PR TITLE
Add experimental support for templates and appending

### DIFF
--- a/src/app/cli/cmd_append.go
+++ b/src/app/cli/cmd_append.go
@@ -1,0 +1,18 @@
+package cli
+
+import (
+	"klog/app"
+)
+
+type Append struct {
+	File string `arg optional type:"existingfile" name:"file" help:".klg source file (if empty the bookmark is used)"`
+	From string `required name:"from" help:"The name of the template to instantiate"`
+}
+
+func (args *Append) Run(ctx app.Context) error {
+	target := args.File
+	if target == "" {
+		target = ctx.Bookmark().Path
+	}
+	return ctx.AppendTemplateToFile(target, args.From)
+}

--- a/src/app/cli/common_args.go
+++ b/src/app/cli/common_args.go
@@ -7,7 +7,7 @@ import (
 )
 
 type InputFilesArgs struct {
-	File []string `arg optional type:"existingfile" name:"file" help:".klg source file(s) (falls back to bookmark if not specified)"`
+	File []string `arg optional type:"existingfile" name:"file" help:".klg source file(s) (if empty the bookmark is used)"`
 }
 
 type DiffArg struct {

--- a/src/app/cli/exec.go
+++ b/src/app/cli/exec.go
@@ -18,6 +18,7 @@ type cli struct {
 	Eval     Eval     `cmd hidden`
 	Report   Report   `cmd help:"Print a calendar report summarising all days"`
 	Tags     Tags     `cmd help:"Print total times aggregated by tags"`
+	Append   Append   `cmd hidden help:"Appends a new record to a file (based on templates)"`
 	Bookmark Bookmark `cmd help:"Set a default file that klog reads from"`
 	Widget   Widget   `cmd help:"Start menu bar widget (MacOS only)"`
 	Version  Version  `cmd help:"Print version info and check for updates"`

--- a/src/app/cli/testutil_test.go
+++ b/src/app/cli/testutil_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"klog"
 	"klog/app"
 	"klog/parser"
@@ -34,8 +35,12 @@ func (m *TestContext) Print(s string) {
 	m.printBuffer += s
 }
 
-func (m *TestContext) HomeDir() string {
+func (m *TestContext) HomeFolder() string {
 	return "~"
+}
+
+func (m *TestContext) KlogFolder() string {
+	return m.HomeFolder() + "/.klog/"
 }
 
 func (m *TestContext) MetaInfo() struct {
@@ -66,4 +71,8 @@ func (m *TestContext) Bookmark() *app.File {
 
 func (m *TestContext) OpenInFileBrowser(_ string) error {
 	return nil
+}
+
+func (m *TestContext) AppendTemplateToFile(string, string) error {
+	return errors.New("No such template")
 }

--- a/src/app/context.go
+++ b/src/app/context.go
@@ -6,11 +6,13 @@ import (
 	"io/ioutil"
 	"klog"
 	"klog/parser"
+	"klog/service"
 	"os"
 	"os/exec"
 	"os/user"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 var BinaryVersion string   // will be set during build
@@ -18,7 +20,8 @@ var BinaryBuildHash string // will be set during build
 
 type Context interface {
 	Print(string)
-	HomeDir() string
+	KlogFolder() string
+	HomeFolder() string
 	MetaInfo() struct {
 		Version   string
 		BuildHash string
@@ -27,6 +30,7 @@ type Context interface {
 	SetBookmark(string) error
 	Bookmark() *File
 	OpenInFileBrowser(string) error
+	AppendTemplateToFile(string, string) error
 }
 
 type context struct {
@@ -51,8 +55,12 @@ func (c *context) Print(text string) {
 	fmt.Print(text)
 }
 
-func (c *context) HomeDir() string {
+func (c *context) HomeFolder() string {
 	return c.homeDir
+}
+
+func (c *context) KlogFolder() string {
+	return c.homeDir + "/.klog/"
 }
 
 func (c *context) MetaInfo() struct {
@@ -95,9 +103,9 @@ func (c *context) RetrieveRecords(paths ...string) ([]klog.Record, error) {
 		if err != nil {
 			return nil, err
 		}
-		rs, errs := parser.Parse(content)
-		if errs != nil {
-			return nil, errs
+		rs, parserErrors := parser.Parse(content)
+		if parserErrors != nil {
+			return nil, parserErrors
 		}
 		records = append(records, rs...)
 	}
@@ -111,7 +119,7 @@ type File struct {
 }
 
 func (c *context) Bookmark() *File {
-	bookmarkPath := c.HomeDir() + "/.klog/bookmark.klg"
+	bookmarkPath := c.KlogFolder() + "bookmark.klg"
 	dest, err := os.Readlink(bookmarkPath)
 	if err != nil {
 		return nil
@@ -130,19 +138,23 @@ func (c *context) Bookmark() *File {
 func (c *context) SetBookmark(path string) error {
 	bookmark, err := filepath.Abs(path)
 	if err != nil {
-		return err
+		return errors.New("Target file does not exist")
 	}
 	if !strings.HasSuffix(bookmark, ".klg") {
 		return errors.New("File name must have .klg extension")
 	}
-	klogFolder := c.HomeDir() + "/.klog"
+	klogFolder := c.KlogFolder()
 	err = os.MkdirAll(klogFolder, 0700)
 	if err != nil {
-		return err
+		return errors.New("Unable to initialise ~/.klog folder")
 	}
 	symlink := klogFolder + "/bookmark.klg"
 	_ = os.Remove(symlink)
-	return os.Symlink(bookmark, symlink)
+	err = os.Symlink(bookmark, symlink)
+	if err != nil {
+		return errors.New("Failed to create bookmark")
+	}
+	return nil
 }
 
 func (c *context) OpenInFileBrowser(path string) error {
@@ -150,10 +162,40 @@ func (c *context) OpenInFileBrowser(path string) error {
 	return cmd.Run()
 }
 
+func (c *context) AppendTemplateToFile(filePath string, templateName string) error {
+	location := c.KlogFolder() + templateName + ".template.klg"
+	template, err := readFile(location)
+	if err != nil {
+		return errors.New("No such template: " + location)
+	}
+	instance, err := service.RenderTemplate(template, time.Now())
+	if err != nil {
+		return err
+	}
+	contents, err := readFile(filePath)
+	if err != nil {
+		return err
+	}
+	err = appendToFile(filePath, service.AppendableText(contents, instance))
+	return err
+}
+
 func readFile(path string) (string, error) {
 	contents, err := ioutil.ReadFile(path)
 	if err != nil {
-		return "", err
+		return "", errors.New("Cannot read file: " + path)
 	}
 	return string(contents), nil
+}
+
+func appendToFile(path string, textToAppend string) error {
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return errors.New("Cannot write to file: " + path)
+	}
+	defer file.Close()
+	if _, err := file.WriteString(textToAppend); err != nil {
+		return errors.New("Cannot write to file: " + path)
+	}
+	return nil
 }

--- a/src/app/mac_widget/render_darwin.go
+++ b/src/app/mac_widget/render_darwin.go
@@ -20,6 +20,12 @@ func render(ctx app.Context, agent *launchAgent) []menuet.MenuItem {
 			if err == nil {
 				return renderRecords(ctx, rs, file)
 			}
+			return []menuet.MenuItem{{
+				Text:       "Bookmarked file invalid",
+				FontWeight: menuet.WeightBold,
+			}, {
+				Text: "Please fix the syntax errors",
+			}}
 		}
 		return []menuet.MenuItem{{
 			Text:       "No bookmark specified",

--- a/src/app/mac_widget/run_darwin.go
+++ b/src/app/mac_widget/run_darwin.go
@@ -16,7 +16,7 @@ func Run(forceRunThroughLaunchAgent bool) {
 		os.Exit(1)
 	}
 	binPath, _ := os.Executable()
-	launchAgent := NewLaunchAgent(ctx.HomeDir(), binPath)
+	launchAgent := NewLaunchAgent(ctx.HomeFolder(), binPath)
 
 	if forceRunThroughLaunchAgent {
 		if !launchAgent.isActive() {

--- a/src/service/evaluate.go
+++ b/src/service/evaluate.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	. "klog"
+	"time"
+)
+
+func Total(rs ...Record) Duration {
+	total, _ := HypotheticalTotal(time.Time{}, rs...)
+	return total
+}
+
+func TotalEntries(es ...Entry) Duration {
+	total := NewDuration(0, 0)
+	for _, e := range es {
+		total = total.Plus(e.Duration())
+	}
+	return total
+}
+
+func HypotheticalTotal(until time.Time, rs ...Record) (Duration, bool) {
+	total := NewDuration(0, 0)
+	isCurrent := false
+	void := time.Time{}
+	thisDay := NewDateFromTime(until)
+	theDayBefore := thisDay.PlusDays(-1)
+	for _, r := range rs {
+		for _, e := range r.Entries() {
+			t := (e.Unbox(
+				func(r Range) interface{} { return r.Duration() },
+				func(d Duration) interface{} { return d },
+				func(o OpenRange) interface{} {
+					if until != void && (r.Date().IsEqualTo(thisDay) || r.Date().IsEqualTo(theDayBefore)) {
+						end := NewTimeFromTime(until)
+						if r.Date().IsEqualTo(theDayBefore) {
+							end, _ = NewTimeTomorrow(end.Hour(), end.Minute())
+						}
+						tr, err := NewRange(o.Start(), end)
+						if err == nil {
+							isCurrent = true
+							return tr.Duration()
+						}
+					}
+					return NewDuration(0, 0)
+				})).(Duration)
+			total = total.Plus(t)
+		}
+	}
+	return total, isCurrent
+}
+
+func ShouldTotalSum(rs ...Record) ShouldTotal {
+	total := NewDuration(0, 0)
+	for _, r := range rs {
+		total = total.Plus(r.ShouldTotal())
+	}
+	return NewShouldTotal(0, total.InMinutes())
+}

--- a/src/service/evaluate_test.go
+++ b/src/service/evaluate_test.go
@@ -1,0 +1,47 @@
+package service
+
+import (
+	"github.com/stretchr/testify/assert"
+	. "klog"
+	"testing"
+	gotime "time"
+)
+
+func TestTotalSumUpZeroIfNoTimesSpecified(t *testing.T) {
+	r := NewRecord(Ɀ_Date_(2020, 1, 1))
+	assert.Equal(t, NewDuration(0, 0), Total(r))
+}
+
+func TestTotalSumsUpTimesAndRangesButNotOpenRanges(t *testing.T) {
+	r1 := NewRecord(Ɀ_Date_(2020, 1, 1))
+	r1.AddDuration(NewDuration(3, 0), "")
+	r1.AddDuration(NewDuration(1, 33), "")
+	r1.AddRange(Ɀ_Range_(Ɀ_TimeYesterday_(8, 0), Ɀ_TimeTomorrow_(12, 0)), "")
+	r1.AddRange(Ɀ_Range_(Ɀ_Time_(13, 49), Ɀ_Time_(17, 12)), "")
+	_ = r1.StartOpenRange(Ɀ_Time_(1, 2), "")
+	r2 := NewRecord(Ɀ_Date_(2020, 1, 2))
+	r2.AddDuration(NewDuration(7, 55), "")
+	assert.Equal(t, NewDuration(3+1+(16+24+12)+3+7, 33+11+12+55), Total(r1, r2))
+}
+
+func TestSumUpHypotheticalTotalAtGivenTime(t *testing.T) {
+	r := NewRecord(Ɀ_Date_(2020, 1, 1))
+	r.AddDuration(NewDuration(2, 14), "")
+	r.AddRange(Ɀ_Range_(Ɀ_TimeYesterday_(23, 0), Ɀ_Time_(4, 0)), "")
+	_ = r.StartOpenRange(Ɀ_Time_(5, 7), "")
+
+	time1, _ := gotime.Parse("2006-01-02T15:04:05-0700", "2020-01-01T05:06:59-0000")
+	ht1, isOngoing1 := HypotheticalTotal(time1, r)
+	assert.False(t, isOngoing1)
+	assert.Equal(t, NewDuration(2+(1+4), 14), ht1)
+
+	time2, _ := gotime.Parse("2006-01-02T15:04:05-0700", "2020-01-01T10:48:13-0000")
+	ht2, isOngoing2 := HypotheticalTotal(time2, r)
+	assert.True(t, isOngoing2)
+	assert.Equal(t, NewDuration(2+(1+4)+4, 14+53+48), ht2)
+
+	time3, _ := gotime.Parse("2006-01-02T15:04:05-0700", "2020-01-02T03:01:29-0000")
+	ht3, isOngoing3 := HypotheticalTotal(time3, r)
+	assert.True(t, isOngoing3)
+	assert.Equal(t, NewDuration(2+(1+4)+18+3, 14+53+1), ht3)
+}

--- a/src/service/lookup.go
+++ b/src/service/lookup.go
@@ -3,60 +3,7 @@ package service
 import (
 	. "klog"
 	"sort"
-	"time"
 )
-
-func Total(rs ...Record) Duration {
-	total, _ := HypotheticalTotal(time.Time{}, rs...)
-	return total
-}
-
-func TotalEntries(es ...Entry) Duration {
-	total := NewDuration(0, 0)
-	for _, e := range es {
-		total = total.Plus(e.Duration())
-	}
-	return total
-}
-
-func HypotheticalTotal(until time.Time, rs ...Record) (Duration, bool) {
-	total := NewDuration(0, 0)
-	isCurrent := false
-	void := time.Time{}
-	thisDay := NewDateFromTime(until)
-	theDayBefore := thisDay.PlusDays(-1)
-	for _, r := range rs {
-		for _, e := range r.Entries() {
-			t := (e.Unbox(
-				func(r Range) interface{} { return r.Duration() },
-				func(d Duration) interface{} { return d },
-				func(o OpenRange) interface{} {
-					if until != void && (r.Date().IsEqualTo(thisDay) || r.Date().IsEqualTo(theDayBefore)) {
-						end := NewTimeFromTime(until)
-						if r.Date().IsEqualTo(theDayBefore) {
-							end, _ = NewTimeTomorrow(end.Hour(), end.Minute())
-						}
-						tr, err := NewRange(o.Start(), end)
-						if err == nil {
-							isCurrent = true
-							return tr.Duration()
-						}
-					}
-					return NewDuration(0, 0)
-				})).(Duration)
-			total = total.Plus(t)
-		}
-	}
-	return total, isCurrent
-}
-
-func ShouldTotalSum(rs ...Record) ShouldTotal {
-	total := NewDuration(0, 0)
-	for _, r := range rs {
-		total = total.Plus(r.ShouldTotal())
-	}
-	return NewShouldTotal(0, total.InMinutes())
-}
 
 type Filter struct {
 	Tags     []string

--- a/src/service/lookup_test.go
+++ b/src/service/lookup_test.go
@@ -5,47 +5,7 @@ import (
 	"github.com/stretchr/testify/require"
 	. "klog"
 	"testing"
-	gotime "time"
 )
-
-func TestTotalSumUpZeroIfNoTimesSpecified(t *testing.T) {
-	r := NewRecord(Ɀ_Date_(2020, 1, 1))
-	assert.Equal(t, NewDuration(0, 0), Total(r))
-}
-
-func TestTotalSumsUpTimesAndRangesButNotOpenRanges(t *testing.T) {
-	r1 := NewRecord(Ɀ_Date_(2020, 1, 1))
-	r1.AddDuration(NewDuration(3, 0), "")
-	r1.AddDuration(NewDuration(1, 33), "")
-	r1.AddRange(Ɀ_Range_(Ɀ_TimeYesterday_(8, 0), Ɀ_TimeTomorrow_(12, 0)), "")
-	r1.AddRange(Ɀ_Range_(Ɀ_Time_(13, 49), Ɀ_Time_(17, 12)), "")
-	_ = r1.StartOpenRange(Ɀ_Time_(1, 2), "")
-	r2 := NewRecord(Ɀ_Date_(2020, 1, 2))
-	r2.AddDuration(NewDuration(7, 55), "")
-	assert.Equal(t, NewDuration(3+1+(16+24+12)+3+7, 33+11+12+55), Total(r1, r2))
-}
-
-func TestSumUpHypotheticalTotalAtGivenTime(t *testing.T) {
-	r := NewRecord(Ɀ_Date_(2020, 1, 1))
-	r.AddDuration(NewDuration(2, 14), "")
-	r.AddRange(Ɀ_Range_(Ɀ_TimeYesterday_(23, 0), Ɀ_Time_(4, 0)), "")
-	_ = r.StartOpenRange(Ɀ_Time_(5, 7), "")
-
-	time1, _ := gotime.Parse("2006-01-02T15:04:05-0700", "2020-01-01T05:06:59-0000")
-	ht1, isOngoing1 := HypotheticalTotal(time1, r)
-	assert.False(t, isOngoing1)
-	assert.Equal(t, NewDuration(2+(1+4), 14), ht1)
-
-	time2, _ := gotime.Parse("2006-01-02T15:04:05-0700", "2020-01-01T10:48:13-0000")
-	ht2, isOngoing2 := HypotheticalTotal(time2, r)
-	assert.True(t, isOngoing2)
-	assert.Equal(t, NewDuration(2+(1+4)+4, 14+53+48), ht2)
-
-	time3, _ := gotime.Parse("2006-01-02T15:04:05-0700", "2020-01-02T03:01:29-0000")
-	ht3, isOngoing3 := HypotheticalTotal(time3, r)
-	assert.True(t, isOngoing3)
-	assert.Equal(t, NewDuration(2+(1+4)+18+3, 14+53+1), ht3)
-}
 
 func sampleRecords() []Record {
 	return []Record{

--- a/src/service/template.go
+++ b/src/service/template.go
@@ -1,0 +1,49 @@
+package service
+
+import (
+	"errors"
+	"klog"
+	"klog/parser"
+	"regexp"
+	"strings"
+	gotime "time"
+)
+
+type RecordText string
+
+func RenderTemplate(templateText string, time gotime.Time) (RecordText, error) {
+	today := klog.NewDateFromTime(time)
+	now := klog.NewTimeFromTime(time)
+	variables := map[string]string{
+		"TODAY":     today.ToString(),
+		"YESTERDAY": today.PlusDays(-1).ToString(),
+		"NOW":       now.ToString(),
+	}
+	instance := markerPattern.ReplaceAllStringFunc(templateText, func(m string) string {
+		m = strings.TrimLeft(m, "{{")
+		m = strings.TrimRight(m, "}}")
+		m = strings.TrimSpace(m)
+		return variables[m]
+	})
+	_, err := parser.Parse(instance)
+	if err != nil {
+		return "", errors.New("Cannot parse:\n" + instance)
+	}
+	return RecordText(instance), nil
+}
+
+func AppendableText(content string, newRecordText RecordText) string {
+	result := string(newRecordText)
+	if content == "" {
+		return result
+	}
+	if strings.HasSuffix(content, "\n\n") {
+		return result
+	}
+	if strings.HasSuffix(content, "\n") {
+		return "\n" + result
+	}
+	return "\n\n" + result
+}
+
+var markerPattern = regexp.MustCompile(`{{.+}}`)

--- a/src/service/template_test.go
+++ b/src/service/template_test.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+var now = time.Date(1995, 3, 31, 13, 15, 29, 0, time.UTC)
+
+func TestRenderTemplate(t *testing.T) {
+	result, err := RenderTemplate(`
+{{ TODAY }}
+Foo #xyz
+
+{{YESTERDAY}} (8h30m!)
+	1h
+	{{ NOW }} - ?
+`, now)
+	require.Nil(t, err)
+	assert.Equal(t, RecordText(`
+1995-03-31
+Foo #xyz
+
+1995-03-30 (8h30m!)
+	1h
+	13:15 - ?
+`), result)
+}
+
+func TestTemplateFailsIfNoValidRecord(t *testing.T) {
+	result, err := RenderTemplate(`
+{{ TODAY }} foo
+	This is all malformed
+`, now)
+	require.Error(t, err)
+	assert.Equal(t, RecordText(""), result)
+}
+
+func TestAppendTemplateToRecord(t *testing.T) {
+	newRecord := RecordText("1659-08-02 (8h!)\nMy template\n    1h")
+	for _, x := range []struct {
+		file string
+		glue string
+	}{
+		{"", ""},
+		{"   ", "\n\n"},
+		{"1659-08-01\n    14:00-19:00 Appointment\n\n\n", ""},
+		{"1659-08-01\n    14:00-19:00 Appointment\n\n", ""},
+		{"1659-08-01\n    14:00-19:00 Appointment\n    \n", "\n"},
+		{"1659-08-01\n    14:00-19:00 Appointment\n", "\n"},
+		{"1659-08-01\n    14:00-19:00 Appointment", "\n\n"},
+	} {
+		txt := AppendableText(x.file, newRecord)
+		require.Equal(t, x.glue+"1659-08-02 (8h!)\nMy template\n    1h", txt)
+	}
+}


### PR DESCRIPTION
In the long run it would be great if the CLI was also capable of manipulating files. As explained in #3 this is not trivial to build, so a first step would already be to append new data to an existing file.

This PR introduces an experimental `append` subcommand. It will be included in the `v1.1` release, albeit still hidden. (So you can use the feature if you know the command, but neither does it show up in the main help nor is it documented).

The idea is this: You can have template files in `~/.klog/` suffixed with `.template.klg`. For example, `~/.klog/work.template.klg`, which could contain this:

```
{{TODAY}} (8h!)
Yet another day at work...
    {{NOW}} - ?
```

The template files are basically regular klog files, but they can contain placeholders: currently `{{TODAY}}`, `{{YESTERDAY}}` for the date, and `{{NOW}}` for the time.

With this you can do `klog append --from=work mytimes.klg`, which instantiates the template `~/.klog/work.template.klg`, substitues the variables, and appends the result to `mytimes.klg` (or your bookmark, if no file was specified).

I think this approach is relatively straightforward, and it also gives users a lot of flexibility. Curious for feedback.