### PR TITLE
Provide “JSON” API for programmatic extensions

### DIFF
--- a/src/app/cli/cmd_json.go
+++ b/src/app/cli/cmd_json.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"klog/app"
+	"klog/parser/json"
+	"klog/parser/parsing"
+)
+
+type Json struct {
+	InputFilesArgs
+}
+
+func (opt *Json) Run(ctx app.Context) error {
+	rs, err := ctx.RetrieveRecords()
+	if err != nil {
+		parserErrs, isParserErr := err.(parsing.Errors)
+		if isParserErr {
+			ctx.Print(json.ToJson(nil, parserErrs) + "\n")
+			return nil
+		}
+		return err
+	}
+	ctx.Print(json.ToJson(rs, nil) + "\n")
+	return nil
+}

--- a/src/app/cli/cmd_now.go
+++ b/src/app/cli/cmd_now.go
@@ -61,8 +61,8 @@ func handle(opt *Now, ctx app.Context) error {
 		ctx.Print("\n")
 		// Diff:
 		ctx.Print("Diff    ")
-		diff := total.Minus(shouldTotal)
-		grandDiff := grandTotal.Minus(grandShouldTotal)
+		diff := service.Diff(shouldTotal, total)
+		grandDiff := service.Diff(grandShouldTotal, grandTotal)
 		ctx.Print(pad(9-len(diff.ToStringWithSign())) + styler.Duration(diff, true))
 		ctx.Print(pad(11-len(grandDiff.ToStringWithSign())) + styler.Duration(grandDiff, true))
 		ctx.Print("\n")

--- a/src/app/cli/cmd_report.go
+++ b/src/app/cli/cmd_report.go
@@ -72,7 +72,7 @@ func (opt *Report) Run(ctx app.Context) error {
 		if opt.Diff {
 			should := service.ShouldTotalSum(rs...)
 			ctx.Print(pad(10-len(should.ToString())) + styler.ShouldTotal(should))
-			diff := total.Minus(should)
+			diff := service.Diff(should, total)
 			ctx.Print(pad(9-len(diff.ToStringWithSign())) + styler.Duration(diff, true))
 		}
 
@@ -88,7 +88,7 @@ func (opt *Report) Run(ctx app.Context) error {
 	if opt.Diff {
 		grandShould := service.ShouldTotalSum(records...)
 		ctx.Print(pad(10-len(grandShould.ToString())) + styler.ShouldTotal(grandShould))
-		grandDiff := grandTotal.Minus(grandShould)
+		grandDiff := service.Diff(grandShould, grandTotal)
 		ctx.Print(pad(9-len(grandDiff.ToStringWithSign())) + styler.Duration(grandDiff, true))
 	}
 	ctx.Print("\n")

--- a/src/app/cli/cmd_total.go
+++ b/src/app/cli/cmd_total.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	. "klog"
 	"klog/app"
 	"klog/service"
 )
@@ -26,7 +25,7 @@ func (opt *Total) Run(ctx app.Context) error {
 	ctx.Print(fmt.Sprintf("Total: %s\n", styler.Duration(total, false)))
 	if opt.Diff {
 		should := service.ShouldTotalSum(records...)
-		diff := NewDuration(0, 0).Minus(should).Plus(total)
+		diff := service.Diff(should, total)
 		ctx.Print(fmt.Sprintf("Should: %s\n", styler.ShouldTotal(should)))
 		ctx.Print(fmt.Sprintf("Diff: %s\n", styler.Duration(diff, true)))
 	}

--- a/src/app/cli/exec.go
+++ b/src/app/cli/exec.go
@@ -19,6 +19,7 @@ type cli struct {
 	Append Append `cmd group:"Manipulate" hidden help:"Appends a new record to a file (based on templates)"`
 
 	Bookmark Bookmark `cmd group:"Misc" help:"Default file that klog reads from"`
+	Json     Json     `cmd group:"Misc" help:"Convert records to JSON"`
 	Widget   Widget   `cmd group:"Misc" help:"Start menu bar widget (MacOS only)"`
 	Version  Version  `cmd group:"Misc" help:"Print version info and check for updates"`
 }

--- a/src/app/cli/exec.go
+++ b/src/app/cli/exec.go
@@ -19,7 +19,7 @@ type cli struct {
 	Append Append `cmd group:"Manipulate" hidden help:"Appends a new record to a file (based on templates)"`
 
 	Bookmark Bookmark `cmd group:"Misc" help:"Default file that klog reads from"`
-	Json     Json     `cmd group:"Misc" help:"Convert records to JSON"`
+	Json     Json     `cmd group:"Misc" hidden help:"Convert records to JSON"`
 	Widget   Widget   `cmd group:"Misc" help:"Start menu bar widget (MacOS only)"`
 	Version  Version  `cmd group:"Misc" help:"Print version info and check for updates"`
 }

--- a/src/app/mac_widget/render_darwin.go
+++ b/src/app/mac_widget/render_darwin.go
@@ -82,7 +82,7 @@ func renderRecords(ctx app.Context, records []klog.Record, file *app.File) []men
 		Children: func() []menuet.MenuItem {
 			total := service.Total(records...)
 			should := service.ShouldTotalSum(records...)
-			diff := klog.NewDuration(0, 0).Minus(should).Plus(total)
+			diff := service.Diff(should, total)
 			plus := ""
 			if diff.InMinutes() > 0 {
 				plus = "+"

--- a/src/parser/json/serialiser.go
+++ b/src/parser/json/serialiser.go
@@ -37,13 +37,17 @@ func toRecordViews(rs []Record) []RecordView {
 	result := []RecordView{}
 	for _, r := range rs {
 		total := service.Total(r)
+		should := r.ShouldTotal()
+		diff := total.Minus(should)
 		v := RecordView{
 			Date:            r.Date().ToString(),
 			Summary:         r.Summary().ToString(),
 			Total:           total.ToString(),
 			TotalMins:       total.InMinutes(),
-			ShouldTotal:     r.ShouldTotal().ToString(),
-			ShouldTotalMins: r.ShouldTotal().InMinutes(),
+			ShouldTotal:     should.ToString(),
+			ShouldTotalMins: should.InMinutes(),
+			Diff:            diff.ToStringWithSign(),
+			DiffMins:        diff.InMinutes(),
 			Tags:            r.Summary().Tags().ToStrings(),
 			Entries:         toEntryViews(r.Entries()),
 		}

--- a/src/parser/json/serialiser.go
+++ b/src/parser/json/serialiser.go
@@ -1,0 +1,79 @@
+package json
+
+import (
+	"encoding/json"
+	. "klog"
+	"klog/parser/parsing"
+	"klog/service"
+)
+
+type Envelop struct {
+	Records interface{} `json:"records"`
+	Errors  interface{} `json:"errors"`
+}
+
+type EntryView struct {
+	Type      string   `json:"type"`
+	Summary   string   `json:"summary"`
+	Tags      []string `json:"tags"`
+	TotalMins int      `json:"total_mins"`
+}
+
+type RecordView struct {
+	Date            string      `json:"date"`
+	Summary         string      `json:"summary"`
+	TotalMins       int         `json:"total_mins"`
+	ShouldTotal     string      `json:"should_total"`
+	ShouldTotalMins int         `json:"should_total_mins"`
+	Tags            []string    `json:"tags"`
+	Entries         []EntryView `json:"entries"`
+}
+
+func ToJson(rs []Record, errs parsing.Errors) string {
+	envelop := Envelop{
+		Records: toView(rs),
+		Errors:  errs,
+	}
+	result, err := json.Marshal(&envelop)
+	if err != nil {
+		panic(err) // This should never happen
+	}
+	return string(result)
+}
+
+func toView(rs []Record) []RecordView {
+	result := []RecordView{}
+	for _, r := range rs {
+		entries := func() []EntryView {
+			var evs []EntryView
+			for _, e := range r.Entries() {
+				entryType := e.Unbox(func(r Range) interface{} {
+					return "range"
+				}, func(d Duration) interface{} {
+					return "duration"
+				}, func(openRange OpenRange) interface{} {
+					return "open_range"
+				}).(string)
+				evs = append(evs, EntryView{
+					Type:      entryType,
+					Summary:   e.Summary().ToString(),
+					Tags:      e.Summary().Tags().ToStrings(),
+					TotalMins: e.Duration().InMinutes(),
+				})
+				return evs
+			}
+			return evs
+		}()
+		v := RecordView{
+			Date:            r.Date().ToString(),
+			Summary:         r.Summary().ToString(),
+			TotalMins:       service.Total(r).InMinutes(),
+			ShouldTotal:     r.ShouldTotal().ToString(),
+			ShouldTotalMins: r.ShouldTotal().InMinutes(),
+			Tags:            r.Summary().Tags().ToStrings(),
+			Entries:         entries,
+		}
+		result = append(result, v)
+	}
+	return result
+}

--- a/src/parser/json/serialiser.go
+++ b/src/parser/json/serialiser.go
@@ -16,12 +16,14 @@ type EntryView struct {
 	Type      string   `json:"type"`
 	Summary   string   `json:"summary"`
 	Tags      []string `json:"tags"`
+	Total     string   `json:"total"`
 	TotalMins int      `json:"total_mins"`
 }
 
 type RecordView struct {
 	Date            string      `json:"date"`
 	Summary         string      `json:"summary"`
+	Total           string      `json:"total"`
 	TotalMins       int         `json:"total_mins"`
 	ShouldTotal     string      `json:"should_total"`
 	ShouldTotalMins int         `json:"should_total_mins"`
@@ -58,16 +60,19 @@ func toView(rs []Record) []RecordView {
 					Type:      entryType,
 					Summary:   e.Summary().ToString(),
 					Tags:      e.Summary().Tags().ToStrings(),
+					Total:     e.Duration().ToString(),
 					TotalMins: e.Duration().InMinutes(),
 				})
 				return evs
 			}
 			return evs
 		}()
+		total := service.Total(r)
 		v := RecordView{
 			Date:            r.Date().ToString(),
 			Summary:         r.Summary().ToString(),
-			TotalMins:       service.Total(r).InMinutes(),
+			Total:           total.ToString(),
+			TotalMins:       total.InMinutes(),
 			ShouldTotal:     r.ShouldTotal().ToString(),
 			ShouldTotalMins: r.ShouldTotal().InMinutes(),
 			Tags:            r.Summary().Tags().ToStrings(),

--- a/src/parser/json/serialiser.go
+++ b/src/parser/json/serialiser.go
@@ -38,7 +38,7 @@ func toRecordViews(rs []Record) []RecordView {
 	for _, r := range rs {
 		total := service.Total(r)
 		should := r.ShouldTotal()
-		diff := total.Minus(should)
+		diff := service.Diff(should, total)
 		v := RecordView{
 			Date:            r.Date().ToString(),
 			Summary:         r.Summary().ToString(),

--- a/src/parser/json/serialiser.go
+++ b/src/parser/json/serialiser.go
@@ -1,10 +1,12 @@
 package json
 
 import (
+	"bytes"
 	"encoding/json"
 	. "klog"
 	"klog/parser/parsing"
 	"klog/service"
+	"strings"
 )
 
 type Envelop struct {
@@ -20,15 +22,27 @@ type EntryView struct {
 	TotalMins int      `json:"total_mins"`
 }
 
+type OpenRangeView struct {
+	EntryView
+	Start     string `json:"start"`
+	StartMins int    `json:"start_mins"`
+}
+
+type RangeView struct {
+	OpenRangeView
+	End     string `json:"end"`
+	EndMins int    `json:"end_mins"`
+}
+
 type RecordView struct {
-	Date            string      `json:"date"`
-	Summary         string      `json:"summary"`
-	Total           string      `json:"total"`
-	TotalMins       int         `json:"total_mins"`
-	ShouldTotal     string      `json:"should_total"`
-	ShouldTotalMins int         `json:"should_total_mins"`
-	Tags            []string    `json:"tags"`
-	Entries         []EntryView `json:"entries"`
+	Date            string        `json:"date"`
+	Summary         string        `json:"summary"`
+	Total           string        `json:"total"`
+	TotalMins       int           `json:"total_mins"`
+	ShouldTotal     string        `json:"should_total"`
+	ShouldTotalMins int           `json:"should_total_mins"`
+	Tags            []string      `json:"tags"`
+	Entries         []interface{} `json:"entries"`
 }
 
 func ToJson(rs []Record, errs parsing.Errors) string {
@@ -36,37 +50,19 @@ func ToJson(rs []Record, errs parsing.Errors) string {
 		Records: toView(rs),
 		Errors:  errs,
 	}
-	result, err := json.Marshal(&envelop)
+	buffer := new(bytes.Buffer)
+	enc := json.NewEncoder(buffer)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(&envelop)
 	if err != nil {
 		panic(err) // This should never happen
 	}
-	return string(result)
+	return strings.TrimRight(buffer.String(), "\n")
 }
 
 func toView(rs []Record) []RecordView {
 	result := []RecordView{}
 	for _, r := range rs {
-		entries := func() []EntryView {
-			var evs []EntryView
-			for _, e := range r.Entries() {
-				entryType := e.Unbox(func(r Range) interface{} {
-					return "range"
-				}, func(d Duration) interface{} {
-					return "duration"
-				}, func(openRange OpenRange) interface{} {
-					return "open_range"
-				}).(string)
-				evs = append(evs, EntryView{
-					Type:      entryType,
-					Summary:   e.Summary().ToString(),
-					Tags:      e.Summary().Tags().ToStrings(),
-					Total:     e.Duration().ToString(),
-					TotalMins: e.Duration().InMinutes(),
-				})
-				return evs
-			}
-			return evs
-		}()
 		total := service.Total(r)
 		v := RecordView{
 			Date:            r.Date().ToString(),
@@ -76,9 +72,48 @@ func toView(rs []Record) []RecordView {
 			ShouldTotal:     r.ShouldTotal().ToString(),
 			ShouldTotalMins: r.ShouldTotal().InMinutes(),
 			Tags:            r.Summary().Tags().ToStrings(),
-			Entries:         entries,
+			Entries:         toEntryViews(r.Entries()),
 		}
 		result = append(result, v)
 	}
 	return result
+}
+
+func toEntryViews(es []Entry) []interface{} {
+	var views []interface{}
+	for _, e := range es {
+		base := EntryView{
+			Summary:   e.Summary().ToString(),
+			Tags:      e.Summary().Tags().ToStrings(),
+			Total:     e.Duration().ToString(),
+			TotalMins: e.Duration().InMinutes(),
+		}
+		if base.Tags == nil {
+			base.Tags = []string{}
+		}
+		view := e.Unbox(func(r Range) interface{} {
+			base.Type = "range"
+			return RangeView{
+				OpenRangeView: OpenRangeView{
+					EntryView: base,
+					Start:     r.Start().ToString(),
+					StartMins: r.Start().MidnightOffset().InMinutes(),
+				},
+				End:     r.End().ToString(),
+				EndMins: r.End().MidnightOffset().InMinutes(),
+			}
+		}, func(d Duration) interface{} {
+			base.Type = "duration"
+			return base
+		}, func(o OpenRange) interface{} {
+			base.Type = "open_range"
+			return OpenRangeView{
+				EntryView: base,
+				Start:     o.Start().ToString(),
+				StartMins: o.Start().MidnightOffset().InMinutes(),
+			}
+		})
+		views = append(views, view)
+	}
+	return views
 }

--- a/src/parser/json/serialiser_test.go
+++ b/src/parser/json/serialiser_test.go
@@ -1,0 +1,41 @@
+package json
+
+import (
+	"github.com/stretchr/testify/assert"
+	. "klog"
+	"testing"
+)
+
+func TestSerialiseEmptyRecords(t *testing.T) {
+	json := ToJson([]Record{}, nil)
+	assert.Equal(t, `{"records":[],"errors":null}`, json)
+}
+
+func TestSerialiseEmptyArrayIfNoErrors(t *testing.T) {
+	json := ToJson(nil, nil)
+	assert.Equal(t, `{"records":[],"errors":null}`, json)
+}
+
+func TestSerialiseFullBlownRecord(t *testing.T) {
+	json := ToJson(func() []Record {
+		r := NewRecord(Ɀ_Date_(2000, 12, 31))
+		r.SetSummary("Hello #World")
+		r.SetShouldTotal(NewDuration(7, 30))
+		r.AddDuration(NewDuration(1, 30), "#some #thing")
+		return []Record{r}
+	}(), nil)
+	assert.Equal(t, `{"records":[{`+
+		`"date":"2000-12-31",`+
+		`"summary":"Hello #World",`+
+		`"total_mins":90,`+
+		`"should_total":"7h30m!",`+
+		`"should_total_mins":450,`+
+		`"tags":["#world"],`+
+		`"entries":[{`+
+		`"type":"duration",`+
+		`"summary":"#some #thing",`+
+		`"tags":["#some","#thing"],`+
+		`"total_mins":90`+
+		`}]`+
+		`}],"errors":null}`, json)
+}

--- a/src/parser/json/serialiser_test.go
+++ b/src/parser/json/serialiser_test.go
@@ -27,6 +27,7 @@ func TestSerialiseFullBlownRecord(t *testing.T) {
 	assert.Equal(t, `{"records":[{`+
 		`"date":"2000-12-31",`+
 		`"summary":"Hello #World",`+
+		`"total":"1h30m",`+
 		`"total_mins":90,`+
 		`"should_total":"7h30m!",`+
 		`"should_total_mins":450,`+
@@ -35,6 +36,7 @@ func TestSerialiseFullBlownRecord(t *testing.T) {
 		`"type":"duration",`+
 		`"summary":"#some #thing",`+
 		`"tags":["#some","#thing"],`+
+		`"total":"1h30m",`+
 		`"total_mins":90`+
 		`}]`+
 		`}],"errors":null}`, json)

--- a/src/parser/json/serialiser_test.go
+++ b/src/parser/json/serialiser_test.go
@@ -22,13 +22,15 @@ func TestSerialiseFullBlownRecord(t *testing.T) {
 		r.SetSummary("Hello #World")
 		r.SetShouldTotal(NewDuration(7, 30))
 		r.AddDuration(NewDuration(1, 30), "#some #thing")
+		r.AddRange(Ɀ_Range_(Ɀ_TimeYesterday_(23, 44), Ɀ_Time_(5, 23)), "")
+		r.StartOpenRange(Ɀ_TimeTomorrow_(0, 28), "Started #todo")
 		return []Record{r}
 	}(), nil)
 	assert.Equal(t, `{"records":[{`+
 		`"date":"2000-12-31",`+
 		`"summary":"Hello #World",`+
-		`"total":"1h30m",`+
-		`"total_mins":90,`+
+		`"total":"7h9m",`+
+		`"total_mins":429,`+
 		`"should_total":"7h30m!",`+
 		`"should_total_mins":450,`+
 		`"tags":["#world"],`+
@@ -38,6 +40,24 @@ func TestSerialiseFullBlownRecord(t *testing.T) {
 		`"tags":["#some","#thing"],`+
 		`"total":"1h30m",`+
 		`"total_mins":90`+
+		`},{`+
+		`"type":"range",`+
+		`"summary":"",`+
+		`"tags":[],`+
+		`"total":"5h39m",`+
+		`"total_mins":339,`+
+		`"start":"<23:44",`+
+		`"start_mins":-16,`+
+		`"end":"5:23",`+
+		`"end_mins":323`+
+		`},{`+
+		`"type":"open_range",`+
+		`"summary":"Started #todo",`+
+		`"tags":["#todo"],`+
+		`"total":"0m",`+
+		`"total_mins":0,`+
+		`"start":"0:28>",`+
+		`"start_mins":1468`+
 		`}]`+
 		`}],"errors":null}`, json)
 }

--- a/src/parser/json/serialiser_test.go
+++ b/src/parser/json/serialiser_test.go
@@ -23,7 +23,7 @@ func TestSerialiseFullBlownRecord(t *testing.T) {
 		r := NewRecord(Ɀ_Date_(2000, 12, 31))
 		r.SetSummary("Hello #World")
 		r.SetShouldTotal(NewDuration(7, 30))
-		r.AddDuration(NewDuration(1, 30), "#some #thing")
+		r.AddDuration(NewDuration(2, 3), "#some #thing")
 		r.AddRange(Ɀ_Range_(Ɀ_TimeYesterday_(23, 44), Ɀ_Time_(5, 23)), "")
 		r.StartOpenRange(Ɀ_TimeTomorrow_(0, 28), "Started #todo")
 		return []Record{r}
@@ -31,17 +31,19 @@ func TestSerialiseFullBlownRecord(t *testing.T) {
 	assert.Equal(t, `{"records":[{`+
 		`"date":"2000-12-31",`+
 		`"summary":"Hello #World",`+
-		`"total":"7h9m",`+
-		`"total_mins":429,`+
+		`"total":"7h42m",`+
+		`"total_mins":462,`+
 		`"should_total":"7h30m!",`+
 		`"should_total_mins":450,`+
+		`"diff":"+12m",`+
+		`"diff_mins":12,`+
 		`"tags":["#world"],`+
 		`"entries":[{`+
 		`"type":"duration",`+
 		`"summary":"#some #thing",`+
 		`"tags":["#some","#thing"],`+
-		`"total":"1h30m",`+
-		`"total_mins":90`+
+		`"total":"2h3m",`+
+		`"total_mins":123`+
 		`},{`+
 		`"type":"range",`+
 		`"summary":"",`+

--- a/src/parser/json/serialiser_test.go
+++ b/src/parser/json/serialiser_test.go
@@ -3,6 +3,8 @@ package json
 import (
 	"github.com/stretchr/testify/assert"
 	. "klog"
+	"klog/parser"
+	"klog/parser/parsing"
 	"testing"
 )
 
@@ -60,4 +62,19 @@ func TestSerialiseFullBlownRecord(t *testing.T) {
 		`"start_mins":1468`+
 		`}]`+
 		`}],"errors":null}`, json)
+}
+
+func TestSerialiseParserErrors(t *testing.T) {
+	json := ToJson(nil, parsing.NewErrors([]parsing.Error{
+		parser.ErrorInvalidDate(parsing.NewError(parsing.Line{
+			Text:       "2018-99-99",
+			LineNumber: 7,
+		}, 0, 10)),
+	}))
+	assert.Equal(t, `{"records":null,"errors":[{`+
+		`"line":7,`+
+		`"column":0,`+
+		`"length":10,`+
+		`"message":"Invalid date: please make sure that the date format is either YYYY-MM-DD or YYYY/MM/DD, and that its value represents a valid day in the calendar."`+
+		`}]}`, json)
 }

--- a/src/parser/json/view.go
+++ b/src/parser/json/view.go
@@ -12,6 +12,8 @@ type RecordView struct {
 	TotalMins       int           `json:"total_mins"`
 	ShouldTotal     string        `json:"should_total"`
 	ShouldTotalMins int           `json:"should_total_mins"`
+	Diff            string        `json:"diff"`
+	DiffMins        int           `json:"diff_mins"`
 	Tags            []string      `json:"tags"`
 	Entries         []interface{} `json:"entries"`
 }

--- a/src/parser/json/view.go
+++ b/src/parser/json/view.go
@@ -1,0 +1,44 @@
+package json
+
+type Envelop struct {
+	Records []RecordView `json:"records"`
+	Errors  []ErrorView  `json:"errors"`
+}
+
+type RecordView struct {
+	Date            string        `json:"date"`
+	Summary         string        `json:"summary"`
+	Total           string        `json:"total"`
+	TotalMins       int           `json:"total_mins"`
+	ShouldTotal     string        `json:"should_total"`
+	ShouldTotalMins int           `json:"should_total_mins"`
+	Tags            []string      `json:"tags"`
+	Entries         []interface{} `json:"entries"`
+}
+
+type EntryView struct {
+	Type      string   `json:"type"`
+	Summary   string   `json:"summary"`
+	Tags      []string `json:"tags"`
+	Total     string   `json:"total"`
+	TotalMins int      `json:"total_mins"`
+}
+
+type OpenRangeView struct {
+	EntryView
+	Start     string `json:"start"`
+	StartMins int    `json:"start_mins"`
+}
+
+type RangeView struct {
+	OpenRangeView
+	End     string `json:"end"`
+	EndMins int    `json:"end_mins"`
+}
+
+type ErrorView struct {
+	Line    int    `json:"line"`
+	Column  int    `json:"column"`
+	Length  int    `json:"length"`
+	Message string `json:"message"`
+}

--- a/src/service/evaluate.go
+++ b/src/service/evaluate.go
@@ -63,3 +63,8 @@ func ShouldTotalSum(rs ...Record) ShouldTotal {
 	}
 	return NewShouldTotal(0, total.InMinutes())
 }
+
+// Diff calculates the difference between should total and actual total
+func Diff(should ShouldTotal, actual Duration) Duration {
+	return actual.Minus(should)
+}

--- a/src/summary.go
+++ b/src/summary.go
@@ -2,6 +2,7 @@ package klog
 
 import (
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -18,6 +19,17 @@ type Tag string
 
 func (t Tag) ToString() string {
 	return "#" + string(t)
+}
+
+func (ts TagSet) ToStrings() []string {
+	var tags []string
+	for t := range ts {
+		tags = append(tags, t.ToString())
+	}
+	sort.Slice(tags, func(i, j int) bool {
+		return i < j
+	})
+	return tags
 }
 
 type TagSet map[Tag]bool

--- a/src/summary.go
+++ b/src/summary.go
@@ -27,7 +27,7 @@ func (ts TagSet) ToStrings() []string {
 		tags = append(tags, t.ToString())
 	}
 	sort.Slice(tags, func(i, j int) bool {
-		return i < j
+		return tags[i] < tags[j]
 	})
 	return tags
 }

--- a/src/summary_test.go
+++ b/src/summary_test.go
@@ -20,6 +20,14 @@ func TestSummaryCannotContainWhitespaceAtBeginningOfLine(t *testing.T) {
 	assert.Equal(t, Summary(""), r.Summary()) // Still empty
 }
 
+func TestRecognisesAllTags(t *testing.T) {
+	s := Summary("Hello #world, I feel #GREAT today #123_test")
+	assert.True(t, s.Tags()["world"])
+	assert.True(t, s.Tags()["great"])
+	assert.True(t, s.Tags()["123_test"])
+	assert.Equal(t, s.Tags().ToStrings(), []string{"#123_test", "#great", "#world"})
+}
+
 func TestFindHashTagMatches(t *testing.T) {
 	// `#` is stripped
 	tags := NewTagSet("this", "#THAT", "numb3rs", "under_score")


### PR DESCRIPTION
In order to allow people to build tooling around klog in a convenient way, the topic of a JSON API has come up in various contexts. This PR addresses https://github.com/jotaen/klog/issues/15 and introduces a JSON command that turns klog input file(s) into a structures JSON output.

The command is still configured to be hidden from the help text, since the JSON structure might not be final yet. The command will be `klog json` or `klog json myfile.klg` respectively.