### PR TITLE
Add flags for setting the summary when calling `start`/`stop`

### DIFF
--- a/src/app/cli/start.go
+++ b/src/app/cli/start.go
@@ -10,6 +10,7 @@ import (
 type Start struct {
 	lib.AtTimeArgs
 	lib.AtDateArgs
+	Summary string `name:"summary" short:"s" help:"Summary text for this entry"`
 	lib.NoStyleArgs
 	lib.OutputFileArgs
 }
@@ -33,7 +34,13 @@ func (opt *Start) Run(ctx app.Context) error {
 				)
 			}
 			return reconciler.AppendEntry(
-				func(r Record) string { return time.ToString() + " - ?" },
+				func(r Record) string {
+					summary := ""
+					if opt.Summary != "" {
+						summary += " " + opt.Summary
+					}
+					return time.ToString() + " - ?" + summary
+				},
 			)
 		},
 	)

--- a/src/app/cli/start_test.go
+++ b/src/app/cli/start_test.go
@@ -23,6 +23,22 @@ func TestStart(t *testing.T) {
 `, state.writtenFileContents)
 }
 
+func TestStartWithSummary(t *testing.T) {
+	state, err := NewTestingContext()._SetRecords(`
+1920-02-02
+	9:00-12:00
+`)._SetNow(1920, 2, 2, 15, 24)._Run((&Start{
+		AtDateArgs: lib.AtDateArgs{Date: klog.Ɀ_Date_(1920, 2, 2)},
+		Summary:    "Started something",
+	}).Run)
+	require.Nil(t, err)
+	assert.Equal(t, `
+1920-02-02
+	9:00-12:00
+	15:24 - ? Started something
+`, state.writtenFileContents)
+}
+
 func TestStartFailsIfOpenRangeAlreadyPresent(t *testing.T) {
 	state, err := NewTestingContext()._SetRecords(`
 1623-12-13

--- a/src/app/cli/stop.go
+++ b/src/app/cli/stop.go
@@ -10,6 +10,7 @@ import (
 type Stop struct {
 	lib.AtTimeArgs
 	lib.AtDateArgs
+	Summary string `name:"summary" short:"s" help:"Text to append to the entry summary"`
 	lib.NoStyleArgs
 	lib.OutputFileArgs
 }
@@ -36,7 +37,7 @@ func (opt *Stop) Run(ctx app.Context) error {
 				)
 			}
 			return reconciler.CloseOpenRange(
-				func(r Record) Time { return time },
+				func(r Record) (Time, Summary) { return time, Summary(opt.Summary) },
 			)
 		},
 	)

--- a/src/app/cli/stop_test.go
+++ b/src/app/cli/stop_test.go
@@ -22,6 +22,21 @@ func TestStop(t *testing.T) {
 `, state.writtenFileContents)
 }
 
+func TestStopWithSummary(t *testing.T) {
+	state, err := NewTestingContext()._SetRecords(`
+1920-02-02
+	11:22-? Started something...
+`)._SetNow(1920, 2, 2, 15, 24)._Run((&Stop{
+		AtDateArgs: lib.AtDateArgs{Date: klog.Ɀ_Date_(1920, 2, 2)},
+		Summary:    " Done!",
+	}).Run)
+	require.Nil(t, err)
+	assert.Equal(t, `
+1920-02-02
+	11:22-15:24 Started something... Done!
+`, state.writtenFileContents)
+}
+
 func TestStopFailsIfNoOpenRange(t *testing.T) {
 	state, err := NewTestingContext()._SetRecords(`
 1623-12-13

--- a/src/parser/reconciler.go
+++ b/src/parser/reconciler.go
@@ -50,7 +50,7 @@ func (r *RecordReconciler) AppendEntry(handler func(Record) string) (*ReconcileR
 	return makeResult(result, r.recordPointer)
 }
 
-func (r *RecordReconciler) CloseOpenRange(handler func(Record) Time) (*ReconcileResult, error) {
+func (r *RecordReconciler) CloseOpenRange(handler func(Record) (Time, Summary)) (*ReconcileResult, error) {
 	record := r.pr.Records[r.recordPointer]
 	if record.OpenRange() == nil {
 		return nil, errors.New("NO_OPEN_RANGE")
@@ -66,11 +66,11 @@ func (r *RecordReconciler) CloseOpenRange(handler func(Record) Time) (*Reconcile
 			},
 		)
 	}
-	time := handler(record)
+	time, summary := handler(record)
 	openRangeLineIndex := r.pr.lastLineOfRecord[r.recordPointer] - len(record.Entries()) + entryIndex
 	originalText := r.pr.lines[openRangeLineIndex].Text
 	r.pr.lines[openRangeLineIndex].Text = regexp.MustCompile(`^(.*?)\?+(.*)$`).
-		ReplaceAllString(originalText, "${1}"+time.ToString()+"${2}")
+		ReplaceAllString(originalText, "${1}"+time.ToString()+"${2}"+summary.ToString())
 	return makeResult(r.pr.lines, r.recordPointer)
 }
 

--- a/src/parser/reconciler_test.go
+++ b/src/parser/reconciler_test.go
@@ -92,12 +92,14 @@ func TestReconcilerClosesOpenRange(t *testing.T) {
 		return r.Date().ToString() == "2018-01-01"
 	})
 	require.NotNil(t, reconciler)
-	result, err := reconciler.CloseOpenRange(func(r Record) Time { return Ɀ_Time_(16, 42) })
+	result, err := reconciler.CloseOpenRange(func(r Record) (Time, Summary) {
+		return Ɀ_Time_(16, 42), " Yes!"
+	})
 	require.Nil(t, err)
 	assert.Equal(t, `
 2018-01-01
     1h
-    15:00-16:42 Will this close? I hope so!?!?
+    15:00-16:42 Will this close? I hope so!?!? Yes!
 	2m
 `, result.NewText)
 }


### PR DESCRIPTION
Fixes https://github.com/jotaen/klog/issues/36.