### PR TITLE
Support wilcard tag filtering via `...` operator

### DIFF
--- a/src/service/query_test.go
+++ b/src/service/query_test.go
@@ -88,6 +88,15 @@ func TestQueryWithTagOnEntriesAndInSummary(t *testing.T) {
 	assert.Equal(t, NewDuration(8+6, 0), Total(rs...))
 }
 
+func TestQueryWithFuzzyTags(t *testing.T) {
+	rs := Filter(sampleRecordsForQuerying(), FilterQry{Tags: []string{"fo..."}})
+	require.Len(t, rs, 4)
+	assert.Equal(t, 30, rs[0].Date().Day())
+	assert.Equal(t, 1, rs[1].Date().Day())
+	assert.Equal(t, 2, rs[2].Date().Day())
+	assert.Equal(t, 3, rs[3].Date().Day())
+}
+
 func TestQueryWithSorting(t *testing.T) {
 	ss := sampleRecordsForQuerying()
 	for _, x := range []struct{ rs []Record }{

--- a/src/summary.go
+++ b/src/summary.go
@@ -32,21 +32,26 @@ func (ts TagSet) ToStrings() []string {
 	return tags
 }
 
+func (ts TagSet) Contains(queryTag string) bool {
+	if !strings.HasSuffix(queryTag, "...") {
+		return ts[NewTag(queryTag)]
+	}
+	queryBaseTag := NewTag(strings.TrimSuffix(queryTag, "..."))
+	for t := range ts {
+		if strings.HasPrefix(t.ToString(), queryBaseTag.ToString()) {
+			return true
+		}
+	}
+	return false
+}
+
 type TagSet map[Tag]bool
 
 func NewTag(value string) Tag {
-	return Tag(strings.ToLower(value))
-}
-
-func (s Summary) MatchTags(tags TagSet) TagSet {
-	matches := NewTagSet()
-	allTags := s.Tags()
-	for t := range tags {
-		if allTags[t] {
-			matches[t] = true
-		}
+	if value[0] == '#' {
+		value = value[1:]
 	}
-	return matches
+	return Tag(strings.ToLower(value))
 }
 
 func (s Summary) Tags() TagSet {
@@ -63,9 +68,6 @@ func NewTagSet(tags ...string) TagSet {
 	for _, v := range tags {
 		if len(v) == 0 {
 			continue
-		}
-		if v[0] == '#' {
-			v = v[1:]
 		}
 		tag := NewTag(v)
 		result[tag] = true

--- a/src/summary_test.go
+++ b/src/summary_test.go
@@ -21,33 +21,17 @@ func TestSummaryCannotContainWhitespaceAtBeginningOfLine(t *testing.T) {
 }
 
 func TestRecognisesAllTags(t *testing.T) {
-	s := Summary("Hello #world, I feel #GREAT today #123_test")
-	assert.True(t, s.Tags()["world"])
-	assert.True(t, s.Tags()["great"])
-	assert.True(t, s.Tags()["123_test"])
+	s := Summary("Hello #world, I feel #GREAT-ish today #123_test!")
 	assert.Equal(t, s.Tags().ToStrings(), []string{"#123_test", "#great", "#world"})
+	assert.True(t, s.Tags().Contains("#123_test"))
+	assert.True(t, s.Tags().Contains("great"))
+	assert.True(t, s.Tags().Contains("world"))
 }
 
-func TestFindHashTagMatches(t *testing.T) {
-	// `#` is stripped
-	tags := NewTagSet("this", "#THAT", "numb3rs", "under_score")
-	for _, x := range []struct {
-		summary string
-		matches []string
-	}{
-		{"#this at the beginning", []string{"this"}},
-		{"#this, with punctuation afterwards", []string{"this"}},
-		{"or at the end: #this", []string{"this"}},
-		{"or #this in between", []string{"this"}},
-		{"or all: #this and #that and #numb3rs", []string{"this", "that", "numb3rs"}},
-		{"or #that as well (case-insensitive)", []string{"that"}},
-		{"not case sensitive #THIS", []string{"this"}},
-		{"can also contain #numb3rs!", []string{"numb3rs"}},
-		{"or #under_score's", []string{"under_score"}},
-		{"#some other tag", nil},
-		{"#thisAndThat is similar but not the same", nil},
-	} {
-		matches := Summary(x.summary).MatchTags(tags)
-		assert.Equal(t, matches, NewTagSet(x.matches...))
-	}
+func TestPerformsFuzzyMatching(t *testing.T) {
+	s := Summary("Hello #world, I feel #GREAT-ish today #123_test!")
+	assert.True(t, s.Tags().Contains("#123_..."))
+	assert.True(t, s.Tags().Contains("GR..."))
+	assert.True(t, s.Tags().Contains("WoRl..."))
+	assert.False(t, s.Tags().Contains("worl"))
 }


### PR DESCRIPTION
Fixes https://github.com/jotaen/klog/issues/56, so you can do `--tag=foo...` now when filtering on the CLI.

I eventually went with the `...` operator instead of `*`, because the latter is usually caught by shells and interpreted as glob pattern, so you would be forced to quote (`--tag='foo*'`) which is inconvenient. I also assume that wildcards are only useful at the end of the string to support hierarchical tag structures (e.g. `#category_something` → `--tag=category_...`).