### PR TITLE
Windows: display more helpful error message for `bookmark set`

### DIFF
--- a/src/app/context.go
+++ b/src/app/context.go
@@ -254,13 +254,9 @@ func (ctx *context) SetBookmark(path string) Error {
 	if appErr != nil {
 		return appErr
 	}
-	err = os.Symlink(bookmark, ctx.bookmarkOrigin())
-	if err != nil {
-		return NewError(
-			"Failed to create bookmark",
-			"Unable to create the new bookmark",
-			err,
-		)
+	appErr = createSymlinkForBookmark(bookmark, ctx.bookmarkOrigin())
+	if appErr != nil {
+		return appErr
 	}
 	return nil
 }

--- a/src/app/ioutil_unix.go
+++ b/src/app/ioutil_unix.go
@@ -2,6 +2,20 @@
 
 package app
 
+import "os"
+
 func flagAsHidden(path string) {
 	// Nothing to do on UNIX
+}
+
+func createSymlinkForBookmark(targetPath string, linkPath string) Error {
+	err := os.Symlink(targetPath, linkPath)
+	if err != nil {
+		return NewError(
+			"Failed to create bookmark",
+			"Unable to create a symlink for the new bookmark",
+			err,
+		)
+	}
+	return nil
 }

--- a/src/app/ioutil_windows.go
+++ b/src/app/ioutil_windows.go
@@ -3,6 +3,7 @@
 package app
 
 import (
+	"os"
 	"syscall"
 )
 
@@ -12,4 +13,18 @@ func flagAsHidden(path string) {
 		return
 	}
 	_ = syscall.SetFileAttributes(winFileName, syscall.FILE_ATTRIBUTE_HIDDEN)
+}
+
+func createSymlinkForBookmark(targetPath string, linkPath string) Error {
+	err := os.Symlink(targetPath, linkPath)
+	if err != nil {
+		return NewError(
+			"Failed to create bookmark",
+			"On Windows the `bookmark set` subcommand requires admin privileges or "+
+				"developer mode. (klog needs to create a symlink and Windows doesn’t "+
+				"allow this otherwise.)",
+			err,
+		)
+	}
+	return nil
 }


### PR DESCRIPTION
Windows doesn’t support setting symlinks easily, it’s a feature only available for admins or in developer mode. This PR displays a specific error message on Windows so that users know how to work around it for the time being.

Addresses https://github.com/jotaen/klog/issues/66.