### PR TITLE
Clarify definition of whitespace (blank characters)

### DIFF
--- a/Specification.md
+++ b/Specification.md
@@ -219,9 +219,9 @@ and MUST NOT be combined into a single *record*.
 
 - “space”: The character ` ` (U+0020)
 - “tab”: The tab character (U+0009), escape sequence `\t`
-- “blank character”: A “tab”, or a character as defined by the Unicode space separator category (regex `\p{Zs}`)
+- “blank character”: A “tab”, or a character as defined by the Unicode Space Separator category (Zs)
 - “blank line”: A line that only contains “blank characters”
 - “parenthesis”: The opening and closing parentheses `(` and `)` (U+0028 and U+0029)
-- “letter”: A character as defined by the Unicode letter category (regex `\p{L}`)
+- “letter”: A character as defined by the Unicode Letter category (L)
 - “digit”: Any of 0, 1, 2, 3, 4, 5, 6, 7, 8, 9
 - “integer”: An unsigned number without fractional component

--- a/Specification.md
+++ b/Specification.md
@@ -56,7 +56,7 @@ There are two places where *summary* text MAY appear in *records*:
 - Underneath the *date*:
   In this case the *summary* is considered to be associated with the entire *record*.
   The *summary* MAY span multiple lines.
-  Each of its lines MUST NOT start with “whitespace”.
+  Each of its lines MUST NOT start with “blank characters”.
 - Behind *entries*:
   In this case the *summary* is only considered to be referring to the corresponding *entry*.
   The *summary* text follows the *entry* on the same line,
@@ -219,9 +219,9 @@ and MUST NOT be combined into a single *record*.
 
 - “space”: The character ` ` (U+0020)
 - “tab”: The tab character (U+0009), escape sequence `\t`
-- “whitespace”: A “space”, a “tab”, or another character that appears blank
+- “blank character”: A “tab”, or a character as defined by the Unicode space separator category (regex `\p{Zs}`)
+- “blank line”: A line that only contains “blank characters”
 - “parenthesis”: The opening and closing parentheses `(` and `)` (U+0028 and U+0029)
-- “blank line”: A line that only contains “whitespace” characters
-- “letter”: A character as defined by the Unicode letter category, regex `\p{L}`
+- “letter”: A character as defined by the Unicode letter category (regex `\p{L}`)
 - “digit”: Any of 0, 1, 2, 3, 4, 5, 6, 7, 8, 9
 - “integer”: An unsigned number without fractional component

--- a/Specification.md
+++ b/Specification.md
@@ -229,3 +229,5 @@ and MUST NOT be combined into a single *record*.
 ## V. Changelog
 
 ## (Unreleased)
+- Remove technical term “whitespace”, since its meaning is ambiguous and the definition lacked clarity.
+  Replace it with “blank character” and base the definition on the Unicode category.


### PR DESCRIPTION
@vladdeSV next try to fix https://github.com/jotaen/klog/issues/90.

[See here for Unicode space separator category.](https://www.compart.com/en/unicode/category/Zs)