### PR TITLE
Make clearing the bookmark more robust

### DIFF
--- a/src/app/context.go
+++ b/src/app/context.go
@@ -250,13 +250,15 @@ func (ctx *context) SetBookmark(path string) Error {
 			err,
 		)
 	}
-	symlink := ctx.bookmarkOrigin()
-	_ = os.Remove(symlink)
-	err = os.Symlink(bookmark, symlink)
+	appErr := ctx.UnsetBookmark()
+	if appErr != nil {
+		return appErr
+	}
+	err = os.Symlink(bookmark, ctx.bookmarkOrigin())
 	if err != nil {
 		return NewError(
 			"Failed to create bookmark",
-			"",
+			"Unable to create the new bookmark",
 			err,
 		)
 	}
@@ -264,7 +266,15 @@ func (ctx *context) SetBookmark(path string) Error {
 }
 
 func (ctx *context) UnsetBookmark() Error {
-	return RemoveFile(ctx.bookmarkOrigin())
+	err := os.Remove(ctx.bookmarkOrigin())
+	if err != nil && !os.IsNotExist(err) {
+		return NewError(
+			"Failed to unset bookmark",
+			"The current bookmark could not be cleared",
+			err,
+		)
+	}
+	return nil
 }
 
 func (ctx *context) OpenInFileBrowser(path string) Error {

--- a/src/app/ioutil.go
+++ b/src/app/ioutil.go
@@ -17,18 +17,6 @@ func ReadFile(path string) (string, Error) {
 	return string(contents), nil
 }
 
-func RemoveFile(path string) Error {
-	err := os.Remove(path)
-	if err != nil {
-		return NewError(
-			"Cannot remove file",
-			"Location: "+path,
-			err,
-		)
-	}
-	return nil
-}
-
 func WriteToFile(path string, contents string) Error {
 	err := os.WriteFile(path, []byte(contents), 0644)
 	if err != nil {


### PR DESCRIPTION
Addresses https://github.com/jotaen/klog/issues/66, where the removal of the previous bookmark failed but klog just swallowed the error. The error handling now explicitly checks for the expected error and fails in case something else goes wrong.