### PR TITLE
Colours

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
 
             - [**MacOS**](https://github.com/jotaen/klog/releases/download/${{ github.event.inputs.release_id }}/klog-mac.zip)
             - [**Linux**](https://github.com/jotaen/klog/releases/download/${{ github.event.inputs.release_id }}/klog-linux.zip)
+            - [**Windows**](https://github.com/jotaen/klog/releases/download/${{ github.event.inputs.release_id }}/klog-windows.zip)
 
             You find the install instructions in the [README](https://github.com/jotaen/klog).
             Consult the [Changelog](https://github.com/jotaen/klog/blob/main/CHANGELOG.md) to learn what’s new.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog (command line tool)
 
+## v2.2
+- **[ FEATURE ]** Provide `--no-style` option to disable output
+  formatting (i.e. no colours, underlined, bold, etc.)
+- **[ FIX ]** Make sure that output formatting works on Windows
+  across all Terminals.
+
 ## v2.1
 - **[ FEATURE ]** Provide native Windows binary
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,6 @@ In order to not miss any updates you can either subscribe to the release notific
 1. [**Download**](https://www.github.com/jotaen/klog/releases) and unzip
 2. Copy to path, e.g. to `C:\Windows\System32` (might require admin privileges)
 
-klog works well with [Windows Terminal](https://www.microsoft.com/en-us/p/windows-terminal/9n0dx20hk701),
-support for other terminals might be limited.
-
 By the way, as an alternative you can also use the Linux binary on the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
 
 ## Contribute

--- a/src/app/cli/create.go
+++ b/src/app/cli/create.go
@@ -12,10 +12,12 @@ type Create struct {
 	Template    string   `name:"template" hidden help:"The name of the template to instantiate"`
 	ShouldTotal Duration `name:"should" help:"A should total property"`
 	lib.AtDateArgs
+	lib.NoStyleArgs
 	lib.OutputFileArgs
 }
 
 func (opt *Create) Run(ctx app.Context) error {
+	opt.NoStyleArgs.SetGlobalState()
 	date := opt.AtDate(ctx.Now())
 	lines, err := func() ([]parsing.Text, error) {
 		if opt.Template != "" {

--- a/src/app/cli/lib/common_args.go
+++ b/src/app/cli/lib/common_args.go
@@ -2,7 +2,9 @@ package lib
 
 import (
 	. "klog"
+	"klog/parser"
 	"klog/service"
+	"os"
 	gotime "time"
 )
 
@@ -106,6 +108,16 @@ func (args *WarnArgs) ToString(now gotime.Time, records []Record) string {
 	}
 	ws := service.SanityCheck(now, records)
 	return PrettifyWarnings(ws)
+}
+
+type NoStyleArgs struct {
+	NoStyle bool `name:"no-style" help:"Do not style or color the values"`
+}
+
+func (args *NoStyleArgs) SetGlobalState() {
+	if args.NoStyle || os.Getenv("NO_COLOR") != "" {
+		Styler = parser.DefaultSerialiser
+	}
 }
 
 type SortArgs struct {

--- a/src/app/cli/now.go
+++ b/src/app/cli/now.go
@@ -17,10 +17,12 @@ type Now struct {
 	lib.DiffArgs
 	Follow bool `name:"follow" short:"f" help:"Keep shell open and follow changes"`
 	lib.WarnArgs
+	lib.NoStyleArgs
 	lib.InputFilesArgs
 }
 
 func (opt *Now) Run(ctx app.Context) error {
+	opt.NoStyleArgs.SetGlobalState()
 	h := func() error { return handle(opt, ctx) }
 	if opt.Follow {
 		return withRepeat(ctx, h)

--- a/src/app/cli/print.go
+++ b/src/app/cli/print.go
@@ -10,10 +10,12 @@ type Print struct {
 	lib.FilterArgs
 	lib.SortArgs
 	lib.WarnArgs
+	lib.NoStyleArgs
 	lib.InputFilesArgs
 }
 
 func (opt *Print) Run(ctx app.Context) error {
+	opt.NoStyleArgs.SetGlobalState()
 	records, err := ctx.ReadInputs(opt.File...)
 	if err != nil {
 		return err

--- a/src/app/cli/report.go
+++ b/src/app/cli/report.go
@@ -15,10 +15,12 @@ type Report struct {
 	lib.WarnArgs
 	Fill bool `name:"fill" short:"f" help:"Show all consecutive days, even if there is no record"`
 	lib.NowArgs
+	lib.NoStyleArgs
 	lib.InputFilesArgs
 }
 
 func (opt *Report) Run(ctx app.Context) error {
+	opt.NoStyleArgs.SetGlobalState()
 	records, err := ctx.ReadInputs(opt.File...)
 	if err != nil {
 		return err

--- a/src/app/cli/start.go
+++ b/src/app/cli/start.go
@@ -10,10 +10,12 @@ import (
 type Start struct {
 	lib.AtTimeArgs
 	lib.AtDateArgs
+	lib.NoStyleArgs
 	lib.OutputFileArgs
 }
 
 func (opt *Start) Run(ctx app.Context) error {
+	opt.NoStyleArgs.SetGlobalState()
 	date := opt.AtDate(ctx.Now())
 	time := opt.AtTime(ctx.Now())
 	return applyReconciler(

--- a/src/app/cli/stop.go
+++ b/src/app/cli/stop.go
@@ -10,10 +10,12 @@ import (
 type Stop struct {
 	lib.AtTimeArgs
 	lib.AtDateArgs
+	lib.NoStyleArgs
 	lib.OutputFileArgs
 }
 
 func (opt *Stop) Run(ctx app.Context) error {
+	opt.NoStyleArgs.SetGlobalState()
 	date := opt.AtDate(ctx.Now())
 	time := opt.AtTime(ctx.Now())
 	return applyReconciler(

--- a/src/app/cli/tags.go
+++ b/src/app/cli/tags.go
@@ -12,10 +12,12 @@ import (
 type Tags struct {
 	lib.FilterArgs
 	lib.WarnArgs
+	lib.NoStyleArgs
 	lib.InputFilesArgs
 }
 
 func (opt *Tags) Run(ctx app.Context) error {
+	opt.NoStyleArgs.SetGlobalState()
 	records, err := ctx.ReadInputs(opt.File...)
 	if err != nil {
 		return err

--- a/src/app/cli/total.go
+++ b/src/app/cli/total.go
@@ -12,10 +12,12 @@ type Total struct {
 	lib.DiffArgs
 	lib.WarnArgs
 	lib.NowArgs
+	lib.NoStyleArgs
 	lib.InputFilesArgs
 }
 
 func (opt *Total) Run(ctx app.Context) error {
+	opt.NoStyleArgs.SetGlobalState()
 	records, err := ctx.ReadInputs(opt.File...)
 	if err != nil {
 		return err

--- a/src/app/cli/track.go
+++ b/src/app/cli/track.go
@@ -12,10 +12,12 @@ import (
 type Track struct {
 	lib.AtDateArgs
 	Entry string `arg required help:"The new entry to add, which may optionally contain summary text. Remember to 'quote' to avoid shell processing."`
+	lib.NoStyleArgs
 	lib.OutputFileArgs
 }
 
 func (opt *Track) Run(ctx app.Context) error {
+	opt.NoStyleArgs.SetGlobalState()
 	date := opt.AtDate(ctx.Now())
 	value := sanitiseQuotedLeadingDash(opt.Entry)
 	return applyReconciler(

--- a/src/lib/jotaen/tf/init_windows.go
+++ b/src/lib/jotaen/tf/init_windows.go
@@ -2,8 +2,8 @@
 package tf
 
 import (
-	"syscall"
 	"os"
+	"syscall"
 	"unsafe"
 )
 

--- a/src/lib/jotaen/tf/init_windows.go
+++ b/src/lib/jotaen/tf/init_windows.go
@@ -1,0 +1,24 @@
+// +build windows
+package tf
+
+import (
+	"syscall"
+	"os"
+	"unsafe"
+)
+
+const enableVirtualTerminalProcessing = 0x0004
+
+var (
+	kernel32           = syscall.NewLazyDLL("kernel32.dll")
+	procGetConsoleMode = kernel32.NewProc("GetConsoleMode")
+	procSetConsoleMode = kernel32.NewProc("SetConsoleMode")
+)
+
+func init() {
+	var mode uint32
+	procGetConsoleMode.Call(os.Stdout.Fd(), uintptr(unsafe.Pointer(&mode)))
+	if (mode & enableVirtualTerminalProcessing) != enableVirtualTerminalProcessing {
+		procSetConsoleMode.Call(os.Stdout.Fd(), uintptr(mode|enableVirtualTerminalProcessing))
+	}
+}

--- a/src/lib/jotaen/tf/init_windows.go
+++ b/src/lib/jotaen/tf/init_windows.go
@@ -1,4 +1,5 @@
 // +build windows
+
 package tf
 
 import (

--- a/src/parser/serialiser.go
+++ b/src/parser/serialiser.go
@@ -9,7 +9,7 @@ import (
 func SerialiseRecords(h *Serialiser, rs ...klog.Record) string {
 	var text []string
 	if h == nil {
-		h = &defaultSerialiser
+		h = &DefaultSerialiser
 	}
 	for _, r := range rs {
 		text = append(text, serialiseRecord(h, r))
@@ -52,7 +52,7 @@ type Serialiser struct {
 	Time        func(klog.Time) string
 }
 
-var defaultSerialiser = Serialiser{
+var DefaultSerialiser = Serialiser{
 	Date:        func(d klog.Date) string { return d.ToString() },
 	ShouldTotal: func(d klog.Duration) string { return d.ToString() },
 	Summary:     func(s klog.Summary) string { return string(s) },


### PR DESCRIPTION
Fixes https://github.com/jotaen/klog/issues/39 by introducing a `--no-style` flag to deactivate styling the output (i.e. no colours, no underlines, no bold, etc.).

Fixes https://github.com/jotaen/klog/issues/40, so text styling should work fine now in all Windows terminals.