### PR TITLE
Refactor `klog today` command (formerly `klog now`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog (command line tool)
 
 ## v2.5
-- **[ FEATURE ]** Restructure output of `klog now`, especially when
-  using the `--diff` flag
+- **[ BREAKING ]** Rename `klog now` to `klog today`; restructure the
+  output, especially when using the `--diff`/`--now` flag
 - **[ FEATURE ]** Use distinct exit codes for different error cases
 - **[ FEATURE ]** Introduce `--quiet` flag to retrieve raw output
 - **[ FEATURE ]** Extend help texts, improve error messages 

--- a/src/app/cli/index.go
+++ b/src/app/cli/index.go
@@ -1,12 +1,18 @@
 package cli
 
+import (
+	"errors"
+	"klog/app"
+)
+
 type Cli struct {
 	// Evaluate
 	Print  Print  `cmd group:"Evaluate" help:"Pretty-prints records"`
 	Total  Total  `cmd group:"Evaluate" help:"Evaluates the total time"`
 	Report Report `cmd group:"Evaluate" help:"Prints a calendar report summarising all days"`
 	Tags   Tags   `cmd group:"Evaluate" help:"Prints total times aggregated by tags"`
-	Now    Now    `cmd group:"Evaluate" help:"Show overview of the current day"`
+	Today  Today  `cmd group:"Evaluate" help:"Show overview of the current day"`
+	Now    Now    `cmd group:"Evaluate" hidden help:"Show overview of the current day"`
 
 	// Manipulate
 	Track  Track  `cmd group:"Manipulate" help:"Adds a new entry to a record"`
@@ -19,4 +25,13 @@ type Cli struct {
 	Json     Json     `cmd group:"Misc" help:"Converts records to JSON"`
 	Widget   Widget   `cmd group:"Misc" help:"Starts menu bar widget (MacOS only)"`
 	Version  Version  `cmd group:"Misc" help:"Prints version info and check for updates"`
+}
+
+// DEPRECATED
+type Now struct {
+	Today
+}
+
+func (opt *Now) Run(_ app.Context) error {
+	return errors.New("`klog now` has been renamed to `klog today`. Note that the `--now` flag must be passed explicitly.")
 }

--- a/src/app/cli/index.go
+++ b/src/app/cli/index.go
@@ -11,7 +11,7 @@ type Cli struct {
 	Total  Total  `cmd group:"Evaluate" help:"Evaluates the total time"`
 	Report Report `cmd group:"Evaluate" help:"Prints a calendar report summarising all days"`
 	Tags   Tags   `cmd group:"Evaluate" help:"Prints total times aggregated by tags"`
-	Today  Today  `cmd group:"Evaluate" help:"Show overview of the current day"`
+	Today  Today  `cmd group:"Evaluate" help:"Evaluate current day"`
 	Now    Now    `cmd group:"Evaluate" hidden help:"Show overview of the current day"`
 
 	// Manipulate

--- a/src/app/cli/now_test.go
+++ b/src/app/cli/now_test.go
@@ -41,9 +41,9 @@ func TestPrintsTodaysEvalutaion(t *testing.T) {
 	assert.Equal(t, `
              Total
 Today        5h45m
-Previous     12h5m
+Other        12h5m
           ========
-           +17h50m
+All        +17h50m
 `, state.printBuffer)
 }
 
@@ -59,9 +59,9 @@ func TestFallsBackToYesterday(t *testing.T) {
 	assert.Equal(t, `
              Total
 Yesterday      12h
-Previous        5m
+Other           5m
           ========
-            +12h5m
+All         +12h5m
 `, state.printBuffer)
 }
 
@@ -77,8 +77,8 @@ func TestPrintsEvaluationWithDiff(t *testing.T) {
 	assert.Equal(t, `
              Total    Should     Diff   End-Time
 Today        3h35m       6h!   -2h25m      20:38
-Previous     6h50m    3h10m!   +3h40m
+Other        6h50m    3h10m!   +3h40m
           ===========================
-           +10h25m    9h10m!   +1h15m      16:58
+All        +10h25m    9h10m!   +1h15m      16:58
 `, state.printBuffer)
 }

--- a/src/app/cli/report.go
+++ b/src/app/cli/report.go
@@ -87,7 +87,7 @@ func (opt *Report) Run(ctx app.Context) error {
 	}
 	ctx.Print("\n")
 	grandTotal := opt.NowArgs.Total(now, records...)
-	ctx.Print(indentation + lib.Pad(9-len(grandTotal.ToStringWithSign())) + ctx.Serialiser().SignedDuration(grandTotal))
+	ctx.Print(indentation + lib.Pad(9-len(grandTotal.ToString())) + ctx.Serialiser().Duration(grandTotal))
 	if opt.Diff {
 		grandShould := service.ShouldTotalSum(records...)
 		ctx.Print(lib.Pad(10-len(grandShould.ToString())) + ctx.Serialiser().ShouldTotal(grandShould))

--- a/src/app/cli/report_test.go
+++ b/src/app/cli/report_test.go
@@ -53,7 +53,7 @@ func TestReportOfRecords(t *testing.T) {
      Mar    Tue  2.    -8h2m
             Wed  3.       1h
                     ========
-                    +335h50m
+                     335h50m
 `, state.printBuffer)
 }
 
@@ -77,7 +77,7 @@ func TestReportConsecutive(t *testing.T) {
             Sat  3.  
             Sun  4.       3h
                     ========
-                         +4h
+                          4h
 `, state.printBuffer)
 }
 
@@ -101,6 +101,6 @@ func TestReportWithDiff(t *testing.T) {
             Sun  8.       2h    5h30m!   -3h30m
             Mon  9.    5h20m    2h19m!    +3h1m
                     ===========================
-                     +15h20m   15h49m!     -29m
+                      15h20m   15h49m!     -29m
 `, state.printBuffer)
 }

--- a/src/app/cli/today.go
+++ b/src/app/cli/today.go
@@ -13,7 +13,7 @@ import (
 	gotime "time"
 )
 
-type Now struct {
+type Today struct {
 	lib.DiffArgs
 	Follow bool `name:"follow" short:"f" help:"Keep shell open and follow changes"`
 	lib.WarnArgs
@@ -21,7 +21,7 @@ type Now struct {
 	lib.InputFilesArgs
 }
 
-func (opt *Now) Help() string {
+func (opt *Today) Help() string {
 	return `Shows a dashboard-like overview of the data where the current day is displayed
 and evaluated separately from all other records. The current day is either today’s date,
 or otherwise yesterday’s date.
@@ -33,7 +33,7 @@ With the --diff option it calculates the forecasted end-time at which the time g
 When no open range is present, the end time will appear wrapped in parenthesis.`
 }
 
-func (opt *Now) Run(ctx app.Context) error {
+func (opt *Today) Run(ctx app.Context) error {
 	opt.NoStyleArgs.Apply(&ctx)
 	h := func() error { return handle(opt, ctx) }
 	if opt.Follow {
@@ -42,7 +42,7 @@ func (opt *Now) Run(ctx app.Context) error {
 	return h()
 }
 
-func handle(opt *Now, ctx app.Context) error {
+func handle(opt *Today, ctx app.Context) error {
 	now := ctx.Now()
 	records, err := ctx.ReadInputs(opt.File...)
 	if err != nil {

--- a/src/app/cli/today.go
+++ b/src/app/cli/today.go
@@ -22,10 +22,12 @@ type Today struct {
 }
 
 func (opt *Today) Help() string {
-	return `Evaluates the total time, where today’s record and the rest is evaluated separately.
+	return `Evaluates the total time, separately for today’s records and all other records.
 
-With both --now and --diff it also calculates the forecasted end-time at which the time goal will be reached.
-(I.e. when the difference between should and actual time will be 0.)`
+When both --now and --diff are set, it also calculates the forecasted end-time at which the time goal will be reached.
+(I.e. when the difference between should and actual time will be 0.)
+
+If there are no records today, it falls back to yesterday.`
 }
 
 func (opt *Today) Run(ctx app.Context) error {
@@ -135,7 +137,7 @@ func handle(opt *Today, ctx app.Context) error {
 
 	// GrandTotal:
 	ctx.Print("All       ")
-	ctx.Print(lib.Pad(8-len(grandTotal.ToStringWithSign())) + ctx.Serialiser().SignedDuration(grandTotal))
+	ctx.Print(lib.Pad(8-len(grandTotal.ToString())) + ctx.Serialiser().Duration(grandTotal))
 	if opt.Diff {
 		ctx.Print(lib.Pad(10-len(grandShouldTotal.ToString())) + ctx.Serialiser().ShouldTotal(grandShouldTotal))
 		ctx.Print(lib.Pad(9-len(grandDiff.ToStringWithSign())) + ctx.Serialiser().SignedDuration(grandDiff))

--- a/src/app/cli/today_test.go
+++ b/src/app/cli/today_test.go
@@ -7,23 +7,8 @@ import (
 	"testing"
 )
 
-func TestSkipsWhenThereAreNoRecords(t *testing.T) {
-	state, err := NewTestingContext()._SetRecords(``)._Run((&Today{}).Run)
-	require.EqualError(t, err, "No current record (dated either today or yesterday)")
-	assert.Equal(t, "", state.printBuffer)
-}
-
-func TestSkipsWhenThereAreNoRecentRecords(t *testing.T) {
-	state, err := NewTestingContext()._SetNow(1999, 3, 14, 0, 0)._SetRecords(`
-1999-03-12
-	4h
-`)._Run((&Today{}).Run)
-	require.EqualError(t, err, "No current record (dated either today or yesterday)")
-	assert.Equal(t, "", state.printBuffer)
-}
-
 func TestPrintsTodaysEvalutaion(t *testing.T) {
-	state, err := NewTestingContext()._SetNow(1999, 3, 14, 15, 0)._SetRecords(`
+	state, err := NewTestingContext()._SetNow(1999, 3, 14, 19, 9)._SetRecords(`
 1999-03-12
 	5m
 
@@ -35,7 +20,7 @@ func TestPrintsTodaysEvalutaion(t *testing.T) {
 
 1999-03-14
 	3h
-	13:15 - ?
+	13:15 - 15:00
 `)._Run((&Today{}).Run)
 	require.Nil(t, err)
 	assert.Equal(t, `
@@ -66,13 +51,49 @@ All         +12h5m
 }
 
 func TestPrintsEvaluationWithDiff(t *testing.T) {
+	state, err := NewTestingContext()._SetNow(1999, 3, 14, 19, 12)._SetRecords(`
+1999-03-12 (3h10m!)
+	6h50m
+
+1999-03-14 (6h!)
+	14:38 - 18:13
+`)._Run((&Today{DiffArgs: lib.DiffArgs{Diff: true}}).Run)
+	require.Nil(t, err)
+	assert.Equal(t, `
+             Total    Should     Diff
+Today        3h35m       6h!   -2h25m
+Other        6h50m    3h10m!   +3h40m
+          ===========================
+All        +10h25m    9h10m!   +1h15m
+`, state.printBuffer)
+}
+
+func TestPrintsEvaluationWithNow(t *testing.T) {
+	state, err := NewTestingContext()._SetNow(1999, 3, 14, 18, 13)._SetRecords(`
+1999-03-12
+	6h50m
+
+1999-03-14
+	14:38 - ??
+`)._Run((&Today{NowArgs: lib.NowArgs{Now: true}}).Run)
+	require.Nil(t, err)
+	assert.Equal(t, `
+             Total
+Today        3h35m
+Other        6h50m
+          ========
+All        +10h25m
+`, state.printBuffer)
+}
+
+func TestPrintsEvaluationWithDiffAndNow(t *testing.T) {
 	state, err := NewTestingContext()._SetNow(1999, 3, 14, 18, 13)._SetRecords(`
 1999-03-12 (3h10m!)
 	6h50m
 
 1999-03-14 (6h!)
 	14:38 - ?
-`)._Run((&Today{DiffArgs: lib.DiffArgs{Diff: true}}).Run)
+`)._Run((&Today{DiffArgs: lib.DiffArgs{Diff: true}, NowArgs: lib.NowArgs{Now: true}}).Run)
 	require.Nil(t, err)
 	assert.Equal(t, `
              Total    Should     Diff   End-Time
@@ -80,5 +101,20 @@ Today        3h35m       6h!   -2h25m      20:38
 Other        6h50m    3h10m!   +3h40m
           ===========================
 All        +10h25m    9h10m!   +1h15m      16:58
+`, state.printBuffer)
+}
+
+func TestPrintsNAWhenNoCurrentRecord(t *testing.T) {
+	state, err := NewTestingContext()._SetNow(1999, 3, 16, 18, 13)._SetRecords(`
+1999-03-12 (3h10m!)
+	6h50m
+`)._Run((&Today{DiffArgs: lib.DiffArgs{Diff: true}, NowArgs: lib.NowArgs{Now: true}}).Run)
+	require.Nil(t, err)
+	assert.Equal(t, `
+             Total    Should     Diff   End-Time
+Today          n/a       n/a      n/a        n/a
+Other        6h50m    3h10m!   +3h40m
+          ===========================
+All         +6h50m    3h10m!   +3h40m        n/a
 `, state.printBuffer)
 }

--- a/src/app/cli/today_test.go
+++ b/src/app/cli/today_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestSkipsWhenThereAreNoRecords(t *testing.T) {
-	state, err := NewTestingContext()._SetRecords(``)._Run((&Now{}).Run)
+	state, err := NewTestingContext()._SetRecords(``)._Run((&Today{}).Run)
 	require.EqualError(t, err, "No current record (dated either today or yesterday)")
 	assert.Equal(t, "", state.printBuffer)
 }
@@ -17,7 +17,7 @@ func TestSkipsWhenThereAreNoRecentRecords(t *testing.T) {
 	state, err := NewTestingContext()._SetNow(1999, 3, 14, 0, 0)._SetRecords(`
 1999-03-12
 	4h
-`)._Run((&Now{}).Run)
+`)._Run((&Today{}).Run)
 	require.EqualError(t, err, "No current record (dated either today or yesterday)")
 	assert.Equal(t, "", state.printBuffer)
 }
@@ -36,7 +36,7 @@ func TestPrintsTodaysEvalutaion(t *testing.T) {
 1999-03-14
 	3h
 	13:15 - ?
-`)._Run((&Now{}).Run)
+`)._Run((&Today{}).Run)
 	require.Nil(t, err)
 	assert.Equal(t, `
              Total
@@ -54,7 +54,7 @@ func TestFallsBackToYesterday(t *testing.T) {
 
 1999-03-13
 	12h
-`)._Run((&Now{}).Run)
+`)._Run((&Today{}).Run)
 	require.Nil(t, err)
 	assert.Equal(t, `
              Total
@@ -72,7 +72,7 @@ func TestPrintsEvaluationWithDiff(t *testing.T) {
 
 1999-03-14 (6h!)
 	14:38 - ?
-`)._Run((&Now{DiffArgs: lib.DiffArgs{Diff: true}}).Run)
+`)._Run((&Today{DiffArgs: lib.DiffArgs{Diff: true}}).Run)
 	require.Nil(t, err)
 	assert.Equal(t, `
              Total    Should     Diff   End-Time

--- a/src/app/cli/today_test.go
+++ b/src/app/cli/today_test.go
@@ -104,6 +104,21 @@ All         10h25m    9h10m!   +1h15m      16:58
 `, state.printBuffer)
 }
 
+func TestPrintsPlaceholderIfEndTimeIsOutOfBounds(t *testing.T) {
+	state, err := NewTestingContext()._SetNow(1999, 3, 14, 18, 13)._SetRecords(`
+1999-03-14 (60h!)
+	1h
+`)._Run((&Today{DiffArgs: lib.DiffArgs{Diff: true}, NowArgs: lib.NowArgs{Now: true}}).Run)
+	require.Nil(t, err)
+	assert.Equal(t, `
+             Total    Should     Diff   End-Time
+Today           1h      60h!     -59h        ???
+Other           0m       0m!       0m
+          ===========================
+All             1h      60h!     -59h        ???
+`, state.printBuffer)
+}
+
 func TestPrintsNAWhenNoCurrentRecord(t *testing.T) {
 	state, err := NewTestingContext()._SetNow(1999, 3, 16, 18, 13)._SetRecords(`
 1999-03-12 (3h10m!)

--- a/src/app/cli/today_test.go
+++ b/src/app/cli/today_test.go
@@ -28,7 +28,7 @@ func TestPrintsTodaysEvalutaion(t *testing.T) {
 Today        5h45m
 Other        12h5m
           ========
-All        +17h50m
+All         17h50m
 `, state.printBuffer)
 }
 
@@ -46,7 +46,7 @@ func TestFallsBackToYesterday(t *testing.T) {
 Yesterday      12h
 Other           5m
           ========
-All         +12h5m
+All          12h5m
 `, state.printBuffer)
 }
 
@@ -64,7 +64,7 @@ func TestPrintsEvaluationWithDiff(t *testing.T) {
 Today        3h35m       6h!   -2h25m
 Other        6h50m    3h10m!   +3h40m
           ===========================
-All        +10h25m    9h10m!   +1h15m
+All         10h25m    9h10m!   +1h15m
 `, state.printBuffer)
 }
 
@@ -82,7 +82,7 @@ func TestPrintsEvaluationWithNow(t *testing.T) {
 Today        3h35m
 Other        6h50m
           ========
-All        +10h25m
+All         10h25m
 `, state.printBuffer)
 }
 
@@ -100,7 +100,7 @@ func TestPrintsEvaluationWithDiffAndNow(t *testing.T) {
 Today        3h35m       6h!   -2h25m      20:38
 Other        6h50m    3h10m!   +3h40m
           ===========================
-All        +10h25m    9h10m!   +1h15m      16:58
+All         10h25m    9h10m!   +1h15m      16:58
 `, state.printBuffer)
 }
 
@@ -115,6 +115,6 @@ func TestPrintsNAWhenNoCurrentRecord(t *testing.T) {
 Today          n/a       n/a      n/a        n/a
 Other        6h50m    3h10m!   +3h40m
           ===========================
-All         +6h50m    3h10m!   +3h40m        n/a
+All          6h50m    3h10m!   +3h40m        n/a
 `, state.printBuffer)
 }


### PR DESCRIPTION
Additionally fix for https://github.com/jotaen/klog/issues/27.

## Changes
- Make `--now` optional. Due to the new structure the command can also useful be without the `--now` option. Plus, it’s more inline with the other commands, e.g. `klog total --now` or `klog report --now`.
- Rename `klog now` to `klog today`. The idea of this command is to give an overview of the total times, with separate evaluations for today and all other records.
- When there are no current records, display `n/a` in that row. Before, the command would just print an error message, which is not very user-friendly.
- Add more tests