### PR TITLE
Auto create on `start` or `track`; also consider “yesterday” for `stop`

### DIFF
--- a/src/app/cli/create.go
+++ b/src/app/cli/create.go
@@ -34,10 +34,10 @@ func (opt *Create) Run(ctx app.Context) error {
 	if err != nil {
 		return err
 	}
-	return ReconcilerApplicator{
-		file: opt.OutputFileArgs.File,
-		ctx:  ctx,
-	}.apply(
+	return lib.ReconcilerChain{
+		File: opt.OutputFileArgs.File,
+		Ctx:  ctx,
+	}.Apply(
 		func(pr *parser.ParseResult) (*parser.ReconcileResult, error) {
 			reconciler := parser.NewBlockReconciler(pr, date)
 			return reconciler.InsertBlock(lines)

--- a/src/app/cli/create.go
+++ b/src/app/cli/create.go
@@ -34,9 +34,10 @@ func (opt *Create) Run(ctx app.Context) error {
 	if err != nil {
 		return err
 	}
-	return applyReconciler(
-		opt.OutputFileArgs,
-		ctx,
+	return ReconcilerApplicator{
+		file: opt.OutputFileArgs.File,
+		ctx:  ctx,
+	}.apply(
 		func(pr *parser.ParseResult) (*parser.ReconcileResult, error) {
 			reconciler := parser.NewBlockReconciler(pr, date)
 			return reconciler.InsertBlock(lines)

--- a/src/app/cli/lib/reconciler_helper.go
+++ b/src/app/cli/lib/reconciler_helper.go
@@ -1,0 +1,49 @@
+package lib
+
+import (
+	"errors"
+	"klog/app"
+	"klog/parser"
+)
+
+type ReconcilerChain struct {
+	File string
+	Ctx  app.Context
+}
+
+type NotEligibleError struct{}
+
+func (e NotEligibleError) Error() string { return "" }
+
+func (c ReconcilerChain) Apply(
+	applicators ...func(pr *parser.ParseResult) (*parser.ReconcileResult, error),
+) error {
+	pr, err := c.Ctx.ReadFileInput(c.File)
+	if err != nil {
+		return err
+	}
+	result, err := func() (*parser.ReconcileResult, error) {
+		for i, a := range applicators {
+			result, err := a(pr)
+			if result != nil {
+				return result, nil
+			}
+			_, isNotEligibleError := err.(NotEligibleError)
+			if isNotEligibleError && i < len(applicators)-1 {
+				// Try next reconcile function
+				continue
+			}
+			return nil, err
+		}
+		return nil, errors.New("No applicable record found")
+	}()
+	if err != nil {
+		return err
+	}
+	err = c.Ctx.WriteFile(c.File, result.NewText)
+	if err != nil {
+		return err
+	}
+	c.Ctx.Print("\n" + parser.SerialiseRecords(&Styler, result.NewRecord) + "\n")
+	return nil
+}

--- a/src/app/cli/start.go
+++ b/src/app/cli/start.go
@@ -5,6 +5,7 @@ import (
 	"klog/app"
 	"klog/app/cli/lib"
 	"klog/parser"
+	"klog/parser/parsing"
 )
 
 type Start struct {
@@ -19,30 +20,36 @@ func (opt *Start) Run(ctx app.Context) error {
 	opt.NoStyleArgs.SetGlobalState()
 	date := opt.AtDate(ctx.Now())
 	time := opt.AtTime(ctx.Now())
-	return ReconcilerApplicator{
-		file: opt.OutputFileArgs.File,
-		ctx:  ctx,
-	}.apply(
+	entry := func() string {
+		summary := ""
+		if opt.Summary != "" {
+			summary += " " + opt.Summary
+		}
+		return time.ToString() + " - ?" + summary
+	}()
+	return lib.ReconcilerChain{
+		File: opt.OutputFileArgs.File,
+		Ctx:  ctx,
+	}.Apply(
 		func(pr *parser.ParseResult) (*parser.ReconcileResult, error) {
 			reconciler := parser.NewRecordReconciler(pr, func(r Record) bool {
-				return r.Date().IsEqualTo(date) && r.OpenRange() == nil
+				return r.Date().IsEqualTo(date)
 			})
 			if reconciler == nil {
-				return nil, app.NewError(
-					"No eligible record at date "+date.ToString(),
-					"Please make sure the record exists and it doesn’t contain an open-ended time range yet.",
-					nil,
-				)
+				return nil, lib.NotEligibleError{}
 			}
-			return reconciler.AppendEntry(
-				func(r Record) string {
-					summary := ""
-					if opt.Summary != "" {
-						summary += " " + opt.Summary
-					}
-					return time.ToString() + " - ?" + summary
-				},
-			)
+			return reconciler.AppendEntry(func(r Record) string {
+				return entry
+			})
+		},
+		func(pr *parser.ParseResult) (*parser.ReconcileResult, error) {
+			reconciler := parser.NewBlockReconciler(pr, date)
+			headline := opt.AtDate(ctx.Now()).ToString()
+			lines := []parsing.Text{
+				{headline, 0},
+				{entry, 1},
+			}
+			return reconciler.InsertBlock(lines)
 		},
 	)
 }

--- a/src/app/cli/start.go
+++ b/src/app/cli/start.go
@@ -19,9 +19,10 @@ func (opt *Start) Run(ctx app.Context) error {
 	opt.NoStyleArgs.SetGlobalState()
 	date := opt.AtDate(ctx.Now())
 	time := opt.AtTime(ctx.Now())
-	return applyReconciler(
-		opt.OutputFileArgs,
-		ctx,
+	return ReconcilerApplicator{
+		file: opt.OutputFileArgs.File,
+		ctx:  ctx,
+	}.apply(
 		func(pr *parser.ParseResult) (*parser.ReconcileResult, error) {
 			reconciler := parser.NewRecordReconciler(pr, func(r Record) bool {
 				return r.Date().IsEqualTo(date) && r.OpenRange() == nil

--- a/src/app/cli/start_test.go
+++ b/src/app/cli/start_test.go
@@ -23,6 +23,17 @@ func TestStart(t *testing.T) {
 `, state.writtenFileContents)
 }
 
+func TestStartFailsIfAlreadyStarted(t *testing.T) {
+	state, err := NewTestingContext()._SetRecords(`
+1920-02-02
+	9:00-???
+`)._Run((&Start{
+		AtDateArgs: lib.AtDateArgs{Date: klog.Ɀ_Date_(1920, 2, 2)},
+	}).Run)
+	require.Error(t, err)
+	assert.Equal(t, state.writtenFileContents, "")
+}
+
 func TestStartWithSummary(t *testing.T) {
 	state, err := NewTestingContext()._SetRecords(`
 1920-02-02
@@ -39,13 +50,15 @@ func TestStartWithSummary(t *testing.T) {
 `, state.writtenFileContents)
 }
 
-func TestStartFailsIfOpenRangeAlreadyPresent(t *testing.T) {
-	state, err := NewTestingContext()._SetRecords(`
+func TestStartAtUnknownDateCreatesNewRecord(t *testing.T) {
+	state, err := NewTestingContext()._SetRecords(`1623-12-13
+	12:23-???
+`)._SetNow(1623, 12, 11, 12, 49)._Run((&Start{}).Run)
+	require.Nil(t, err)
+	assert.Equal(t, `1623-12-11
+	12:49 - ?
+
 1623-12-13
 	12:23-???
-`)._Run((&Start{
-		AtDateArgs: lib.AtDateArgs{Date: klog.Ɀ_Date_(1623, 12, 13)},
-	}).Run)
-	require.Error(t, err)
-	assert.Equal(t, state.writtenFileContents, "")
+`, state.writtenFileContents)
 }

--- a/src/app/cli/stop.go
+++ b/src/app/cli/stop.go
@@ -19,26 +19,37 @@ func (opt *Stop) Run(ctx app.Context) error {
 	opt.NoStyleArgs.SetGlobalState()
 	date := opt.AtDate(ctx.Now())
 	time := opt.AtTime(ctx.Now())
-	return ReconcilerApplicator{
-		file: opt.OutputFileArgs.File,
-		ctx:  ctx,
-	}.apply(
+	return lib.ReconcilerChain{
+		File: opt.OutputFileArgs.File,
+		Ctx:  ctx,
+	}.Apply(
 		func(pr *parser.ParseResult) (*parser.ReconcileResult, error) {
 			reconciler := parser.NewRecordReconciler(pr, func(r Record) bool {
-				return r.Date().IsEqualTo(date) &&
-					r.OpenRange() != nil &&
-					time.IsAfterOrEqual(r.OpenRange().Start())
+				return r.Date().IsEqualTo(date)
 			})
 			if reconciler == nil {
-				return nil, app.NewError(
-					"No eligible record at date "+date.ToString(),
-					"Please make sure the record exists and it contains an open-ended time range "+
-						"which start time is prior to your desired end time.",
-					nil,
-				)
+				return nil, lib.NotEligibleError{}
 			}
 			return reconciler.CloseOpenRange(
 				func(r Record) (Time, Summary) { return time, Summary(opt.Summary) },
+			)
+		},
+		func(pr *parser.ParseResult) (*parser.ReconcileResult, error) {
+			reconciler := parser.NewRecordReconciler(pr, func(r Record) bool {
+				return r.Date().IsEqualTo(date.PlusDays(-1))
+			})
+			if reconciler == nil {
+				return nil, lib.NotEligibleError{}
+			}
+			adjustedTime := func() Time {
+				if time.IsTomorrow() {
+					return time
+				}
+				timeTomorrow, _ := time.Add(NewDuration(24, 0))
+				return timeTomorrow
+			}()
+			return reconciler.CloseOpenRange(
+				func(r Record) (Time, Summary) { return adjustedTime, Summary(opt.Summary) },
 			)
 		},
 	)

--- a/src/app/cli/stop.go
+++ b/src/app/cli/stop.go
@@ -19,9 +19,10 @@ func (opt *Stop) Run(ctx app.Context) error {
 	opt.NoStyleArgs.SetGlobalState()
 	date := opt.AtDate(ctx.Now())
 	time := opt.AtTime(ctx.Now())
-	return applyReconciler(
-		opt.OutputFileArgs,
-		ctx,
+	return ReconcilerApplicator{
+		file: opt.OutputFileArgs.File,
+		ctx:  ctx,
+	}.apply(
 		func(pr *parser.ParseResult) (*parser.ReconcileResult, error) {
 			reconciler := parser.NewRecordReconciler(pr, func(r Record) bool {
 				return r.Date().IsEqualTo(date) &&

--- a/src/app/cli/stop_test.go
+++ b/src/app/cli/stop_test.go
@@ -22,6 +22,18 @@ func TestStop(t *testing.T) {
 `, state.writtenFileContents)
 }
 
+func TestStopFallsBackToYesterday(t *testing.T) {
+	state, err := NewTestingContext()._SetRecords(`
+1920-02-02
+	22:22-?
+`)._SetNow(1920, 2, 3, 4, 16)._Run((&Stop{}).Run)
+	require.Nil(t, err)
+	assert.Equal(t, `
+1920-02-02
+	22:22-4:16>
+`, state.writtenFileContents)
+}
+
 func TestStopWithSummary(t *testing.T) {
 	state, err := NewTestingContext()._SetRecords(`
 1920-02-02
@@ -39,6 +51,8 @@ func TestStopWithSummary(t *testing.T) {
 
 func TestStopFailsIfNoOpenRange(t *testing.T) {
 	state, err := NewTestingContext()._SetRecords(`
+1623-12-12
+
 1623-12-13
 	12:23-13:01
 `)._Run((&Stop{

--- a/src/app/cli/track.go
+++ b/src/app/cli/track.go
@@ -1,11 +1,11 @@
 package cli
 
 import (
-	"errors"
 	. "klog"
 	"klog/app"
 	"klog/app/cli/lib"
 	"klog/parser"
+	"klog/parser/parsing"
 	"strings"
 )
 
@@ -20,18 +20,27 @@ func (opt *Track) Run(ctx app.Context) error {
 	opt.NoStyleArgs.SetGlobalState()
 	date := opt.AtDate(ctx.Now())
 	value := sanitiseQuotedLeadingDash(opt.Entry)
-	return ReconcilerApplicator{
-		file: opt.OutputFileArgs.File,
-		ctx:  ctx,
-	}.apply(
+	return lib.ReconcilerChain{
+		File: opt.OutputFileArgs.File,
+		Ctx:  ctx,
+	}.Apply(
 		func(pr *parser.ParseResult) (*parser.ReconcileResult, error) {
 			reconciler := parser.NewRecordReconciler(pr, func(r Record) bool {
 				return r.Date().IsEqualTo(date)
 			})
 			if reconciler == nil {
-				return nil, errors.New("No record at date " + date.ToString())
+				return nil, lib.NotEligibleError{}
 			}
 			return reconciler.AppendEntry(func(r Record) string { return value })
+		},
+		func(pr *parser.ParseResult) (*parser.ReconcileResult, error) {
+			reconciler := parser.NewBlockReconciler(pr, date)
+			headline := opt.AtDate(ctx.Now()).ToString()
+			lines := []parsing.Text{
+				{headline, 0},
+				{value, 1},
+			}
+			return reconciler.InsertBlock(lines)
 		},
 	)
 }
@@ -41,28 +50,4 @@ func sanitiseQuotedLeadingDash(text string) string {
 	// otherwise it’s treated like a flag. Therefore we have to remove
 	// the potential escaping backslash.
 	return strings.TrimPrefix(text, "\\")
-}
-
-type ReconcilerApplicator struct {
-	file string
-	ctx  app.Context
-}
-
-func (a ReconcilerApplicator) apply(
-	reconcile func(*parser.ParseResult) (*parser.ReconcileResult, error),
-) error {
-	pr, err := a.ctx.ReadFileInput(a.file)
-	if err != nil {
-		return err
-	}
-	result, err := reconcile(pr)
-	if err != nil {
-		return err
-	}
-	err = a.ctx.WriteFile(a.file, result.NewText)
-	if err != nil {
-		return err
-	}
-	a.ctx.Print("\n" + parser.SerialiseRecords(&lib.Styler, result.NewRecord) + "\n")
-	return nil
 }

--- a/src/app/cli/track_test.go
+++ b/src/app/cli/track_test.go
@@ -24,7 +24,7 @@ func TestTrackEntry(t *testing.T) {
 `, state.writtenFileContents)
 }
 
-func TestTrackEntryAtUnknownDateFails(t *testing.T) {
+func TestTrackEntryAtUnknownDateCreatesNewRecord(t *testing.T) {
 	state, err := NewTestingContext()._SetRecords(`
 1855-04-25
 	1h
@@ -32,6 +32,12 @@ func TestTrackEntryAtUnknownDateFails(t *testing.T) {
 		Entry:      "2h",
 		AtDateArgs: lib.AtDateArgs{Date: klog.Ɀ_Date_(2000, 1, 1)},
 	}).Run)
-	require.Error(t, err)
-	assert.Equal(t, state.writtenFileContents, "")
+	require.Nil(t, err)
+	assert.Equal(t, `
+1855-04-25
+	1h
+
+2000-01-01
+	2h
+`, state.writtenFileContents)
 }

--- a/src/parser/reconciler.go
+++ b/src/parser/reconciler.go
@@ -53,7 +53,7 @@ func (r *RecordReconciler) AppendEntry(handler func(Record) string) (*ReconcileR
 func (r *RecordReconciler) CloseOpenRange(handler func(Record) (Time, Summary)) (*ReconcileResult, error) {
 	record := r.pr.Records[r.recordPointer]
 	if record.OpenRange() == nil {
-		return nil, errors.New("NO_OPEN_RANGE")
+		return nil, errors.New("No open time range found")
 	}
 	entryIndex := 0
 	for i, e := range record.Entries() {


### PR DESCRIPTION
Fixes https://github.com/jotaen/klog/issues/60 and https://github.com/jotaen/klog/issues/59:

- If `start` and `track` don’t find an applicable record, they just create it on the fly. (Before it failed.)
- When doing `stop` it now also considers the previous day and closes that range with a shifted time