### PR TITLE
Support `--version` in addition to the subcommand

### DIFF
--- a/src/app/cli/index.go
+++ b/src/app/cli/index.go
@@ -25,6 +25,15 @@ type Cli struct {
 	Json     Json     `cmd group:"Misc" help:"Converts records to JSON"`
 	Widget   Widget   `cmd group:"Misc" help:"Starts menu bar widget (MacOS only)"`
 	Version  Version  `cmd group:"Misc" help:"Prints version info and check for updates"`
+
+	// Default command for displaying info text (hidden)
+	Info Info `cmd default:"1" hidden:"1"`
+
+	// Workaround for supporting --version in addition to the `version` subcommand.
+	// It’s hidden, otherwise the flag would appear in the help text on all subcommands.
+	// There is no short flag (-v) defined, otherwise no subcommand could define -v anymore.
+	// The flag is processed by the `Info` subcommand.
+	VersionFlag bool `name:"version" hidden:"1"`
 }
 
 // DEPRECATED

--- a/src/app/cli/info.go
+++ b/src/app/cli/info.go
@@ -1,0 +1,20 @@
+package cli
+
+import (
+	"klog/app"
+)
+
+const DESCRIPTION = "klog: command line app for time tracking with plain-text files.\n" +
+	"Run with --help to learn usage.\n" +
+	"Documentation online at https://klog.jotaen.net"
+
+type Info struct{}
+
+func (opt *Info) Run(ctx app.Context, cli *Cli) error {
+	if cli.VersionFlag {
+		versionCmd := Version{}
+		return versionCmd.Run(ctx)
+	}
+	ctx.Print(DESCRIPTION + "\n")
+	return nil
+}

--- a/src/app/cli/main/klog.go
+++ b/src/app/cli/main/klog.go
@@ -23,11 +23,7 @@ func main() {
 	cliApp := kong.Parse(
 		&cli.Cli{},
 		kong.Name("klog"),
-		kong.Description(
-			"klog time tracking: command line app for interacting with `.klg` files.\n\n"+
-				"Run the --help flag on subcommands to learn how they work.\n"+
-				"Find a comprehensive documentation at https://klog.jotaen.net",
-		),
+		kong.Description(cli.DESCRIPTION),
 		func() kong.Option {
 			datePrototype, _ := klog.NewDate(1, 1, 1)
 			return kong.TypeMapper(reflect.TypeOf(&datePrototype).Elem(), dateDecoder())


### PR DESCRIPTION
Fixes https://github.com/jotaen/klog/issues/99.

It’s tricky with the CLI library I’m using, because it doesn’t support flags that are scoped to the base command, it rather passes on all “global“ flags to subcommands. Therefore, it’s not possible to support `klog -v`, since that wouldn’t allow `klog foo -v` anymore.

On the bright side, I added a default command, so if you run `klog` as is (without subcommand), it will print a friendly info message instead of an error.