### PR TITLE
Change and extend CLI filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog (command line tool)
 
+## Pending
+- **[ BREAKING ]** Make `--after` and `--before` filters exclusive
+- **[ FEATURE ]** Add `--since` and `--until` filters (inclusive)
+- **[ FEATURE ]** Add `--period` filter (e.g. `--period=2015` for 
+  all in 2015, or `--period=2015-04` for all in April 2015).
+
 ## v1.6
 - **[ FEATURE ]** Add `json` subcommand that allows users to build
   programmatic extensions

--- a/src/app/cli/common_args.go
+++ b/src/app/cli/common_args.go
@@ -41,20 +41,20 @@ type FilterArgs struct {
 
 func (args *FilterArgs) filter(now gotime.Time, rs []Record) []Record {
 	qry := service.FilterQry{
-		BeforeEq: args.Until,
-		AfterEq:  args.Since,
-		Tags:     args.Tags,
-		Dates:    args.Date,
+		BeforeOrEqual: args.Until,
+		AfterOrEqual:  args.Since,
+		Tags:          args.Tags,
+		Dates:         args.Date,
 	}
 	if args.Period.Since != nil {
-		qry.BeforeEq = args.Period.Until
-		qry.AfterEq = args.Period.Since
+		qry.BeforeOrEqual = args.Period.Until
+		qry.AfterOrEqual = args.Period.Since
 	}
 	if args.After != nil {
-		qry.AfterEq = args.After.PlusDays(1)
+		qry.AfterOrEqual = args.After.PlusDays(1)
 	}
 	if args.Before != nil {
-		qry.BeforeEq = args.Before.PlusDays(-1)
+		qry.BeforeOrEqual = args.Before.PlusDays(-1)
 	}
 	if args.Today {
 		qry.Dates = append(qry.Dates, NewDateFromTime(now))

--- a/src/app/cli/common_args.go
+++ b/src/app/cli/common_args.go
@@ -10,22 +10,6 @@ type InputFilesArgs struct {
 	File []string `arg optional type:"existingfile" name:"file" help:".klg source file(s) (if empty the bookmark is used)"`
 }
 
-func (args *FilterArgs) filter(now gotime.Time, rs []Record) []Record {
-	qry := service.FilterQry{
-		BeforeEq: args.BeforeEq,
-		AfterEq:  args.AfterEq,
-		Tags:     args.Tags,
-		Dates:    args.Date,
-	}
-	if args.Today {
-		qry.Dates = append(qry.Dates, NewDateFromTime(now))
-	}
-	if args.Yesterday {
-		qry.Dates = append(qry.Dates, NewDateFromTime(now.AddDate(0, 0, -1)))
-	}
-	return service.Filter(rs, qry)
-}
-
 type DiffArg struct {
 	Diff bool `name:"diff" short:"d" help:"Show difference between actual and should total time"`
 }
@@ -43,12 +27,36 @@ func (args *NowArgs) total(reference gotime.Time, rs ...Record) Duration {
 }
 
 type FilterArgs struct {
-	Tags      []string `name:"tag" help:"Only records (or particular entries) that match this tag"`
-	Date      []Date   `name:"date" help:"Only records at this date"`
-	Today     bool     `name:"today" help:"Only records at today’s date"`
-	Yesterday bool     `name:"yesterday" help:"Only records at yesterday’s date"`
-	AfterEq   Date     `name:"after" help:"Only records after this date (inclusive)"`
-	BeforeEq  Date     `name:"before" help:"Only records before this date (inclusive)"`
+	Tags      []string `name:"tag" group:"Filter" help:"Only records (or particular entries) that match this tag"`
+	Date      []Date   `name:"date" group:"Filter" help:"Only records at this date"`
+	Today     bool     `name:"today" group:"Filter" help:"Only records at today’s date"`
+	Yesterday bool     `name:"yesterday" group:"Filter" help:"Only records at yesterday’s date"`
+	Since     Date     `name:"since" group:"Filter" help:"Only records since this date (inclusive)"`
+	Until     Date     `name:"until" group:"Filter" help:"Only records until this date (inclusive)"`
+	After     Date     `name:"after" group:"Filter" help:"Only records after this date (exclusive)"`
+	Before    Date     `name:"before" group:"Filter" help:"Only records before this date (exclusive)"`
+}
+
+func (args *FilterArgs) filter(now gotime.Time, rs []Record) []Record {
+	qry := service.FilterQry{
+		BeforeEq: args.Until,
+		AfterEq:  args.Since,
+		Tags:     args.Tags,
+		Dates:    args.Date,
+	}
+	if args.After != nil {
+		qry.AfterEq = args.After.PlusDays(1)
+	}
+	if args.Before != nil {
+		qry.BeforeEq = args.Before.PlusDays(-1)
+	}
+	if args.Today {
+		qry.Dates = append(qry.Dates, NewDateFromTime(now))
+	}
+	if args.Yesterday {
+		qry.Dates = append(qry.Dates, NewDateFromTime(now.AddDate(0, 0, -1)))
+	}
+	return service.Filter(rs, qry)
 }
 
 type WarnArgs struct {

--- a/src/app/cli/common_args.go
+++ b/src/app/cli/common_args.go
@@ -35,6 +35,7 @@ type FilterArgs struct {
 	Until     Date     `name:"until" group:"Filter" help:"Only records until this date (inclusive)"`
 	After     Date     `name:"after" group:"Filter" help:"Only records after this date (exclusive)"`
 	Before    Date     `name:"before" group:"Filter" help:"Only records before this date (exclusive)"`
+	Period    Period   `name:"period" group:"Filter" help:"Only records in this period (YYYY-MM or YYYY)"`
 }
 
 func (args *FilterArgs) filter(now gotime.Time, rs []Record) []Record {
@@ -43,6 +44,10 @@ func (args *FilterArgs) filter(now gotime.Time, rs []Record) []Record {
 		AfterEq:  args.Since,
 		Tags:     args.Tags,
 		Dates:    args.Date,
+	}
+	if args.Period.since != nil {
+		qry.BeforeEq = args.Period.until
+		qry.AfterEq = args.Period.since
 	}
 	if args.After != nil {
 		qry.AfterEq = args.After.PlusDays(1)

--- a/src/app/cli/common_args.go
+++ b/src/app/cli/common_args.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	. "klog"
+	"klog/app/cli/lib"
 	"klog/service"
 	gotime "time"
 )
@@ -27,15 +28,15 @@ func (args *NowArgs) total(reference gotime.Time, rs ...Record) Duration {
 }
 
 type FilterArgs struct {
-	Tags      []string `name:"tag" group:"Filter" help:"Only records (or particular entries) that match this tag"`
-	Date      []Date   `name:"date" group:"Filter" help:"Only records at this date"`
-	Today     bool     `name:"today" group:"Filter" help:"Only records at today’s date"`
-	Yesterday bool     `name:"yesterday" group:"Filter" help:"Only records at yesterday’s date"`
-	Since     Date     `name:"since" group:"Filter" help:"Only records since this date (inclusive)"`
-	Until     Date     `name:"until" group:"Filter" help:"Only records until this date (inclusive)"`
-	After     Date     `name:"after" group:"Filter" help:"Only records after this date (exclusive)"`
-	Before    Date     `name:"before" group:"Filter" help:"Only records before this date (exclusive)"`
-	Period    Period   `name:"period" group:"Filter" help:"Only records in this period (YYYY-MM or YYYY)"`
+	Tags      []string   `name:"tag" group:"Filter" help:"Only records (or particular entries) that match this tag"`
+	Date      []Date     `name:"date" group:"Filter" help:"Only records at this date"`
+	Today     bool       `name:"today" group:"Filter" help:"Only records at today’s date"`
+	Yesterday bool       `name:"yesterday" group:"Filter" help:"Only records at yesterday’s date"`
+	Since     Date       `name:"since" group:"Filter" help:"Only records since this date (inclusive)"`
+	Until     Date       `name:"until" group:"Filter" help:"Only records until this date (inclusive)"`
+	After     Date       `name:"after" group:"Filter" help:"Only records after this date (exclusive)"`
+	Before    Date       `name:"before" group:"Filter" help:"Only records before this date (exclusive)"`
+	Period    lib.Period `name:"period" group:"Filter" help:"Only records in this period (YYYY-MM or YYYY)"`
 }
 
 func (args *FilterArgs) filter(now gotime.Time, rs []Record) []Record {
@@ -45,9 +46,9 @@ func (args *FilterArgs) filter(now gotime.Time, rs []Record) []Record {
 		Tags:     args.Tags,
 		Dates:    args.Date,
 	}
-	if args.Period.since != nil {
-		qry.BeforeEq = args.Period.until
-		qry.AfterEq = args.Period.since
+	if args.Period.Since != nil {
+		qry.BeforeEq = args.Period.Until
+		qry.AfterEq = args.Period.Since
 	}
 	if args.After != nil {
 		qry.AfterEq = args.After.PlusDays(1)

--- a/src/app/cli/exec.go
+++ b/src/app/cli/exec.go
@@ -86,7 +86,7 @@ func periodDecoder() kong.MapperFunc {
 		}
 		p, err := lib.NewPeriodFromString(value)
 		if err != nil {
-			return errors.New("Please provide a valid period")
+			return err
 		}
 		target.Set(reflect.ValueOf(p))
 		return nil

--- a/src/app/cli/exec.go
+++ b/src/app/cli/exec.go
@@ -7,6 +7,9 @@ import (
 	"klog"
 	"klog/app"
 	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
 )
 
 type cli struct {
@@ -42,6 +45,10 @@ func Execute() int {
 			datePrototype, _ := klog.NewDate(1, 1, 1)
 			return kong.TypeMapper(reflect.TypeOf(&datePrototype).Elem(), dateDecoder())
 		}(),
+		func() kong.Option {
+			period := Period{}
+			return kong.TypeMapper(reflect.TypeOf(&period).Elem(), periodDecoder())
+		}(),
 		kong.ConfigureHelp(kong.HelpOptions{
 			Compact: true,
 		}),
@@ -62,7 +69,7 @@ func dateDecoder() kong.MapperFunc {
 			return err
 		}
 		if value == "" {
-			return errors.New("please provide a valid date")
+			return errors.New("Please provide a valid date")
 		}
 		d, err := klog.NewDateFromString(value)
 		if err != nil {
@@ -71,4 +78,45 @@ func dateDecoder() kong.MapperFunc {
 		target.Set(reflect.ValueOf(d))
 		return nil
 	}
+}
+
+var periodPattern = regexp.MustCompile(`^\d{4}(-\d{2})?$`)
+
+func periodDecoder() kong.MapperFunc {
+	return func(ctx *kong.DecodeContext, target reflect.Value) error {
+		var value string
+		if err := ctx.Scan.PopValueInto("period", &value); err != nil {
+			return err
+		}
+		if value == "" || !periodPattern.MatchString(value) {
+			return errors.New("Please provide a valid period")
+		}
+		parts := strings.Split(value, "-")
+		year, _ := strconv.Atoi(parts[0])
+		monthStart := 1
+		monthEnd := 12
+		if len(parts) == 2 {
+			monthStart, _ = strconv.Atoi(parts[1])
+			monthEnd = monthStart
+		}
+		start, _ := klog.NewDate(year, monthStart, 1)
+		end, _ := klog.NewDate(year, monthEnd, 28)
+		for true {
+			next := end.PlusDays(1)
+			if next.Month() != end.Month() {
+				break
+			}
+			end = next
+		}
+		target.Set(reflect.ValueOf(Period{
+			since: start,
+			until: end,
+		}))
+		return nil
+	}
+}
+
+type Period struct {
+	since klog.Date
+	until klog.Date
 }

--- a/src/app/cli/exec.go
+++ b/src/app/cli/exec.go
@@ -38,7 +38,6 @@ func Execute() int {
 			"klog time tracking: command line app for interacting with `.klg` files."+
 				"\n\nRead the documentation at https://klog.jotaen.net",
 		),
-		kong.UsageOnError(),
 		func() kong.Option {
 			datePrototype, _ := klog.NewDate(1, 1, 1)
 			return kong.TypeMapper(reflect.TypeOf(&datePrototype).Elem(), dateDecoder())

--- a/src/app/cli/lib/period.go
+++ b/src/app/cli/lib/period.go
@@ -1,0 +1,43 @@
+package lib
+
+import (
+	"errors"
+	"klog"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var periodPattern = regexp.MustCompile(`^\d{4}(-\d{2})?$`)
+
+type Period struct {
+	Since klog.Date
+	Until klog.Date
+}
+
+func NewPeriodFromString(yyyymm string) (Period, error) {
+	if yyyymm == "" || !periodPattern.MatchString(yyyymm) {
+		return Period{}, errors.New("Please provide a valid period")
+	}
+	parts := strings.Split(yyyymm, "-")
+	year, _ := strconv.Atoi(parts[0])
+	monthStart := 1
+	monthEnd := 12
+	if len(parts) == 2 {
+		monthStart, _ = strconv.Atoi(parts[1])
+		monthEnd = monthStart
+	}
+	start, _ := klog.NewDate(year, monthStart, 1)
+	end, _ := klog.NewDate(year, monthEnd, 28)
+	for true {
+		next := end.PlusDays(1)
+		if next.Month() != end.Month() {
+			break
+		}
+		end = next
+	}
+	return Period{
+		Since: start,
+		Until: end,
+	}, nil
+}

--- a/src/app/cli/lib/period_test.go
+++ b/src/app/cli/lib/period_test.go
@@ -1,0 +1,62 @@
+package lib
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	. "klog"
+	"testing"
+)
+
+func TestParseValidPeriodWithYear(t *testing.T) {
+	p, err := NewPeriodFromString("2018")
+	require.Nil(t, err)
+	assert.Equal(t, p.Since, Ɀ_Date_(2018, 1, 1))
+	assert.Equal(t, p.Until, Ɀ_Date_(2018, 12, 31))
+}
+
+func TestParseValidPeriodWithYearAndMonth(t *testing.T) {
+	for _, x := range []struct {
+		text    string
+		month   int
+		lastDay int
+	}{
+		{"2018-01", 1, 31},
+		{"2018-02", 2, 28},
+		{"2018-03", 3, 31},
+		{"2018-04", 4, 30},
+		{"2018-05", 5, 31},
+		{"2018-06", 6, 30},
+		{"2018-07", 7, 31},
+		{"2018-08", 8, 31},
+		{"2018-09", 9, 30},
+		{"2018-10", 10, 31},
+		{"2018-11", 11, 30},
+		{"2018-12", 12, 31},
+	} {
+		p, err := NewPeriodFromString(x.text)
+		require.Nil(t, err)
+		assert.Equal(t, p.Since, Ɀ_Date_(2018, x.month, 1))
+		assert.Equal(t, p.Until, Ɀ_Date_(2018, x.month, x.lastDay))
+	}
+}
+
+func TestParsePeriodWithLeapYear(t *testing.T) {
+	p, _ := NewPeriodFromString("2016-02")
+	assert.Equal(t, p.Until, Ɀ_Date_(2016, 2, 29))
+}
+
+func TestFailParsingWithMalformedInput(t *testing.T) {
+	for _, x := range []string{
+		"",
+		"asdf",
+		"2018-",
+		"2018-3",
+		"2018-a",
+		"20-03",
+		"-03",
+		"03",
+	} {
+		_, err := NewPeriodFromString(x)
+		require.Error(t, err)
+	}
+}

--- a/src/date_test.go
+++ b/src/date_test.go
@@ -20,6 +20,11 @@ func TestReconWithDate(t *testing.T) {
 	assert.Equal(t, Ɀ_Date_(2005, 12, 30), d.PlusDays(-1))
 }
 
+func TestPlusDaysAccountsForLeapYear(t *testing.T) {
+	d, _ := NewDate(2020, 2, 28)
+	assert.Equal(t, Ɀ_Date_(2020, 2, 29), d.PlusDays(1))
+}
+
 func TestHashYieldsDistinctValues(t *testing.T) {
 	hashes := make(map[DateHash]bool)
 	for i, d := 0, Ɀ_Date_(1000, 1, 1); i < 1000; i++ {

--- a/src/service/query.go
+++ b/src/service/query.go
@@ -6,10 +6,10 @@ import (
 )
 
 type FilterQry struct {
-	Tags     []string
-	BeforeEq Date
-	AfterEq  Date
-	Dates    []Date
+	Tags          []string
+	BeforeOrEqual Date
+	AfterOrEqual  Date
+	Dates         []Date
 }
 
 // Filter returns all records the matches the query.
@@ -22,10 +22,10 @@ func Filter(rs []Record, o FilterQry) []Record {
 		if len(dates) > 0 && !dates[r.Date().Hash()] {
 			continue
 		}
-		if o.BeforeEq != nil && !o.BeforeEq.IsAfterOrEqual(r.Date()) {
+		if o.BeforeOrEqual != nil && !o.BeforeOrEqual.IsAfterOrEqual(r.Date()) {
 			continue
 		}
-		if o.AfterEq != nil && !r.Date().IsAfterOrEqual(o.AfterEq) {
+		if o.AfterOrEqual != nil && !r.Date().IsAfterOrEqual(o.AfterOrEqual) {
 			continue
 		}
 		if len(tags) > 0 {

--- a/src/service/query_test.go
+++ b/src/service/query_test.go
@@ -46,7 +46,7 @@ func TestQueryWithNoClauses(t *testing.T) {
 }
 
 func TestQueryWithAfter(t *testing.T) {
-	rs := Filter(sampleRecordsForQuerying(), FilterQry{AfterEq: Ɀ_Date_(2000, 1, 1)})
+	rs := Filter(sampleRecordsForQuerying(), FilterQry{AfterOrEqual: Ɀ_Date_(2000, 1, 1)})
 	require.Len(t, rs, 3)
 	assert.Equal(t, 1, rs[0].Date().Day())
 	assert.Equal(t, 2, rs[1].Date().Day())
@@ -54,7 +54,7 @@ func TestQueryWithAfter(t *testing.T) {
 }
 
 func TestQueryWithBefore(t *testing.T) {
-	rs := Filter(sampleRecordsForQuerying(), FilterQry{BeforeEq: Ɀ_Date_(2000, 1, 1)})
+	rs := Filter(sampleRecordsForQuerying(), FilterQry{BeforeOrEqual: Ɀ_Date_(2000, 1, 1)})
 	require.Len(t, rs, 3)
 	assert.Equal(t, 30, rs[0].Date().Day())
 	assert.Equal(t, 31, rs[1].Date().Day())


### PR DESCRIPTION
## Changelist

- Make `--before` and `--after` exclusive
- Introduce `--until` and `--since` as inclusive equivalents
- Introduce `--period` for calendric date ranges such as `--period=2018` or `--period=2018-09`
- Group all filters in the help text output
- Don’t display help text output anymore when given malformed flags

Fixes https://github.com/jotaen/klog/issues/31.