### PR TITLE
Prettify JSON, support stdin, `bookmark unset`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   programmatic extensions
 - **[ FEATURE ]** Support Windows line endings (`\r\n`)
 - **[ FEATURE ]** Add `bookmark unset` command for clearing current selection
+- **[ FEATURE ]** Check stdin for input (to allow shell piping)
 
 ## v1.5
 - **[ FIX ]** Fix the ongoing time counter in `klog now --follow`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **[ FEATURE ]** Add `json` subcommand that allows users to build
   programmatic extensions
 - **[ FEATURE ]** Support Windows line endings (`\r\n`)
+- **[ FEATURE ]** Add `bookmark unset` command for clearing current selection
 
 ## v1.5
 - **[ FIX ]** Fix the ongoing time counter in `klog now --follow`

--- a/src/app/cli/cmd_bookmark.go
+++ b/src/app/cli/cmd_bookmark.go
@@ -5,9 +5,10 @@ import (
 )
 
 type Bookmark struct {
-	Get  BookmarkGet  `cmd name:"get" group:"Bookmark" help:"Show current bookmark"`
-	Set  BookmarkSet  `cmd name:"set" group:"Bookmark" help:"Set bookmark to a file"`
-	Edit BookmarkEdit `cmd name:"edit" group:"Bookmark" help:"Open bookmark in your editor"`
+	Get   BookmarkGet   `cmd name:"get" group:"Bookmark" help:"Show current bookmark"`
+	Set   BookmarkSet   `cmd name:"set" group:"Bookmark" help:"Set bookmark to a file"`
+	Edit  BookmarkEdit  `cmd name:"edit" group:"Bookmark" help:"Open bookmark in your editor"`
+	Unset BookmarkUnset `cmd name:"unset" group:"Bookmark" help:"Clear current bookmark"`
 }
 
 type BookmarkGet struct{}
@@ -42,4 +43,15 @@ func (args *BookmarkEdit) Run(ctx app.Context) error {
 		return appErr
 	}
 	return ctx.OpenInEditor(b.Path)
+}
+
+type BookmarkUnset struct{}
+
+func (args *BookmarkUnset) Run(ctx app.Context) error {
+	err := ctx.UnsetBookmark()
+	if err != nil {
+		return err
+	}
+	ctx.Print("Removed bookmark\n")
+	return nil
 }

--- a/src/app/cli/cmd_bookmark.go
+++ b/src/app/cli/cmd_bookmark.go
@@ -52,6 +52,6 @@ func (args *BookmarkUnset) Run(ctx app.Context) error {
 	if err != nil {
 		return err
 	}
-	ctx.Print("Removed bookmark\n")
+	ctx.Print("Cleared bookmark\n")
 	return nil
 }

--- a/src/app/cli/cmd_json.go
+++ b/src/app/cli/cmd_json.go
@@ -13,7 +13,7 @@ type Json struct {
 }
 
 func (opt *Json) Run(ctx app.Context) error {
-	records, err := ctx.RetrieveRecords()
+	records, err := ctx.RetrieveRecords(opt.File...)
 	if err != nil {
 		parserErrs, isParserErr := err.(parsing.Errors)
 		if isParserErr {

--- a/src/app/cli/cmd_json.go
+++ b/src/app/cli/cmd_json.go
@@ -10,6 +10,7 @@ type Json struct {
 	FilterArgs
 	SortArgs
 	InputFilesArgs
+	Pretty bool `name:"pretty" help:"Pretty-print output"`
 }
 
 func (opt *Json) Run(ctx app.Context) error {
@@ -17,13 +18,13 @@ func (opt *Json) Run(ctx app.Context) error {
 	if err != nil {
 		parserErrs, isParserErr := err.(parsing.Errors)
 		if isParserErr {
-			ctx.Print(json.ToJson(nil, parserErrs) + "\n")
+			ctx.Print(json.ToJson(nil, parserErrs, opt.Pretty) + "\n")
 			return nil
 		}
 		return err
 	}
 	records = opt.filter(ctx.Now(), records)
 	records = opt.sort(records)
-	ctx.Print(json.ToJson(records, nil) + "\n")
+	ctx.Print(json.ToJson(records, nil, opt.Pretty) + "\n")
 	return nil
 }

--- a/src/app/cli/testutil_test.go
+++ b/src/app/cli/testutil_test.go
@@ -89,6 +89,10 @@ func (ctx *TestingContext) Bookmark() (*app.File, app.Error) {
 	}, nil
 }
 
+func (ctx *TestingContext) UnsetBookmark() app.Error {
+	return nil
+}
+
 func (ctx *TestingContext) OpenInFileBrowser(_ string) app.Error {
 	return nil
 }

--- a/src/app/fileutil.go
+++ b/src/app/fileutil.go
@@ -1,0 +1,77 @@
+package app
+
+import (
+	"bufio"
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+func readFile(path string) (string, Error) {
+	contents, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", appError{
+			"Cannot read file",
+			"Location: " + path,
+		}
+	}
+	return string(contents), nil
+}
+
+func removeFile(path string) Error {
+	err := os.Remove(path)
+	if err != nil {
+		return appError{
+			"Cannot remove file",
+			"Location: " + path,
+		}
+	}
+	return nil
+}
+
+func appendToFile(path string, textToAppend string) Error {
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return appError{
+			"Cannot write to file",
+			"Location: " + path,
+		}
+	}
+	defer file.Close()
+	if _, err := file.WriteString(textToAppend); err != nil {
+		return appError{
+			"Cannot write to file",
+			"Location: " + path,
+		}
+	}
+	return nil
+}
+
+func readStdin() (string, Error) {
+	info, err := os.Stdin.Stat()
+	if err != nil {
+		return "", appError{
+			"Cannot read from Stdin",
+			"Cannot open Stdin stream to check for input",
+		}
+	}
+	if info.Mode()&os.ModeCharDevice != 0 || info.Size() <= 0 {
+		return "", nil
+	}
+	reader := bufio.NewReader(os.Stdin)
+	var output []rune
+	for {
+		input, _, err := reader.ReadRune()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", appError{
+				"Error while reading from Stdin",
+				"An error occurred while processing the input stream",
+			}
+		}
+		output = append(output, input)
+	}
+	return string(output), nil
+}

