### PR TITLE
Fix CLI formatting issues

### DIFF
--- a/src/app/cli/create.go
+++ b/src/app/cli/create.go
@@ -17,7 +17,7 @@ type Create struct {
 }
 
 func (opt *Create) Run(ctx app.Context) error {
-	opt.NoStyleArgs.SetGlobalState()
+	opt.NoStyleArgs.Apply(&ctx)
 	date := opt.AtDate(ctx.Now())
 	lines, err := func() ([]parsing.Text, error) {
 		if opt.Template != "" {

--- a/src/app/cli/lib/common_args.go
+++ b/src/app/cli/lib/common_args.go
@@ -116,7 +116,7 @@ type NoStyleArgs struct {
 
 func (args *NoStyleArgs) SetGlobalState() {
 	if args.NoStyle || os.Getenv("NO_COLOR") != "" {
-		Styler = parser.DefaultSerialiser
+		Styler = parser.PlainSerialiser
 	}
 }
 

--- a/src/app/cli/lib/common_args.go
+++ b/src/app/cli/lib/common_args.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	. "klog"
+	"klog/app"
 	"klog/parser"
 	"klog/service"
 	"os"
@@ -114,9 +115,9 @@ type NoStyleArgs struct {
 	NoStyle bool `name:"no-style" help:"Do not style or color the values"`
 }
 
-func (args *NoStyleArgs) SetGlobalState() {
+func (args *NoStyleArgs) Apply(ctx *app.Context) {
 	if args.NoStyle || os.Getenv("NO_COLOR") != "" {
-		Styler = parser.PlainSerialiser
+		(*ctx).SetSerialiser(&parser.PlainSerialiser)
 	}
 }
 

--- a/src/app/cli/lib/format.go
+++ b/src/app/cli/lib/format.go
@@ -12,45 +12,47 @@ import (
 	"strings"
 )
 
-var Styler = parser.Serialiser{
-	Date: func(d Date) string {
-		return Style{Color: "015", IsUnderlined: true}.Format(d.ToString())
-	},
-	ShouldTotal: func(d Duration) string {
-		return Style{Color: "213"}.Format(d.ToString())
-	},
-	Summary: func(s Summary) string {
-		txt := s.ToString()
-		style := Style{Color: "249"}
-		hashStyle := style.ChangedBold(true).ChangedColor("251")
-		txt = HashTagPattern.ReplaceAllStringFunc(txt, func(h string) string {
-			return hashStyle.FormatAndRestore(h, style)
-		})
-		return style.Format(txt)
-	},
-	Range: func(r Range) string {
-		return Style{Color: "117"}.Format(r.ToString())
-	},
-	OpenRange: func(or OpenRange) string {
-		return Style{Color: "027"}.Format(or.ToString())
-	},
-	Duration: func(d Duration) string {
-		f := Style{Color: "120"}
-		if d.InMinutes() < 0 {
-			f.Color = "167"
-		}
-		return f.Format(d.ToString())
-	},
-	SignedDuration: func(d Duration) string {
-		f := Style{Color: "120"}
-		if d.InMinutes() < 0 {
-			f.Color = "167"
-		}
-		return f.Format(d.ToStringWithSign())
-	},
-	Time: func(t Time) string {
-		return Style{Color: "027"}.Format(t.ToString())
-	},
+func NewCliSerialiser() *parser.Serialiser {
+	return &parser.Serialiser{
+		Date: func(d Date) string {
+			return Style{Color: "015", IsUnderlined: true}.Format(d.ToString())
+		},
+		ShouldTotal: func(d Duration) string {
+			return Style{Color: "213"}.Format(d.ToString())
+		},
+		Summary: func(s Summary) string {
+			txt := s.ToString()
+			style := Style{Color: "249"}
+			hashStyle := style.ChangedBold(true).ChangedColor("251")
+			txt = HashTagPattern.ReplaceAllStringFunc(txt, func(h string) string {
+				return hashStyle.FormatAndRestore(h, style)
+			})
+			return style.Format(txt)
+		},
+		Range: func(r Range) string {
+			return Style{Color: "117"}.Format(r.ToString())
+		},
+		OpenRange: func(or OpenRange) string {
+			return Style{Color: "027"}.Format(or.ToString())
+		},
+		Duration: func(d Duration) string {
+			f := Style{Color: "120"}
+			if d.InMinutes() < 0 {
+				f.Color = "167"
+			}
+			return f.Format(d.ToString())
+		},
+		SignedDuration: func(d Duration) string {
+			f := Style{Color: "120"}
+			if d.InMinutes() < 0 {
+				f.Color = "167"
+			}
+			return f.Format(d.ToStringWithSign())
+		},
+		Time: func(t Time) string {
+			return Style{Color: "027"}.Format(t.ToString())
+		},
+	}
 }
 
 var lineBreaker = lineBreakerT{

--- a/src/app/cli/lib/format.go
+++ b/src/app/cli/lib/format.go
@@ -49,92 +49,9 @@ var Styler = parser.Serialiser{
 	},
 }
 
-func Pad(length int) string {
-	if length < 0 {
-		return ""
-	}
-	return strings.Repeat(" ", length)
-}
-
-func PrettyMonth(m int) string {
-	switch m {
-	case 1:
-		return "January"
-	case 2:
-		return "February"
-	case 3:
-		return "March"
-	case 4:
-		return "April"
-	case 5:
-		return "May"
-	case 6:
-		return "June"
-	case 7:
-		return "July"
-	case 8:
-		return "August"
-	case 9:
-		return "September"
-	case 10:
-		return "October"
-	case 11:
-		return "November"
-	case 12:
-		return "December"
-	}
-	panic("Illegal month") // this can/should never happen
-}
-
-func PrettyDay(d int) string {
-	switch d {
-	case 1:
-		return "Monday"
-	case 2:
-		return "Tuesday"
-	case 3:
-		return "Wednesday"
-	case 4:
-		return "Thursday"
-	case 5:
-		return "Friday"
-	case 6:
-		return "Saturday"
-	case 7:
-		return "Sunday"
-	}
-	panic("Illegal weekday") // this can/should never happen
-}
-
-type lineBreakerT struct {
-	maxLength int
-	newLine   string
-}
-
 var lineBreaker = lineBreakerT{
 	maxLength: 60,
 	newLine:   "\n",
-}
-
-func (b lineBreakerT) split(text string, linePrefix string) string {
-	SPACE := " "
-	words := strings.Split(text, SPACE)
-	lines := []string{""}
-	for i, word := range words {
-		nr := len(lines) - 1
-		isLastWordOfText := i == len(words)-1
-		if !isLastWordOfText && len(lines[nr])+len(words[i+1]) > b.maxLength {
-			lines = append(lines, "")
-			nr = len(lines) - 1
-		}
-		if lines[nr] == "" {
-			lines[nr] += linePrefix
-		} else {
-			lines[nr] += SPACE
-		}
-		lines[nr] += word
-	}
-	return strings.Join(lines, b.newLine)
 }
 
 func PrettifyError(err error, isDebug bool) error {

--- a/src/app/cli/lib/format.go
+++ b/src/app/cli/lib/format.go
@@ -116,17 +116,23 @@ var lineBreaker = lineBreakerT{
 	newLine:   "\n",
 }
 
-func (b lineBreakerT) split(text string) string {
+func (b lineBreakerT) split(text string, linePrefix string) string {
 	SPACE := " "
 	words := strings.Split(text, SPACE)
 	lines := []string{""}
-	for i, w := range words {
-		lastLine := lines[len(lines)-1]
-		isLastWord := i == len(words)-1
-		if !isLastWord && len(lastLine)+len(words[i+1]) > b.maxLength {
+	for i, word := range words {
+		nr := len(lines) - 1
+		isLastWordOfText := i == len(words)-1
+		if !isLastWordOfText && len(lines[nr])+len(words[i+1]) > b.maxLength {
 			lines = append(lines, "")
+			nr = len(lines) - 1
 		}
-		lines[len(lines)-1] += w + SPACE
+		if lines[nr] == "" {
+			lines[nr] += linePrefix
+		} else {
+			lines[nr] += SPACE
+		}
+		lines[nr] += word
 	}
 	return strings.Join(lines, b.newLine)
 }
@@ -150,14 +156,14 @@ func PrettifyError(err error, isDebug bool) error {
 				strings.Repeat(" ", e.Position()), strings.Repeat("^", e.Length()),
 			) + "\n"
 			message += fmt.Sprintf(
-				Style{Color: "227"}.Format(INDENT+"%s"),
-				lineBreaker.split(e.Message()), "\n"+INDENT,
+				Style{Color: "227"}.Format("%s"),
+				lineBreaker.split(e.Message(), INDENT),
 			) + "\n\n"
 		}
 		return errors.New(message)
 	case app.Error:
 		message := "Error: " + e.Error() + "\n"
-		message += lineBreaker.split(e.Details())
+		message += lineBreaker.split(e.Details(), "")
 		if isDebug && e.Original() != nil {
 			message += "\n\nOriginal Error:\n" + e.Original().Error()
 		}

--- a/src/app/cli/lib/format.go
+++ b/src/app/cli/lib/format.go
@@ -34,15 +34,19 @@ var Styler = parser.Serialiser{
 	OpenRange: func(or OpenRange) string {
 		return Style{Color: "027"}.Format(or.ToString())
 	},
-	Duration: func(d Duration, forceSign bool) string {
+	Duration: func(d Duration) string {
 		f := Style{Color: "120"}
 		if d.InMinutes() < 0 {
 			f.Color = "167"
 		}
-		if forceSign {
-			return f.Format(d.ToStringWithSign())
-		}
 		return f.Format(d.ToString())
+	},
+	SignedDuration: func(d Duration) string {
+		f := Style{Color: "120"}
+		if d.InMinutes() < 0 {
+			f.Color = "167"
+		}
+		return f.Format(d.ToStringWithSign())
 	},
 	Time: func(t Time) string {
 		return Style{Color: "027"}.Format(t.ToString())

--- a/src/app/cli/lib/format.go
+++ b/src/app/cli/lib/format.go
@@ -55,7 +55,7 @@ func NewCliSerialiser() *parser.Serialiser {
 	}
 }
 
-var lineBreaker = lineBreakerT{
+var lineBreaker = LineBreaker{
 	maxLength: 60,
 	newLine:   "\n",
 }
@@ -80,13 +80,13 @@ func PrettifyError(err error, isDebug bool) error {
 			) + "\n"
 			message += fmt.Sprintf(
 				Style{Color: "227"}.Format("%s"),
-				lineBreaker.split(e.Message(), INDENT),
+				lineBreaker.apply(e.Message(), INDENT),
 			) + "\n\n"
 		}
 		return errors.New(message)
 	case app.Error:
 		message := "Error: " + e.Error() + "\n"
-		message += lineBreaker.split(e.Details(), "")
+		message += lineBreaker.apply(e.Details(), "")
 		if isDebug && e.Original() != nil {
 			message += "\n\nOriginal Error:\n" + e.Original().Error()
 		}

--- a/src/app/cli/lib/format_test.go
+++ b/src/app/cli/lib/format_test.go
@@ -1,0 +1,41 @@
+package lib
+
+import (
+	"github.com/stretchr/testify/assert"
+	"klog/parser/parsing"
+	"regexp"
+	"testing"
+)
+
+var ansiSequencePattern = regexp.MustCompile(`\x1b\[.+?m`)
+
+func stripAllAnsiSequences(text string) string {
+	return ansiSequencePattern.ReplaceAllString(text, "")
+}
+
+func TestFormatParserError(t *testing.T) {
+	err := parsing.NewErrors([]parsing.Error{
+		func() parsing.Error {
+			err := parsing.NewError(parsing.NewLineFromString("Foo bar", 2), 4, 3)
+			return err.Set("CODE", "Some Title", "A verbose description with details, potentially spanning multiple lines with a comprehensive text and tremendously helpful information.")
+		}(),
+		func() parsing.Error {
+			err := parsing.NewError(parsing.NewLineFromString("Some malformed text", 39), 0, 4)
+			return err.Set("CODE", "Error", "Short explanation.")
+		}(),
+	})
+	text := PrettifyError(err, false).Error()
+	assert.Equal(t, ` ERROR in line 2: 
+    Foo bar
+        ^^^
+    Some Title: A verbose description with details, potentially
+    spanning multiple lines with a comprehensive text
+    and tremendously helpful information.
+
+ ERROR in line 39: 
+    Some malformed text
+    ^^^^
+    Error: Short explanation.
+
+`, stripAllAnsiSequences(text))
+}

--- a/src/app/cli/lib/format_test.go
+++ b/src/app/cli/lib/format_test.go
@@ -1,7 +1,9 @@
 package lib
 
 import (
+	"errors"
 	"github.com/stretchr/testify/assert"
+	"klog/app"
 	"klog/parser/parsing"
 	"regexp"
 	"testing"
@@ -38,4 +40,28 @@ func TestFormatParserError(t *testing.T) {
     Error: Short explanation.
 
 `, stripAllAnsiSequences(text))
+}
+
+func TestFormatAppError(t *testing.T) {
+	err := app.NewError("Some message", "A more detailed explanation", nil)
+	text := PrettifyError(err, false).Error()
+	assert.Equal(t, `Error: Some message
+A more detailed explanation`, text)
+}
+
+func TestFormatAppErrorWithDebugFlag(t *testing.T) {
+	textWithNilErr := PrettifyError(
+		app.NewError("Some message", "A more detailed explanation", nil),
+		true).Error()
+	assert.Equal(t, `Error: Some message
+A more detailed explanation`, textWithNilErr)
+
+	textWithErr := PrettifyError(
+		app.NewError("Some message", "A more detailed explanation", errors.New("ORIG_ERR")),
+		true).Error()
+	assert.Equal(t, `Error: Some message
+A more detailed explanation
+
+Original Error:
+ORIG_ERR`, textWithErr)
 }

--- a/src/app/cli/lib/format_test.go
+++ b/src/app/cli/lib/format_test.go
@@ -5,15 +5,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"klog/app"
 	"klog/parser/parsing"
-	"regexp"
 	"testing"
 )
-
-var ansiSequencePattern = regexp.MustCompile(`\x1b\[.+?m`)
-
-func stripAllAnsiSequences(text string) string {
-	return ansiSequencePattern.ReplaceAllString(text, "")
-}
 
 func TestFormatParserError(t *testing.T) {
 	err := parsing.NewErrors([]parsing.Error{
@@ -39,7 +32,7 @@ func TestFormatParserError(t *testing.T) {
     ^^^^
     Error: Short explanation.
 
-`, stripAllAnsiSequences(text))
+`, StripAllAnsiSequences(text))
 }
 
 func TestFormatAppError(t *testing.T) {

--- a/src/app/cli/lib/format_test.go
+++ b/src/app/cli/lib/format_test.go
@@ -65,3 +65,8 @@ A more detailed explanation
 Original Error:
 ORIG_ERR`, textWithErr)
 }
+
+func TestFormatRegularError(t *testing.T) {
+	textWithNilErr := PrettifyError(errors.New("Some plain error"), true).Error()
+	assert.Equal(t, `Error: Some plain error`, textWithNilErr)
+}

--- a/src/app/cli/lib/reconciler_helper.go
+++ b/src/app/cli/lib/reconciler_helper.go
@@ -44,6 +44,6 @@ func (c ReconcilerChain) Apply(
 	if err != nil {
 		return err
 	}
-	c.Ctx.Print("\n" + parser.SerialiseRecords(&Styler, result.NewRecord) + "\n")
+	c.Ctx.Print("\n" + Styler.SerialiseRecords(result.NewRecord) + "\n")
 	return nil
 }

--- a/src/app/cli/lib/reconciler_helper.go
+++ b/src/app/cli/lib/reconciler_helper.go
@@ -44,6 +44,6 @@ func (c ReconcilerChain) Apply(
 	if err != nil {
 		return err
 	}
-	c.Ctx.Print("\n" + Styler.SerialiseRecords(result.NewRecord) + "\n")
+	c.Ctx.Print("\n" + c.Ctx.Serialiser().SerialiseRecords(result.NewRecord) + "\n")
 	return nil
 }

--- a/src/app/cli/lib/textutil.go
+++ b/src/app/cli/lib/textutil.go
@@ -1,0 +1,86 @@
+package lib
+
+import "strings"
+
+func Pad(length int) string {
+	if length < 0 {
+		return ""
+	}
+	return strings.Repeat(" ", length)
+}
+
+func PrettyMonth(m int) string {
+	switch m {
+	case 1:
+		return "January"
+	case 2:
+		return "February"
+	case 3:
+		return "March"
+	case 4:
+		return "April"
+	case 5:
+		return "May"
+	case 6:
+		return "June"
+	case 7:
+		return "July"
+	case 8:
+		return "August"
+	case 9:
+		return "September"
+	case 10:
+		return "October"
+	case 11:
+		return "November"
+	case 12:
+		return "December"
+	}
+	panic("Illegal month") // this can/should never happen
+}
+
+func PrettyDay(d int) string {
+	switch d {
+	case 1:
+		return "Monday"
+	case 2:
+		return "Tuesday"
+	case 3:
+		return "Wednesday"
+	case 4:
+		return "Thursday"
+	case 5:
+		return "Friday"
+	case 6:
+		return "Saturday"
+	case 7:
+		return "Sunday"
+	}
+	panic("Illegal weekday") // this can/should never happen
+}
+
+type lineBreakerT struct {
+	maxLength int
+	newLine   string
+}
+
+func (b lineBreakerT) split(text string, linePrefix string) string {
+	SPACE := " "
+	words := strings.Split(text, SPACE)
+	lines := []string{""}
+	for i, word := range words {
+		nr := len(lines) - 1
+		isLastWordOfText := i == len(words)-1
+		if !isLastWordOfText && len(lines[nr])+len(words[i+1]) > b.maxLength {
+			lines = append(lines, "")
+			nr = len(lines) - 1
+		}
+		if lines[nr] == "" {
+			lines[nr] += linePrefix
+		} else {
+			lines[nr] += SPACE
+		}
+		lines[nr] += word
+	}
+	return strings.Join(lines, b.newLine)
+}

--- a/src/app/cli/lib/textutil.go
+++ b/src/app/cli/lib/textutil.go
@@ -1,6 +1,15 @@
 package lib
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
+
+var ansiSequencePattern = regexp.MustCompile(`\x1b\[[\d;]+m`)
+
+func StripAllAnsiSequences(text string) string {
+	return ansiSequencePattern.ReplaceAllString(text, "")
+}
 
 func Pad(length int) string {
 	if length < 0 {

--- a/src/app/cli/lib/textutil.go
+++ b/src/app/cli/lib/textutil.go
@@ -68,12 +68,12 @@ func PrettyDay(d int) string {
 	panic("Illegal weekday") // this can/should never happen
 }
 
-type lineBreakerT struct {
+type LineBreaker struct {
 	maxLength int
 	newLine   string
 }
 
-func (b lineBreakerT) split(text string, linePrefix string) string {
+func (b LineBreaker) apply(text string, linePrefix string) string {
 	SPACE := " "
 	words := strings.Split(text, SPACE)
 	lines := []string{""}

--- a/src/app/cli/main/klog.go
+++ b/src/app/cli/main/klog.go
@@ -14,7 +14,7 @@ import (
 )
 
 func main() {
-	ctx, err := app.NewContextFromEnv()
+	ctx, err := app.NewContextFromEnv(&lib.Styler)
 	if err != nil {
 		fmt.Println("Failed to initialise application. Error:")
 		fmt.Println(err)

--- a/src/app/cli/main/klog.go
+++ b/src/app/cli/main/klog.go
@@ -14,7 +14,7 @@ import (
 )
 
 func main() {
-	ctx, err := app.NewContextFromEnv(&lib.Styler)
+	ctx, err := app.NewContextFromEnv(lib.NewCliSerialiser())
 	if err != nil {
 		fmt.Println("Failed to initialise application. Error:")
 		fmt.Println(err)

--- a/src/app/cli/now.go
+++ b/src/app/cli/now.go
@@ -22,7 +22,7 @@ type Now struct {
 }
 
 func (opt *Now) Run(ctx app.Context) error {
-	opt.NoStyleArgs.SetGlobalState()
+	opt.NoStyleArgs.Apply(&ctx)
 	h := func() error { return handle(opt, ctx) }
 	if opt.Follow {
 		return withRepeat(ctx, h)
@@ -51,35 +51,35 @@ func handle(opt *Now, ctx app.Context) error {
 	ctx.Print("Total  ")
 	total, _ := service.HypotheticalTotal(now, recents...)
 	grandTotal, _ := service.HypotheticalTotal(now, records...)
-	ctx.Print(lib.Pad(10-len(total.ToString())) + lib.Styler.Duration(total))
-	ctx.Print(lib.Pad(11-len(grandTotal.ToString())) + lib.Styler.Duration(grandTotal))
+	ctx.Print(lib.Pad(10-len(total.ToString())) + ctx.Serialiser().Duration(total))
+	ctx.Print(lib.Pad(11-len(grandTotal.ToString())) + ctx.Serialiser().Duration(grandTotal))
 	ctx.Print("\n")
 	if opt.Diff {
 		// Should:
 		ctx.Print("Should  ")
 		shouldTotal := service.ShouldTotalSum(recents...)
 		grandShouldTotal := service.ShouldTotalSum(records...)
-		ctx.Print(lib.Pad(9-len(shouldTotal.ToString())) + lib.Styler.ShouldTotal(shouldTotal))
-		ctx.Print(lib.Pad(11-len(grandShouldTotal.ToString())) + lib.Styler.ShouldTotal(grandShouldTotal))
+		ctx.Print(lib.Pad(9-len(shouldTotal.ToString())) + ctx.Serialiser().ShouldTotal(shouldTotal))
+		ctx.Print(lib.Pad(11-len(grandShouldTotal.ToString())) + ctx.Serialiser().ShouldTotal(grandShouldTotal))
 		ctx.Print("\n")
 		// Diff:
 		ctx.Print("Diff    ")
 		diff := service.Diff(shouldTotal, total)
 		grandDiff := service.Diff(grandShouldTotal, grandTotal)
-		ctx.Print(lib.Pad(9-len(diff.ToStringWithSign())) + lib.Styler.SignedDuration(diff))
-		ctx.Print(lib.Pad(11-len(grandDiff.ToStringWithSign())) + lib.Styler.SignedDuration(grandDiff))
+		ctx.Print(lib.Pad(9-len(diff.ToStringWithSign())) + ctx.Serialiser().SignedDuration(diff))
+		ctx.Print(lib.Pad(11-len(grandDiff.ToStringWithSign())) + ctx.Serialiser().SignedDuration(grandDiff))
 		ctx.Print("\n")
 		// ETA:
 		ctx.Print("E.T.A.  ")
 		eta, _ := NewTimeFromTime(now).Add(NewDuration(0, 0).Minus(diff))
 		if eta != nil {
-			ctx.Print(lib.Pad(9-len(eta.ToString())) + lib.Styler.Time(eta))
+			ctx.Print(lib.Pad(9-len(eta.ToString())) + ctx.Serialiser().Time(eta))
 		} else {
 			ctx.Print(lib.Pad(9-3) + "???")
 		}
 		grandEta, _ := NewTimeFromTime(now).Add(NewDuration(0, 0).Minus(grandDiff))
 		if grandEta != nil {
-			ctx.Print(lib.Pad(11-len(grandEta.ToString())) + lib.Styler.Time(grandEta))
+			ctx.Print(lib.Pad(11-len(grandEta.ToString())) + ctx.Serialiser().Time(grandEta))
 		} else {
 			ctx.Print(lib.Pad(11-3) + "???")
 		}

--- a/src/app/cli/now.go
+++ b/src/app/cli/now.go
@@ -51,8 +51,8 @@ func handle(opt *Now, ctx app.Context) error {
 	ctx.Print("Total  ")
 	total, _ := service.HypotheticalTotal(now, recents...)
 	grandTotal, _ := service.HypotheticalTotal(now, records...)
-	ctx.Print(lib.Pad(10-len(total.ToString())) + lib.Styler.Duration(total, false))
-	ctx.Print(lib.Pad(11-len(grandTotal.ToString())) + lib.Styler.Duration(grandTotal, false))
+	ctx.Print(lib.Pad(10-len(total.ToString())) + lib.Styler.Duration(total))
+	ctx.Print(lib.Pad(11-len(grandTotal.ToString())) + lib.Styler.Duration(grandTotal))
 	ctx.Print("\n")
 	if opt.Diff {
 		// Should:
@@ -66,8 +66,8 @@ func handle(opt *Now, ctx app.Context) error {
 		ctx.Print("Diff    ")
 		diff := service.Diff(shouldTotal, total)
 		grandDiff := service.Diff(grandShouldTotal, grandTotal)
-		ctx.Print(lib.Pad(9-len(diff.ToStringWithSign())) + lib.Styler.Duration(diff, true))
-		ctx.Print(lib.Pad(11-len(grandDiff.ToStringWithSign())) + lib.Styler.Duration(grandDiff, true))
+		ctx.Print(lib.Pad(9-len(diff.ToStringWithSign())) + lib.Styler.SignedDuration(diff))
+		ctx.Print(lib.Pad(11-len(grandDiff.ToStringWithSign())) + lib.Styler.SignedDuration(grandDiff))
 		ctx.Print("\n")
 		// ETA:
 		ctx.Print("E.T.A.  ")

--- a/src/app/cli/print.go
+++ b/src/app/cli/print.go
@@ -14,7 +14,7 @@ type Print struct {
 }
 
 func (opt *Print) Run(ctx app.Context) error {
-	opt.NoStyleArgs.SetGlobalState()
+	opt.NoStyleArgs.Apply(&ctx)
 	records, err := ctx.ReadInputs(opt.File...)
 	if err != nil {
 		return err
@@ -25,7 +25,7 @@ func (opt *Print) Run(ctx app.Context) error {
 	now := ctx.Now()
 	records = opt.ApplyFilter(now, records)
 	records = opt.ApplySort(records)
-	ctx.Print("\n" + lib.Styler.SerialiseRecords(records...) + "\n")
+	ctx.Print("\n" + ctx.Serialiser().SerialiseRecords(records...) + "\n")
 
 	ctx.Print(opt.WarnArgs.ToString(now, records))
 	return nil

--- a/src/app/cli/print.go
+++ b/src/app/cli/print.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"klog/app"
 	"klog/app/cli/lib"
-	"klog/parser"
 )
 
 type Print struct {
@@ -26,7 +25,7 @@ func (opt *Print) Run(ctx app.Context) error {
 	now := ctx.Now()
 	records = opt.ApplyFilter(now, records)
 	records = opt.ApplySort(records)
-	ctx.Print("\n" + parser.SerialiseRecords(&lib.Styler, records...) + "\n")
+	ctx.Print("\n" + lib.Styler.SerialiseRecords(records...) + "\n")
 
 	ctx.Print(opt.WarnArgs.ToString(now, records))
 	return nil

--- a/src/app/cli/report.go
+++ b/src/app/cli/report.go
@@ -70,13 +70,13 @@ func (opt *Report) Run(ctx app.Context) error {
 			continue
 		}
 		total := opt.NowArgs.Total(now, rs...)
-		ctx.Print(lib.Pad(7-len(total.ToString())) + lib.Styler.Duration(total, false))
+		ctx.Print(lib.Pad(7-len(total.ToString())) + lib.Styler.Duration(total))
 
 		if opt.Diff {
 			should := service.ShouldTotalSum(rs...)
 			ctx.Print(lib.Pad(10-len(should.ToString())) + lib.Styler.ShouldTotal(should))
 			diff := service.Diff(should, total)
-			ctx.Print(lib.Pad(9-len(diff.ToStringWithSign())) + lib.Styler.Duration(diff, true))
+			ctx.Print(lib.Pad(9-len(diff.ToStringWithSign())) + lib.Styler.SignedDuration(diff))
 		}
 
 		ctx.Print("\n")
@@ -87,12 +87,12 @@ func (opt *Report) Run(ctx app.Context) error {
 	}
 	ctx.Print("\n")
 	grandTotal := opt.NowArgs.Total(now, records...)
-	ctx.Print(indentation + lib.Pad(9-len(grandTotal.ToStringWithSign())) + lib.Styler.Duration(grandTotal, true))
+	ctx.Print(indentation + lib.Pad(9-len(grandTotal.ToStringWithSign())) + lib.Styler.SignedDuration(grandTotal))
 	if opt.Diff {
 		grandShould := service.ShouldTotalSum(records...)
 		ctx.Print(lib.Pad(10-len(grandShould.ToString())) + lib.Styler.ShouldTotal(grandShould))
 		grandDiff := service.Diff(grandShould, grandTotal)
-		ctx.Print(lib.Pad(9-len(grandDiff.ToStringWithSign())) + lib.Styler.Duration(grandDiff, true))
+		ctx.Print(lib.Pad(9-len(grandDiff.ToStringWithSign())) + lib.Styler.SignedDuration(grandDiff))
 	}
 	ctx.Print("\n")
 

--- a/src/app/cli/report.go
+++ b/src/app/cli/report.go
@@ -20,7 +20,7 @@ type Report struct {
 }
 
 func (opt *Report) Run(ctx app.Context) error {
-	opt.NoStyleArgs.SetGlobalState()
+	opt.NoStyleArgs.Apply(&ctx)
 	records, err := ctx.ReadInputs(opt.File...)
 	if err != nil {
 		return err
@@ -70,13 +70,13 @@ func (opt *Report) Run(ctx app.Context) error {
 			continue
 		}
 		total := opt.NowArgs.Total(now, rs...)
-		ctx.Print(lib.Pad(7-len(total.ToString())) + lib.Styler.Duration(total))
+		ctx.Print(lib.Pad(7-len(total.ToString())) + ctx.Serialiser().Duration(total))
 
 		if opt.Diff {
 			should := service.ShouldTotalSum(rs...)
-			ctx.Print(lib.Pad(10-len(should.ToString())) + lib.Styler.ShouldTotal(should))
+			ctx.Print(lib.Pad(10-len(should.ToString())) + ctx.Serialiser().ShouldTotal(should))
 			diff := service.Diff(should, total)
-			ctx.Print(lib.Pad(9-len(diff.ToStringWithSign())) + lib.Styler.SignedDuration(diff))
+			ctx.Print(lib.Pad(9-len(diff.ToStringWithSign())) + ctx.Serialiser().SignedDuration(diff))
 		}
 
 		ctx.Print("\n")
@@ -87,12 +87,12 @@ func (opt *Report) Run(ctx app.Context) error {
 	}
 	ctx.Print("\n")
 	grandTotal := opt.NowArgs.Total(now, records...)
-	ctx.Print(indentation + lib.Pad(9-len(grandTotal.ToStringWithSign())) + lib.Styler.SignedDuration(grandTotal))
+	ctx.Print(indentation + lib.Pad(9-len(grandTotal.ToStringWithSign())) + ctx.Serialiser().SignedDuration(grandTotal))
 	if opt.Diff {
 		grandShould := service.ShouldTotalSum(records...)
-		ctx.Print(lib.Pad(10-len(grandShould.ToString())) + lib.Styler.ShouldTotal(grandShould))
+		ctx.Print(lib.Pad(10-len(grandShould.ToString())) + ctx.Serialiser().ShouldTotal(grandShould))
 		grandDiff := service.Diff(grandShould, grandTotal)
-		ctx.Print(lib.Pad(9-len(grandDiff.ToStringWithSign())) + lib.Styler.SignedDuration(grandDiff))
+		ctx.Print(lib.Pad(9-len(grandDiff.ToStringWithSign())) + ctx.Serialiser().SignedDuration(grandDiff))
 	}
 	ctx.Print("\n")
 

--- a/src/app/cli/start.go
+++ b/src/app/cli/start.go
@@ -17,7 +17,7 @@ type Start struct {
 }
 
 func (opt *Start) Run(ctx app.Context) error {
-	opt.NoStyleArgs.SetGlobalState()
+	opt.NoStyleArgs.Apply(&ctx)
 	date := opt.AtDate(ctx.Now())
 	time := opt.AtTime(ctx.Now())
 	entry := func() string {

--- a/src/app/cli/stop.go
+++ b/src/app/cli/stop.go
@@ -16,7 +16,7 @@ type Stop struct {
 }
 
 func (opt *Stop) Run(ctx app.Context) error {
-	opt.NoStyleArgs.SetGlobalState()
+	opt.NoStyleArgs.Apply(&ctx)
 	date := opt.AtDate(ctx.Now())
 	time := opt.AtTime(ctx.Now())
 	return lib.ReconcilerChain{

--- a/src/app/cli/tags.go
+++ b/src/app/cli/tags.go
@@ -17,7 +17,7 @@ type Tags struct {
 }
 
 func (opt *Tags) Run(ctx app.Context) error {
-	opt.NoStyleArgs.SetGlobalState()
+	opt.NoStyleArgs.Apply(&ctx)
 	records, err := ctx.ReadInputs(opt.File...)
 	if err != nil {
 		return err
@@ -30,7 +30,7 @@ func (opt *Tags) Run(ctx app.Context) error {
 		es := entriesByTag[t]
 		ctx.Print(t.ToString())
 		ctx.Print(strings.Repeat(" ", maxLength-len(t)) + " ")
-		ctx.Print(lib.Styler.Duration(service.TotalEntries(es...)))
+		ctx.Print(ctx.Serialiser().Duration(service.TotalEntries(es...)))
 		ctx.Print("\n")
 	}
 

--- a/src/app/cli/tags.go
+++ b/src/app/cli/tags.go
@@ -30,7 +30,7 @@ func (opt *Tags) Run(ctx app.Context) error {
 		es := entriesByTag[t]
 		ctx.Print(t.ToString())
 		ctx.Print(strings.Repeat(" ", maxLength-len(t)) + " ")
-		ctx.Print(lib.Styler.Duration(service.TotalEntries(es...), false))
+		ctx.Print(lib.Styler.Duration(service.TotalEntries(es...)))
 		ctx.Print("\n")
 	}
 

--- a/src/app/cli/testutil_test.go
+++ b/src/app/cli/testutil_test.go
@@ -3,13 +3,11 @@ package cli
 import (
 	. "klog"
 	"klog/app"
+	"klog/app/cli/lib"
 	"klog/parser"
 	"klog/parser/parsing"
-	"regexp"
 	gotime "time"
 )
-
-var ansiSequencePattern = regexp.MustCompile(`\x1b\[[\d;]+m`)
 
 func NewTestingContext() TestingContext {
 	return TestingContext{
@@ -40,7 +38,7 @@ func (ctx TestingContext) _SetNow(Y int, M int, D int, h int, m int) TestingCont
 
 func (ctx TestingContext) _Run(cmd func(app.Context) error) (State, error) {
 	cmdErr := cmd(&ctx)
-	out := ansiSequencePattern.ReplaceAllString(ctx.printBuffer, "")
+	out := lib.StripAllAnsiSequences(ctx.printBuffer)
 	if len(out) > 0 && out[0] != '\n' {
 		out = "\n" + out
 	}

--- a/src/app/cli/testutil_test.go
+++ b/src/app/cli/testutil_test.go
@@ -18,6 +18,7 @@ func NewTestingContext() TestingContext {
 		now:         gotime.Now(),
 		records:     nil,
 		parseResult: nil,
+		serialiser:  lib.NewCliSerialiser(),
 	}
 }
 

--- a/src/app/cli/testutil_test.go
+++ b/src/app/cli/testutil_test.go
@@ -55,6 +55,7 @@ type TestingContext struct {
 	now         gotime.Time
 	records     []Record
 	parseResult *parser.ParseResult
+	serialiser  *parser.Serialiser
 }
 
 func (ctx *TestingContext) Print(s string) {
@@ -122,4 +123,15 @@ func (ctx *TestingContext) OpenInEditor(_ string) app.Error {
 
 func (ctx *TestingContext) InstantiateTemplate(_ string) ([]parsing.Text, app.Error) {
 	return nil, nil
+}
+
+func (ctx *TestingContext) Serialiser() *parser.Serialiser {
+	return ctx.serialiser
+}
+
+func (ctx *TestingContext) SetSerialiser(serialiser *parser.Serialiser) {
+	if serialiser == nil {
+		panic("Serialiser cannot be nil")
+	}
+	ctx.serialiser = serialiser
 }

--- a/src/app/cli/total.go
+++ b/src/app/cli/total.go
@@ -17,7 +17,7 @@ type Total struct {
 }
 
 func (opt *Total) Run(ctx app.Context) error {
-	opt.NoStyleArgs.SetGlobalState()
+	opt.NoStyleArgs.Apply(&ctx)
 	records, err := ctx.ReadInputs(opt.File...)
 	if err != nil {
 		return err
@@ -25,12 +25,12 @@ func (opt *Total) Run(ctx app.Context) error {
 	now := ctx.Now()
 	records = opt.ApplyFilter(now, records)
 	total := opt.NowArgs.Total(now, records...)
-	ctx.Print(fmt.Sprintf("Total: %s\n", lib.Styler.Duration(total)))
+	ctx.Print(fmt.Sprintf("Total: %s\n", ctx.Serialiser().Duration(total)))
 	if opt.Diff {
 		should := service.ShouldTotalSum(records...)
 		diff := service.Diff(should, total)
-		ctx.Print(fmt.Sprintf("Should: %s\n", lib.Styler.ShouldTotal(should)))
-		ctx.Print(fmt.Sprintf("Diff: %s\n", lib.Styler.SignedDuration(diff)))
+		ctx.Print(fmt.Sprintf("Should: %s\n", ctx.Serialiser().ShouldTotal(should)))
+		ctx.Print(fmt.Sprintf("Diff: %s\n", ctx.Serialiser().SignedDuration(diff)))
 	}
 	ctx.Print(fmt.Sprintf("(In %d record%s)\n", len(records), func() string {
 		if len(records) == 1 {

--- a/src/app/cli/total.go
+++ b/src/app/cli/total.go
@@ -25,12 +25,12 @@ func (opt *Total) Run(ctx app.Context) error {
 	now := ctx.Now()
 	records = opt.ApplyFilter(now, records)
 	total := opt.NowArgs.Total(now, records...)
-	ctx.Print(fmt.Sprintf("Total: %s\n", lib.Styler.Duration(total, false)))
+	ctx.Print(fmt.Sprintf("Total: %s\n", lib.Styler.Duration(total)))
 	if opt.Diff {
 		should := service.ShouldTotalSum(records...)
 		diff := service.Diff(should, total)
 		ctx.Print(fmt.Sprintf("Should: %s\n", lib.Styler.ShouldTotal(should)))
-		ctx.Print(fmt.Sprintf("Diff: %s\n", lib.Styler.Duration(diff, true)))
+		ctx.Print(fmt.Sprintf("Diff: %s\n", lib.Styler.SignedDuration(diff)))
 	}
 	ctx.Print(fmt.Sprintf("(In %d record%s)\n", len(records), func() string {
 		if len(records) == 1 {

--- a/src/app/cli/track.go
+++ b/src/app/cli/track.go
@@ -17,7 +17,7 @@ type Track struct {
 }
 
 func (opt *Track) Run(ctx app.Context) error {
-	opt.NoStyleArgs.SetGlobalState()
+	opt.NoStyleArgs.Apply(&ctx)
 	date := opt.AtDate(ctx.Now())
 	value := sanitiseQuotedLeadingDash(opt.Entry)
 	return lib.ReconcilerChain{

--- a/src/app/context.go
+++ b/src/app/context.go
@@ -34,24 +34,28 @@ type Context interface {
 	OpenInFileBrowser(string) Error
 	OpenInEditor(string) Error
 	InstantiateTemplate(string) ([]parsing.Text, Error)
+	Serialiser() *parser.Serialiser
+	SetSerialiser(*parser.Serialiser)
 }
 
 type context struct {
-	homeDir string
+	homeDir    string
+	serialiser *parser.Serialiser
 }
 
-func NewContext(homeDir string) (Context, error) {
+func NewContext(homeDir string, serialiser *parser.Serialiser) (Context, error) {
 	return &context{
-		homeDir: homeDir,
+		homeDir:    homeDir,
+		serialiser: serialiser,
 	}, nil
 }
 
-func NewContextFromEnv() (Context, error) {
+func NewContextFromEnv(serialiser *parser.Serialiser) (Context, error) {
 	homeDir, err := user.Current()
 	if err != nil {
 		return nil, err
 	}
-	return NewContext(homeDir.HomeDir)
+	return NewContext(homeDir.HomeDir, serialiser)
 }
 
 func (ctx *context) Print(text string) {
@@ -328,4 +332,15 @@ func (ctx *context) InstantiateTemplate(templateName string) ([]parsing.Text, Er
 		)
 	}
 	return instance, nil
+}
+
+func (ctx *context) Serialiser() *parser.Serialiser {
+	return ctx.serialiser
+}
+
+func (ctx *context) SetSerialiser(serialiser *parser.Serialiser) {
+	if serialiser == nil {
+		panic("Serialiser cannot be nil")
+	}
+	ctx.serialiser = serialiser
 }

--- a/src/app/mac_widget/run_darwin.go
+++ b/src/app/mac_widget/run_darwin.go
@@ -3,6 +3,7 @@ package mac_widget
 import (
 	"klog/app"
 	"klog/lib/caseymrm/menuet"
+	"klog/parser"
 	"os"
 	"os/exec"
 	"time"
@@ -11,7 +12,7 @@ import (
 var ticker = time.NewTicker(500 * time.Millisecond)
 
 func Run(forceRunThroughLaunchAgent bool) {
-	ctx, err := app.NewContextFromEnv()
+	ctx, err := app.NewContextFromEnv(&parser.PlainSerialiser)
 	if err != nil {
 		os.Exit(1)
 	}

--- a/src/parser/integration_test.go
+++ b/src/parser/integration_test.go
@@ -18,6 +18,6 @@ lines and contains a #tag as well.
     7:00 - ?
 `
 	pr, _ := Parse(text)
-	s := DefaultSerialiser.SerialiseRecords(pr.Records...)
+	s := PlainSerialiser.SerialiseRecords(pr.Records...)
 	assert.Equal(t, text, s)
 }

--- a/src/parser/integration_test.go
+++ b/src/parser/integration_test.go
@@ -18,6 +18,6 @@ lines and contains a #tag as well.
     7:00 - ?
 `
 	pr, _ := Parse(text)
-	s := SerialiseRecords(nil, pr.Records...)
+	s := DefaultSerialiser.SerialiseRecords(pr.Records...)
 	assert.Equal(t, text, s)
 }

--- a/src/parser/serialiser.go
+++ b/src/parser/serialiser.go
@@ -1,12 +1,12 @@
 package parser
 
 import (
-	"klog"
+	. "klog"
 	"strings"
 )
 
 // SerialiseRecords serialises records into the canonical string representation.
-func (h *Serialiser) SerialiseRecords(rs ...klog.Record) string {
+func (h *Serialiser) SerialiseRecords(rs ...Record) string {
 	var text []string
 	for _, r := range rs {
 		text = append(text, h.serialiseRecord(r))
@@ -14,7 +14,7 @@ func (h *Serialiser) SerialiseRecords(rs ...klog.Record) string {
 	return strings.Join(text, "\n")
 }
 
-func (h *Serialiser) serialiseRecord(r klog.Record) string {
+func (h *Serialiser) serialiseRecord(r Record) string {
 	text := ""
 	text += h.Date(r.Date())
 	if r.ShouldTotal().InMinutes() != 0 {
@@ -27,9 +27,9 @@ func (h *Serialiser) serialiseRecord(r klog.Record) string {
 	for _, e := range r.Entries() {
 		text += "    " // indentation
 		text += (e.Unbox(
-			func(r klog.Range) interface{} { return h.Range(r) },
-			func(d klog.Duration) interface{} { return h.Duration(d, false) },
-			func(o klog.OpenRange) interface{} { return h.OpenRange(o) },
+			func(r Range) interface{} { return h.Range(r) },
+			func(d Duration) interface{} { return h.Duration(d) },
+			func(o OpenRange) interface{} { return h.OpenRange(o) },
 		)).(string)
 		if e.Summary() != "" {
 			text += " " + h.Summary(e.Summary())
@@ -40,21 +40,23 @@ func (h *Serialiser) serialiseRecord(r klog.Record) string {
 }
 
 type Serialiser struct {
-	Date        func(klog.Date) string
-	ShouldTotal func(klog.Duration) string
-	Summary     func(klog.Summary) string
-	Range       func(klog.Range) string
-	OpenRange   func(klog.OpenRange) string
-	Duration    func(klog.Duration, bool) string
-	Time        func(klog.Time) string
+	Date           func(Date) string
+	ShouldTotal    func(Duration) string
+	Summary        func(Summary) string
+	Range          func(Range) string
+	OpenRange      func(OpenRange) string
+	Duration       func(Duration) string
+	SignedDuration func(Duration) string
+	Time           func(Time) string
 }
 
-var DefaultSerialiser = Serialiser{
-	Date:        func(d klog.Date) string { return d.ToString() },
-	ShouldTotal: func(d klog.Duration) string { return d.ToString() },
-	Summary:     func(s klog.Summary) string { return string(s) },
-	Range:       func(r klog.Range) string { return r.ToString() },
-	OpenRange:   func(or klog.OpenRange) string { return or.ToString() },
-	Duration:    func(d klog.Duration, _ bool) string { return d.ToString() },
-	Time:        func(t klog.Time) string { return t.ToString() },
+var PlainSerialiser = Serialiser{
+	Date:           Date.ToString,
+	ShouldTotal:    Duration.ToString,
+	Summary:        Summary.ToString,
+	Range:          Range.ToString,
+	OpenRange:      OpenRange.ToString,
+	Duration:       Duration.ToString,
+	SignedDuration: Duration.ToStringWithSign,
+	Time:           Time.ToString,
 }

--- a/src/parser/serialiser.go
+++ b/src/parser/serialiser.go
@@ -6,18 +6,15 @@ import (
 )
 
 // SerialiseRecords serialises records into the canonical string representation.
-func SerialiseRecords(h *Serialiser, rs ...klog.Record) string {
+func (h *Serialiser) SerialiseRecords(rs ...klog.Record) string {
 	var text []string
-	if h == nil {
-		h = &DefaultSerialiser
-	}
 	for _, r := range rs {
-		text = append(text, serialiseRecord(h, r))
+		text = append(text, h.serialiseRecord(r))
 	}
 	return strings.Join(text, "\n")
 }
 
-func serialiseRecord(h *Serialiser, r klog.Record) string {
+func (h *Serialiser) serialiseRecord(r klog.Record) string {
 	text := ""
 	text += h.Date(r.Date())
 	if r.ShouldTotal().InMinutes() != 0 {

--- a/src/parser/serialiser_test.go
+++ b/src/parser/serialiser_test.go
@@ -7,18 +7,18 @@ import (
 )
 
 func TestSerialiseNoRecordsToEmptyString(t *testing.T) {
-	text := SerialiseRecords(nil, []klog.Record{}...)
+	text := DefaultSerialiser.SerialiseRecords([]klog.Record{}...)
 	assert.Equal(t, "", text)
 }
 
 func TestSerialiseEndsWithNewlineIfContainsContent(t *testing.T) {
-	text := SerialiseRecords(nil, klog.NewRecord(klog.Ɀ_Date_(2020, 01, 15)))
+	text := DefaultSerialiser.SerialiseRecords(klog.NewRecord(klog.Ɀ_Date_(2020, 01, 15)))
 	lastChar := []rune(text)[len(text)-1]
 	assert.Equal(t, '\n', lastChar)
 }
 
 func TestSerialiseRecordWithMinimalRecord(t *testing.T) {
-	text := SerialiseRecords(nil, klog.NewRecord(klog.Ɀ_Date_(2020, 01, 15)))
+	text := DefaultSerialiser.SerialiseRecords(klog.NewRecord(klog.Ɀ_Date_(2020, 01, 15)))
 	assert.Equal(t, `2020-01-15
 `, text)
 }
@@ -33,7 +33,7 @@ func TestSerialiseRecordWithCompleteRecord(t *testing.T) {
 	r.AddDuration(klog.NewDuration(-1, -51), "")
 	r.AddRange(klog.Ɀ_Range_(klog.Ɀ_TimeYesterday_(23, 23), klog.Ɀ_Time_(4, 3)), "")
 	r.AddRange(klog.Ɀ_Range_(klog.Ɀ_Time_(22, 0), klog.Ɀ_TimeTomorrow_(0, 1)), "")
-	text := SerialiseRecords(nil, r)
+	text := DefaultSerialiser.SerialiseRecords(r)
 	assert.Equal(t, `2020-01-15 (7h30m!)
 This is a
 multiline summary
@@ -47,7 +47,7 @@ multiline summary
 }
 
 func TestSerialiseMultipleRecords(t *testing.T) {
-	text := SerialiseRecords(nil, []klog.Record{
+	text := DefaultSerialiser.SerialiseRecords([]klog.Record{
 		klog.NewRecord(klog.Ɀ_Date_(2020, 01, 15)),
 		klog.NewRecord(klog.Ɀ_Date_(2020, 01, 20)),
 	}...)

--- a/src/parser/serialiser_test.go
+++ b/src/parser/serialiser_test.go
@@ -7,18 +7,18 @@ import (
 )
 
 func TestSerialiseNoRecordsToEmptyString(t *testing.T) {
-	text := DefaultSerialiser.SerialiseRecords([]klog.Record{}...)
+	text := PlainSerialiser.SerialiseRecords([]klog.Record{}...)
 	assert.Equal(t, "", text)
 }
 
 func TestSerialiseEndsWithNewlineIfContainsContent(t *testing.T) {
-	text := DefaultSerialiser.SerialiseRecords(klog.NewRecord(klog.Ɀ_Date_(2020, 01, 15)))
+	text := PlainSerialiser.SerialiseRecords(klog.NewRecord(klog.Ɀ_Date_(2020, 01, 15)))
 	lastChar := []rune(text)[len(text)-1]
 	assert.Equal(t, '\n', lastChar)
 }
 
 func TestSerialiseRecordWithMinimalRecord(t *testing.T) {
-	text := DefaultSerialiser.SerialiseRecords(klog.NewRecord(klog.Ɀ_Date_(2020, 01, 15)))
+	text := PlainSerialiser.SerialiseRecords(klog.NewRecord(klog.Ɀ_Date_(2020, 01, 15)))
 	assert.Equal(t, `2020-01-15
 `, text)
 }
@@ -33,7 +33,7 @@ func TestSerialiseRecordWithCompleteRecord(t *testing.T) {
 	r.AddDuration(klog.NewDuration(-1, -51), "")
 	r.AddRange(klog.Ɀ_Range_(klog.Ɀ_TimeYesterday_(23, 23), klog.Ɀ_Time_(4, 3)), "")
 	r.AddRange(klog.Ɀ_Range_(klog.Ɀ_Time_(22, 0), klog.Ɀ_TimeTomorrow_(0, 1)), "")
-	text := DefaultSerialiser.SerialiseRecords(r)
+	text := PlainSerialiser.SerialiseRecords(r)
 	assert.Equal(t, `2020-01-15 (7h30m!)
 This is a
 multiline summary
@@ -47,7 +47,7 @@ multiline summary
 }
 
 func TestSerialiseMultipleRecords(t *testing.T) {
-	text := DefaultSerialiser.SerialiseRecords([]klog.Record{
+	text := PlainSerialiser.SerialiseRecords([]klog.Record{
 		klog.NewRecord(klog.Ɀ_Date_(2020, 01, 15)),
 		klog.NewRecord(klog.Ɀ_Date_(2020, 01, 20)),
 	}...)


### PR DESCRIPTION
Fixes https://github.com/jotaen/klog/issues/78
Fixes https://github.com/jotaen/klog/issues/79

## Changes
- Inject serialiser via the context. That’s cleaner and more robust than accessing a singleton instance.
- Add `SignedDuration` on serialiser to avoid having additional logic in the override objects
- Add tests for error rendering to avoid future regressions
- Fix trailing spaces in line-breaking utility