### PR TITLE
Smaller fixes and tweaks for the JSON command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog (command line tool)
 
+## v1.6
+- **[ FEATURE ]** Add `json` subcommand that allows users to build
+  programmatic extensions
+- **[ FEATURE ]** Support Windows line endings (`\r\n`)
+
 ## v1.5
 - **[ FIX ]** Fix the ongoing time counter in `klog now --follow`
 

--- a/src/app/cli/cmd_json.go
+++ b/src/app/cli/cmd_json.go
@@ -7,11 +7,13 @@ import (
 )
 
 type Json struct {
+	FilterArgs
+	SortArgs
 	InputFilesArgs
 }
 
 func (opt *Json) Run(ctx app.Context) error {
-	rs, err := ctx.RetrieveRecords()
+	records, err := ctx.RetrieveRecords()
 	if err != nil {
 		parserErrs, isParserErr := err.(parsing.Errors)
 		if isParserErr {
@@ -20,6 +22,8 @@ func (opt *Json) Run(ctx app.Context) error {
 		}
 		return err
 	}
-	ctx.Print(json.ToJson(rs, nil) + "\n")
+	records = opt.filter(ctx.Now(), records)
+	records = opt.sort(records)
+	ctx.Print(json.ToJson(records, nil) + "\n")
 	return nil
 }

--- a/src/parser/error.go
+++ b/src/parser/error.go
@@ -7,7 +7,8 @@ import (
 func ErrorInvalidDate(e Error) Error {
 	return e.Set(
 		"ErrorInvalidDate",
-		"Invalid date: please make sure that the date format is either YYYY-MM-DD or YYYY/MM/DD, "+
+		"Invalid date",
+		"Please make sure that the date format is either YYYY-MM-DD or YYYY/MM/DD, "+
 			"and that its value represents a valid day in the calendar.",
 	)
 }
@@ -15,14 +16,16 @@ func ErrorInvalidDate(e Error) Error {
 func ErrorIllegalIndentation(e Error) Error {
 	return e.Set(
 		"ErrorIllegalIndentation",
-		"Unexpected indentation: please correct the indentation of this line.",
+		"Unexpected indentation",
+		"Please correct the indentation of this line.",
 	)
 }
 
 func ErrorMalformedShouldTotal(e Error) Error {
 	return e.Set(
 		"ErrorMalformedShouldTotal",
-		"Malformed property: please review the syntax of the should-total property. "+
+		"Malformed property",
+		"Please review the syntax of the should-total property. "+
 			"Valid examples for it would be: (8h!) or (4h30m!) or (45m!)",
 	)
 }
@@ -30,7 +33,8 @@ func ErrorMalformedShouldTotal(e Error) Error {
 func ErrorUnrecognisedProperty(e Error) Error {
 	return e.Set(
 		"ErrorUnrecognisedProperty",
-		"Unrecognised property: the highlighted property is not recognised. "+
+		"Unrecognised property",
+		"The highlighted property is not recognised. "+
 			"The should-total property must be a time duration suffixed with an "+
 			"exclamation mark, e.g. 5h15m! or 8h!",
 	)
@@ -39,7 +43,8 @@ func ErrorUnrecognisedProperty(e Error) Error {
 func ErrorMalformedPropertiesSyntax(e Error) Error {
 	return e.Set(
 		"ErrorMalformedPropertiesSyntax",
-		"Malformed properties list: properties cannot be empty and must be "+
+		"Malformed properties list",
+		"Properties cannot be empty and must be "+
 			"surrounded by parenthesis on both sides",
 	)
 }
@@ -47,7 +52,8 @@ func ErrorMalformedPropertiesSyntax(e Error) Error {
 func ErrorUnrecognisedTextInHeadline(e Error) Error {
 	return e.Set(
 		"ErrorUnrecognisedTextInHeadline",
-		"Malformed headline: the highlighted text in the headline is not recognised. "+
+		"Malformed headline",
+		"The highlighted text in the headline is not recognised. "+
 			"Please make sure to surround properties with parentheses, e.g.: (5h!) "+
 			"You generally cannot put arbitrary text into the headline.",
 	)
@@ -58,13 +64,15 @@ func ErrorMalformedSummary(e Error) Error {
 	return e.Set(
 		"ErrorMalformedSummary",
 		"Invalid summary",
+		"The summary text is not valid",
 	)
 }
 
 func ErrorMalformedEntry(e Error) Error {
 	return e.Set(
 		"ErrorMalformedEntry",
-		"Malformed entry: please review the syntax of the entry. "+
+		"Malformed entry",
+		"Please review the syntax of the entry. "+
 			"It must start with a duration or a time range. "+
 			"Valid examples would be: 3h20m or 8:00-10:00 or 8:00-? "+
 			"or <23:00-6:00 or 18:00-0:30>",
@@ -74,7 +82,8 @@ func ErrorMalformedEntry(e Error) Error {
 func ErrorDuplicateOpenRange(e Error) Error {
 	return e.Set(
 		"ErrorDuplicateOpenRange",
-		"Invalid duplicate entry: please make sure that there is only "+
+		"Duplicate entry",
+		"Please make sure that there is only "+
 			"one open (unclosed) time range in this record.",
 	)
 }
@@ -82,7 +91,8 @@ func ErrorDuplicateOpenRange(e Error) Error {
 func ErrorIllegalRange(e Error) Error {
 	return e.Set(
 		"ErrorIllegalRange",
-		"Invalid date range: please make sure that both time values appear in chronological order. "+
+		"Invalid date range",
+		"Please make sure that both time values appear in chronological order. "+
 			"If you want a time to be associated with an adjacent day you can use angle brackets "+
 			"to shift the time by one day: <23:00-6:00 or 18:00-0:30>",
 	)

--- a/src/parser/json/serialiser.go
+++ b/src/parser/json/serialiser.go
@@ -107,7 +107,8 @@ func toErrorViews(errs parsing.Errors) []ErrorView {
 			Line:    e.Context().LineNumber,
 			Column:  e.Position(),
 			Length:  e.Length(),
-			Message: e.Message(),
+			Title: e.Title(),
+			Details: e.Details(),
 		})
 	}
 	return result

--- a/src/parser/json/serialiser.go
+++ b/src/parser/json/serialiser.go
@@ -105,9 +105,9 @@ func toErrorViews(errs parsing.Errors) []ErrorView {
 	for _, e := range errs.Get() {
 		result = append(result, ErrorView{
 			Line:    e.Context().LineNumber,
-			Column:  e.Position(),
+			Column:  e.Column(),
 			Length:  e.Length(),
-			Title: e.Title(),
+			Title:   e.Title(),
 			Details: e.Details(),
 		})
 	}

--- a/src/parser/json/serialiser.go
+++ b/src/parser/json/serialiser.go
@@ -48,7 +48,7 @@ func toRecordViews(rs []Record) []RecordView {
 			ShouldTotalMins: should.InMinutes(),
 			Diff:            diff.ToStringWithSign(),
 			DiffMins:        diff.InMinutes(),
-			Tags:            r.Summary().Tags().ToStrings(),
+			Tags:            toTagViews(r.Summary().Tags()),
 			Entries:         toEntryViews(r.Entries()),
 		}
 		result = append(result, v)
@@ -56,17 +56,22 @@ func toRecordViews(rs []Record) []RecordView {
 	return result
 }
 
+func toTagViews(ts TagSet) []string {
+	result := ts.ToStrings()
+	if result == nil {
+		return []string{}
+	}
+	return result
+}
+
 func toEntryViews(es []Entry) []interface{} {
-	var views []interface{}
+	views := []interface{}{}
 	for _, e := range es {
 		base := EntryView{
 			Summary:   e.Summary().ToString(),
-			Tags:      e.Summary().Tags().ToStrings(),
+			Tags:      toTagViews(e.Summary().Tags()),
 			Total:     e.Duration().ToString(),
 			TotalMins: e.Duration().InMinutes(),
-		}
-		if base.Tags == nil {
-			base.Tags = []string{}
 		}
 		view := e.Unbox(func(r Range) interface{} {
 			base.Type = "range"

--- a/src/parser/json/serialiser_test.go
+++ b/src/parser/json/serialiser_test.go
@@ -18,6 +18,25 @@ func TestSerialiseEmptyArrayIfNoErrors(t *testing.T) {
 	assert.Equal(t, `{"records":[],"errors":null}`, json)
 }
 
+func TestSerialiseMinimalRecord(t *testing.T) {
+	json := ToJson(func() []Record {
+		r := NewRecord(Ɀ_Date_(2000, 12, 31))
+		return []Record{r}
+	}(), nil)
+	assert.Equal(t, `{"records":[{`+
+		`"date":"2000-12-31",`+
+		`"summary":"",`+
+		`"total":"0m",`+
+		`"total_mins":0,`+
+		`"should_total":"0m",`+
+		`"should_total_mins":0,`+
+		`"diff":"0m",`+
+		`"diff_mins":0,`+
+		`"tags":[],`+
+		`"entries":[]`+
+		`}],"errors":null}`, json)
+}
+
 func TestSerialiseFullBlownRecord(t *testing.T) {
 	json := ToJson(func() []Record {
 		r := NewRecord(Ɀ_Date_(2000, 12, 31))

--- a/src/parser/json/serialiser_test.go
+++ b/src/parser/json/serialiser_test.go
@@ -94,7 +94,7 @@ func TestSerialiseParserErrors(t *testing.T) {
 	}))
 	assert.Equal(t, `{"records":null,"errors":[{`+
 		`"line":7,`+
-		`"column":0,`+
+		`"column":1,`+
 		`"length":10,`+
 		`"title":"Invalid date",`+
 		`"details":"Please make sure that the date format is either YYYY-MM-DD or YYYY/MM/DD, and that its value represents a valid day in the calendar."`+

--- a/src/parser/json/serialiser_test.go
+++ b/src/parser/json/serialiser_test.go
@@ -96,6 +96,7 @@ func TestSerialiseParserErrors(t *testing.T) {
 		`"line":7,`+
 		`"column":0,`+
 		`"length":10,`+
-		`"message":"Invalid date: please make sure that the date format is either YYYY-MM-DD or YYYY/MM/DD, and that its value represents a valid day in the calendar."`+
+		`"title":"Invalid date",`+
+		`"details":"Please make sure that the date format is either YYYY-MM-DD or YYYY/MM/DD, and that its value represents a valid day in the calendar."`+
 		`}]}`, json)
 }

--- a/src/parser/json/view.go
+++ b/src/parser/json/view.go
@@ -42,5 +42,6 @@ type ErrorView struct {
 	Line    int    `json:"line"`
 	Column  int    `json:"column"`
 	Length  int    `json:"length"`
-	Message string `json:"message"`
+	Title   string `json:"title"`
+	Details string `json:"details"`
 }

--- a/src/parser/parsing/error.go
+++ b/src/parser/parsing/error.go
@@ -26,7 +26,8 @@ func (pe errors) Get() []Error {
 type Error interface {
 	Error() string
 	Context() Line
-	Position() int
+	Position() int // text position _without_ indentation
+	Column() int   // column number _with_ indentation
 	Length() int
 	Code() string
 	Title() string
@@ -47,10 +48,11 @@ type err struct {
 func (e *err) Error() string   { return e.Message() }
 func (e *err) Context() Line   { return e.context }
 func (e *err) Position() int   { return e.position }
+func (e *err) Column() int     { return len(e.context.originalIndentation) + e.position + 1 }
 func (e *err) Length() int     { return e.length }
 func (e *err) Code() string    { return e.code }
-func (e *err) Title() string    { return e.title }
-func (e *err) Details() string    { return e.details }
+func (e *err) Title() string   { return e.title }
+func (e *err) Details() string { return e.details }
 func (e *err) Message() string { return e.title + ": " + e.details }
 func (e *err) Set(code string, title string, details string) Error {
 	e.code = code

--- a/src/parser/parsing/error.go
+++ b/src/parser/parsing/error.go
@@ -29,8 +29,10 @@ type Error interface {
 	Position() int
 	Length() int
 	Code() string
+	Title() string
+	Details() string
 	Message() string
-	Set(string, string) Error
+	Set(string, string, string) Error
 }
 
 type err struct {
@@ -38,18 +40,22 @@ type err struct {
 	position int
 	length   int
 	code     string
-	message  string
+	title    string
+	details  string
 }
 
-func (e *err) Error() string   { return e.message }
+func (e *err) Error() string   { return e.Message() }
 func (e *err) Context() Line   { return e.context }
 func (e *err) Position() int   { return e.position }
 func (e *err) Length() int     { return e.length }
 func (e *err) Code() string    { return e.code }
-func (e *err) Message() string { return e.message }
-func (e *err) Set(code string, message string) Error {
+func (e *err) Title() string    { return e.title }
+func (e *err) Details() string    { return e.details }
+func (e *err) Message() string { return e.title + ": " + e.details }
+func (e *err) Set(code string, title string, details string) Error {
 	e.code = code
-	e.message = message
+	e.title = title
+	e.details = details
 	return e
 }
 

--- a/src/parser/parsing/error_test.go
+++ b/src/parser/parsing/error_test.go
@@ -1,0 +1,23 @@
+package parsing
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestCreateError(t *testing.T) {
+	err := NewError(Line{
+		Text:                "Hello World",
+		LineNumber:          2,
+		originalLineEnding:  "\n",
+		originalIndentation: "  ",
+	}, 0, 5)
+	err = err.Set("CODE", "Title", "Details")
+	assert.Equal(t, "CODE", err.Code())
+	assert.Equal(t, "Title", err.Title())
+	assert.Equal(t, "Details", err.Details())
+	assert.Equal(t, 0, err.Position())
+	assert.Equal(t, 3, err.Column())
+	assert.Equal(t, 5, err.Length())
+	assert.Equal(t, "Title: Details", err.Message())
+}


### PR DESCRIPTION
On https://github.com/jotaen/klog/issues/15

- `column` in the error output now takes indentation into account
- You can filter and sort the same way as with other commands `klog json --before 2020-12-31 --tag work`
- Put an empty array `"tags":[]` if there are no tags, instead of `"tags":null`
- Split error message into title and details