--- a/src/parser/json/serialiser.go
+++ b/src/parser/json/serialiser.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-func ToJson(rs []Record, errs parsing.Errors) string {
+func ToJson(rs []Record, errs parsing.Errors, prettyPrint bool) string {
 	envelop := func() Envelop {
 		if errs == nil {
 			return Envelop{
@@ -25,6 +25,9 @@ func ToJson(rs []Record, errs parsing.Errors) string {
 	}()
 	buffer := new(bytes.Buffer)
 	enc := json.NewEncoder(buffer)
+	if prettyPrint {
+		enc.SetIndent("", "  ")
+	}
 	enc.SetEscapeHTML(false)
 	err := enc.Encode(&envelop)
 	if err != nil {

--- a/src/parser/json/serialiser_test.go
+++ b/src/parser/json/serialiser_test.go
@@ -9,20 +9,28 @@ import (
 )
 
 func TestSerialiseEmptyRecords(t *testing.T) {
-	json := ToJson([]Record{}, nil)
+	json := ToJson([]Record{}, nil, false)
 	assert.Equal(t, `{"records":[],"errors":null}`, json)
 }
 
 func TestSerialiseEmptyArrayIfNoErrors(t *testing.T) {
-	json := ToJson(nil, nil)
+	json := ToJson(nil, nil, false)
 	assert.Equal(t, `{"records":[],"errors":null}`, json)
+}
+
+func TestSerialisePrettyPrinted(t *testing.T) {
+	json := ToJson(nil, nil, true)
+	assert.Equal(t, `{
+  "records": [],
+  "errors": null
+}`, json)
 }
 
 func TestSerialiseMinimalRecord(t *testing.T) {
 	json := ToJson(func() []Record {
 		r := NewRecord(Ɀ_Date_(2000, 12, 31))
 		return []Record{r}
-	}(), nil)
+	}(), nil, false)
 	assert.Equal(t, `{"records":[{`+
 		`"date":"2000-12-31",`+
 		`"summary":"",`+
@@ -46,7 +54,7 @@ func TestSerialiseFullBlownRecord(t *testing.T) {
 		r.AddRange(Ɀ_Range_(Ɀ_TimeYesterday_(23, 44), Ɀ_Time_(5, 23)), "")
 		r.StartOpenRange(Ɀ_TimeTomorrow_(0, 28), "Started #todo")
 		return []Record{r}
-	}(), nil)
+	}(), nil, false)
 	assert.Equal(t, `{"records":[{`+
 		`"date":"2000-12-31",`+
 		`"summary":"Hello #World",`+
@@ -91,7 +99,7 @@ func TestSerialiseParserErrors(t *testing.T) {
 			Text:       "2018-99-99",
 			LineNumber: 7,
 		}, 0, 10)),
-	}))
+	}), false)
 	assert.Equal(t, `{"records":null,"errors":[{`+
 		`"line":7,`+
 		`"column":1,`+


### PR DESCRIPTION
Mixed bag of things:

- Add `--pretty` flag for `klog json`, to make output more discoverable by humans
- Read from stdin, to allow piping input, e.g. `cat myfile.klg | klog total`. That also ties into making programatic access easier via 3rd party tools
- Add `bookmark unset` to clear the current bookmark