### PR TITLE
Require indentation style to be consistent within records

### DIFF
--- a/Specification.md
+++ b/Specification.md
@@ -83,7 +83,7 @@ MUST be indented in one of the following ways:
 - by two or three “spaces”
 - by one “tab”
 
-The indentation style MUST be consistent within records.
+The indentation style MUST be uniform within records.
 (It MAY differ between records, though.)
 
 ### Time

--- a/Specification.md
+++ b/Specification.md
@@ -232,3 +232,5 @@ and MUST NOT be combined into a single *record*.
 ## V. Changelog
 
 ## (Unreleased)
+- Add a constraint regarding the indentation that requires the indentation style
+  to be uniform within a record.

--- a/Specification.md
+++ b/Specification.md
@@ -83,6 +83,9 @@ MUST be indented in one of the following ways:
 - by two or three “spaces”
 - by one “tab”
 
+The indentation style MUST be consistent within records.
+(It MAY differ between records, though.)
+
 ### Time
 A *time* is a value that represents a point in time throughout a day
 as it would be displayed by a wall clock (which divides a day into


### PR DESCRIPTION
I’d like to make a minor, but important modification to the spec, which is also a breaking change. In order to move forward with https://github.com/jotaen/klog/issues/51, it’s important to enforce a consistent indentation style within records. Otherwise, the following problem could occur with multiline entry summaries, when using 2 spaces as indentation style:

```
2020-01-01
  4h With the upcoming multiline entry summaries,
    text can continue on the next line with increased indentation level.
```

The 2 space indentation style is ambiguous, because 2*2=4, and 4 spaces is also allowed as indentation. If the indentation style was required to be consistent, the ambiguity would be resolved.