### PR TITLE
Abandon abstract concept of “properties”

### DIFF
--- a/Specification.md
+++ b/Specification.md
@@ -34,7 +34,7 @@ without any “blank lines” appearing within.
 The first line of a *record* MUST start with a *date*.
 On the same line there MAY follow a *should-total*,
 which MUST be separated by one “space” from the *date*
-(there MAY appear additional “spaces”).
+(additional “spaces” MAY appear).
 
 A *summary* MAY appear on the subsequent lines.
 Any amount of *entries* MAY appear afterwards.
@@ -56,8 +56,7 @@ A *should-total* denotes the targeted total time of a *record*.
 A *should-total* MUST be a *duration* value
 followed by a `!`
 and wrapped in parentheses,
-e.g. `(8h!)` or `(5h30m!)`.
-(A negative value MAY be used, e.g. `(-8h!)`.)
+e.g. `(8h!)` or `(-5h30m!)`.
 
 ### Summary
 A *summary* is user-provided text for holding arbitrary information.

--- a/Specification.md
+++ b/Specification.md
@@ -32,13 +32,9 @@ Each *record* MUST appear as one consecutive block in the file,
 without any “blank lines” appearing within.
 
 The first line of a *record* MUST start with a *date*.
-On the same line there MAY follow a list of *properties*.
-This list MUST be enclosed in “parentheses” and
-separated by one “space” from the *date*
-(there MAY also be multiple “spaces”).
-If there are multiple *properties* they MUST be separated
-by a `,` followed by a “space”.
-The list of *properties* MUST NOT be empty.
+On the same line there MAY follow a *should-total*,
+which MUST be separated by one “space” from the *date*
+(there MAY appear additional “spaces”).
 
 A *summary* MAY appear on the subsequent lines.
 Any amount of *entries* MAY appear afterwards.
@@ -54,17 +50,14 @@ It MUST be formatted according to one of the following patterns:
 
 (Where `Y` is a digit to denote the year, `M` the month, `D` the day.)
 
-### Properties
-*Property* is an abstract term that denotes additional information
-or configuration of a *record*.
-A *should-total* is an instance of a *property*.
-
 ### Should-Total
-A *should-total* is a *property* to denote the targeted total time of a *record*.
+A *should-total* denotes the targeted total time of a *record*.
 
-A *should-total* MUST be a *duration* value followed by a `!`,
-e.g. `8h!` or `5h30m!`.
-(That implies that a negative value MAY be used.)
+A *should-total* MUST be a *duration* value
+followed by a `!`
+and wrapped in parentheses,
+e.g. `(8h!)` or `(5h30m!)`.
+(A negative value MAY be used, e.g. `(-8h!)`.)
 
 ### Summary
 A *summary* is user-provided text for holding arbitrary information.

--- a/src/app/cli/create.go
+++ b/src/app/cli/create.go
@@ -10,7 +10,7 @@ import (
 
 type Create struct {
 	Template    string   `name:"template" hidden help:"The name of the template to instantiate"`
-	ShouldTotal Duration `name:"should" help:"A should total property"`
+	ShouldTotal Duration `name:"should" help:"The should-total of the record"`
 	lib.AtDateArgs
 	lib.NoStyleArgs
 	lib.OutputFileArgs

--- a/src/app/cli/lib/common_args.go
+++ b/src/app/cli/lib/common_args.go
@@ -45,7 +45,7 @@ func (args *AtTimeArgs) AtTime(now gotime.Time) Time {
 }
 
 type DiffArgs struct {
-	Diff bool `name:"diff" short:"d" help:"Show difference between actual and should total time"`
+	Diff bool `name:"diff" short:"d" help:"Show difference between actual and should-total time"`
 }
 
 type NowArgs struct {

--- a/src/parser/error.go
+++ b/src/parser/error.go
@@ -24,8 +24,8 @@ func ErrorIllegalIndentation(e Error) Error {
 func ErrorMalformedShouldTotal(e Error) Error {
 	return e.Set(
 		"ErrorMalformedShouldTotal",
-		"Malformed property",
-		"Please review the syntax of the should-total property. "+
+		"Malformed should-total time",
+		"Please review the syntax of the should-total time. "+
 			"Valid examples for it would be: (8h!) or (4h30m!) or (45m!)",
 	)
 }
@@ -33,9 +33,9 @@ func ErrorMalformedShouldTotal(e Error) Error {
 func ErrorUnrecognisedProperty(e Error) Error {
 	return e.Set(
 		"ErrorUnrecognisedProperty",
-		"Unrecognised property",
-		"The highlighted property is not recognised. "+
-			"The should-total property must be a time duration suffixed with an "+
+		"Unrecognised should-total value",
+		"The highlighted value is not recognised. "+
+			"The should-total must be a time duration suffixed with an "+
 			"exclamation mark, e.g. 5h15m! or 8h!",
 	)
 }
@@ -43,8 +43,8 @@ func ErrorUnrecognisedProperty(e Error) Error {
 func ErrorMalformedPropertiesSyntax(e Error) Error {
 	return e.Set(
 		"ErrorMalformedPropertiesSyntax",
-		"Malformed properties list",
-		"Properties cannot be empty and must be "+
+		"Malformed should-total time",
+		"The should-total cannot be empty and it must be "+
 			"surrounded by parenthesis on both sides",
 	)
 }
@@ -54,7 +54,7 @@ func ErrorUnrecognisedTextInHeadline(e Error) Error {
 		"ErrorUnrecognisedTextInHeadline",
 		"Malformed headline",
 		"The highlighted text in the headline is not recognised. "+
-			"Please make sure to surround properties with parentheses, e.g.: (5h!) "+
+			"Please make sure to surround the should-total with parentheses, e.g.: (5h!) "+
 			"You generally cannot put arbitrary text into the headline.",
 	)
 }

--- a/src/service/evaluate.go
+++ b/src/service/evaluate.go
@@ -55,7 +55,7 @@ func HypotheticalTotal(until time.Time, rs ...Record) (Duration, bool) {
 	return total, isCurrent
 }
 
-// ShouldTotalSum calculates the overall should total time of records.
+// ShouldTotalSum calculates the overall should-total time of records.
 func ShouldTotalSum(rs ...Record) ShouldTotal {
 	total := NewDuration(0, 0)
 	for _, r := range rs {
@@ -64,7 +64,7 @@ func ShouldTotalSum(rs ...Record) ShouldTotal {
 	return NewShouldTotal(0, total.InMinutes())
 }
 
-// Diff calculates the difference between should total and actual total
+// Diff calculates the difference between should-total and actual total
 func Diff(should ShouldTotal, actual Duration) Duration {
 	return actual.Minus(should)
 }


### PR DESCRIPTION
Fixes https://github.com/jotaen/klog/issues/62. @vladdeSV would you mind looking at the spec changes and double-check whether it makes sense? 🙏🏼

Changes:
- Remove concept of “properties” from the spec
- Use consistent spelling in the CLI (with a dash: `should-total`)
- Rephrase error messages

The notion of properties still appears internally in the parser code, since it helps to distinguish error cases. The term is not user-facing anymore, though.