### PR TITLE
Spec: Restructuring and more examples

### DIFF
--- a/Specification.md
+++ b/Specification.md
@@ -35,7 +35,7 @@ A *date* is a day that is representable in the Gregorian calendar.
 
 > Examples: `2020-01-01`, `1984-08-30`, `2004/12/24`.
 
-It MUST be formatted according to one of the following patterns:
+*Dates* MUST be formatted according to one of the following patterns:
 - `YYYY-MM-DD` (RECOMMENDED),
 - `YYYY/MM/DD`
 
@@ -46,7 +46,7 @@ A *should-total* denotes the targeted total time of a *record*.
 
 > Examples: `(8h!)`, `(5h15m!)`, `(-3h30m!)`.
 
-A *should-total* MUST be a *duration* value
+*Should-totals* MUST be a *duration* value
 followed by a `!`
 and wrapped in “parentheses”.
 
@@ -120,7 +120,7 @@ A *range* is an *entry* that represents the time span between two points in time
 
 > Examples: `8:00 - 9:00`, `11:00am - 1:00pm`, `<23:40 - 3:12`, `0:30> - 4:00>`.
 
-It MUST consist of two values that denote the start and the end.
+*Ranges* MUST consist of two values that denote the start and the end.
 Start and end MUST be written in chronological order.
 They MAY be equal.
 
@@ -149,8 +149,8 @@ A *duration* is an *entry* that represents a period of time.
 
 > Examples: `1h`, `5m`, `4h12m`, `-8h30m`.
 
-It contains an amount of hours and/or an amount of minutes.
-(So it MUST either contain one of these two or both.)
+*Durations* contain an amount of hours and/or an amount of minutes.
+(So they MUST either contain one of these two or both.)
 The hour part MUST be written first.
 
 The hour part MUST be an “integer”

--- a/Specification.md
+++ b/Specification.md
@@ -33,7 +33,7 @@ Any amount of *entries* MAY appear afterwards.
 ### Date
 A *date* is a day that is representable in the Gregorian calendar.
 
-Each *record* MUST contain a *date*.
+> Examples: `2020-01-01`, `1984-08-30`, `2004/12/24`.
 
 It MUST be formatted according to one of the following patterns:
 - `YYYY-MM-DD` (RECOMMENDED),
@@ -44,15 +44,16 @@ It MUST be formatted according to one of the following patterns:
 ### Should-Total
 A *should-total* denotes the targeted total time of a *record*.
 
+> Examples: `(8h!)`, `(5h15m!)`, `(-3h30m!)`.
+
 A *should-total* MUST be a *duration* value
 followed by a `!`
-and wrapped in “parentheses”,
-e.g. `(8h!)` or `(-5h30m!)`.
+and wrapped in “parentheses”.
 
 ### Summary
 A *summary* is user-provided text for holding arbitrary information.
-There are two places where *summary* text MAY appear in *records*:
 
+There are two places where *summary* text MAY appear in *records*:
 - Underneath the *date*:
   In this case the *summary* is considered to be associated with the entire *record*.
   The *summary* MAY span multiple lines.
@@ -61,21 +62,22 @@ There are two places where *summary* text MAY appear in *records*:
   In this case the *summary* is only considered to be referring to the corresponding *entry*.
   The *summary* text follows the *entry* on the same line,
   and it ends at the end of that line.
-  It MUST be separated from the *entry* by one “space”
-  (there MAY be multiple “spaces”).
+  It MUST be separated from the *entry* by one “space”.
 
 ### Tags
 The purpose of *tags* is to help categorise *records* and *entries*.
 
+> Examples: `#gym`, `#24hours`, `#home_office`, `#読む`.
+
 Any amount of *tags* MAY appear anywhere within *summaries*.
 A *tag* MUST be a sequence of “letters”, “digits” or the `_` character,
-preceded by a single `#` character,
-e.g. `#gym`, `#24hours` or `#home_office`.
+preceded by a single `#` character.
 
 ### Entry
 *Entry* is an abstract term for time-related data.
 *Durations*, *ranges* and *open ranges* are instances of *entries*.
-A *summary* MAY be associated with an *entry* (see section Summary).
+
+> Examples (indentation omitted): `5h`, `5h Gardening`, `11:00 - 14:15`, `8:00 - 15:00 Long day at #school`.
 
 Each *entry* MUST appear on its own line and
 MUST be indented in one of the following ways:
@@ -86,30 +88,14 @@ MUST be indented in one of the following ways:
 The indentation style MUST be uniform within *records*.
 (It MAY differ between *records*, though.)
 
+A *summary* MAY be associated with an *entry* (see section Summary).
+
 ### Time
 A *time* is a value that represents a point in time throughout a day
 as it would be displayed by a wall clock (which divides a day into
-24 hours and every hour into 60 minutes),
-e.g. `9:00`, `23:18`, `6:30am`, `9:23pm` 
+24 hours and every hour into 60 minutes).
 
-A *time* value MUST consist of both an hour part and a minute part.
-Single-digit hour parts MAY be padded with a `0`.
-The minute part MUST always contain two “digits”.
-
-As default, *times* are to be interpreted as 24-hour clock values.
-An `am` or `pm` suffix MAY be used to denote that the value is
-to be interpreted as 12-hour clock value.
-
-### Range
-A *range* is an *entry* that represents the time span between two points in time.
-
-It MUST consist of two values that denote the start and the end.
-Start and end MUST be written in chronological order.
-They MAY be equal.
-
-There MUST be a `-` between the two values.
-There MAY appear “spaces” on either side of the `-`,
-in which case it is RECOMMENDED to use exactly one “space” on both sides of the dash.
+> Examples: `9:00`, `23:18`, `6:30am`, `9:23pm`, `1:00>`, `1:00am>`, `<23:00`.
 
 *Time* values MAY be *shifted* to the next or to the previous day:
 - To associate the *time* with the day before the *record’s* *date*,
@@ -119,13 +105,35 @@ in which case it is RECOMMENDED to use exactly one “space” on both sides of 
   a `>` suffix MUST be used,
   e.g. `1:30>`.
 
-Examples of *ranges* with *shifted times*:
-`<23:00 - 5:00`, `19:00 - 0:30>`, `<22:25 - <23:59`, `<15:00 - 12:00>`, `0:30> - 4:00>`.
+A *time* value MUST consist of both an hour part and a minute part:
+- The minute part MUST be between 0-59 (inclusive).
+  The minute part MUST always contain two “digits”.
+- The hour part MUST be between 0-23 (inclusive).
+  Single-digit hour parts MAY be padded with a `0`.
+
+As default, *times* are to be interpreted as 24-hour clock values.
+An `am` or `pm` suffix MAY be used to denote that the value is
+to be interpreted as 12-hour clock value.
+
+### Range
+A *range* is an *entry* that represents the time span between two points in time.
+
+> Examples: `8:00 - 9:00`, `11:00am - 1:00pm`, `<23:40 - 3:12`, `0:30> - 4:00>`.
+
+It MUST consist of two values that denote the start and the end.
+Start and end MUST be written in chronological order.
+They MAY be equal.
+
+There MUST be a `-` between the two values.
+There MAY appear “spaces” on either side of the `-`,
+in which case it is RECOMMENDED to use exactly one “space” on both sides of the dash.
 
 ### Open range
 An *open range* is an *entry*
 that can be used to track the start *time* of an activity,
 i.e. the end *time* is not determined yet.
+
+> Examples: `05:17 - ?`, `4:00pm - ?`.
 
 *Open ranges* are formatted in the same way as *ranges*,
 except that the end *time* MUST be replaced by a placeholder.
@@ -138,10 +146,12 @@ The placeholder MUST NOT be *shifted*.
 
 ### Duration
 A *duration* is an *entry* that represents a period of time.
+
+> Examples: `1h`, `5m`, `4h12m`, `-8h30m`.
+
 It contains an amount of hours and/or an amount of minutes.
 (So it MUST either contain one of these two or both.)
 The hour part MUST be written first.
-Examples are: `1h`, `5m`, `4h12m`, `-8h30m`.
 
 The hour part MUST be an “integer”
 which MUST be immediately followed by the character `h`.

--- a/Specification.md
+++ b/Specification.md
@@ -97,15 +97,20 @@ as it would be displayed by a wall clock (which divides a day into
 
 > Examples: `9:00`, `23:18`, `6:30am`, `9:23pm`, `1:00>`, `1:00am>`, `<23:00`.
 
-A *time* value MUST consist of both an hour part and a minute part:
-- The minute part MUST be between 0-59 (inclusive).
-  Single-figure minute parts MUST be padded with a `0`.
-- The hour part MUST be between 0-23 (inclusive).
-  Single-figure hour parts MAY be padded with a `0`.
+*Time* values MUST consist of an hour part and a minute part,
+separated by a `:` in between.
+The hour part MUST be written first.
 
 As default, *times* are to be interpreted as 24-hour clock values.
 An `am` or `pm` suffix MAY be used to denote that the value is
 to be interpreted as 12-hour clock value.
+
+The minute part MUST be between 0-59 (inclusive).
+Single-figure minute parts MUST be padded with a `0`.
+
+The hour part MUST either be between 0-23 (inclusive) when using the 24-hour clock,
+or between 1-12 (inclusive) when using the 12-hour clock.
+Single-figure hour parts MAY be padded with a `0`.
 
 *Time* values MAY be *shifted* to the next or to the previous day:
 - To associate the *time* with the day before the *record’s* *date*,

--- a/Specification.md
+++ b/Specification.md
@@ -33,15 +33,20 @@ A *summary* MAY appear on the subsequent lines.
 Any amount of *entries* MAY appear afterwards.
 
 ### Date
-A *date* is a day that is representable in the Gregorian calendar.
+A *date* is a day in the calendar.
 
 > Examples: `2020-01-01`, `1984-08-30`, `2004/12/24`
 
-*Dates* MUST be formatted according to one of the following patterns:
-- `YYYY-MM-DD` (RECOMMENDED),
-- `YYYY/MM/DD`
+*Dates* MUST contain 4 “digits” that denote the year,
+2 “digits” that denote the month,
+and 2 “digits” that denote the day.
+The parts MUST be separated by either a `-` (RECOMMENDED)
+or a `/`.
+The year part MUST be written first, then the month, then the day.
 
-(Where `Y` is a “digit” to denote the year, `M` the month, `D` the day.)
+The combination of year, month and day MUST be representable by the Gregorian calendar.
+The *date* MUST be later or equal than `0000-01-01`,
+and it MUST be earlier or equal than `9999-12-31`.
 
 ### Should-Total
 A *should-total* denotes the targeted total time of a *record*.

--- a/Specification.md
+++ b/Specification.md
@@ -45,8 +45,6 @@ or a `/`.
 The year part MUST be written first, then the month, then the day.
 
 The combination of year, month and day MUST be representable by the Gregorian calendar.
-The *date* MUST be later or equal than `0000-01-01`,
-and it MUST be earlier or equal than `9999-12-31`.
 
 ### Should-Total
 A *should-total* denotes the targeted total time of a *record*.

--- a/Specification.md
+++ b/Specification.md
@@ -156,19 +156,19 @@ A *duration* is an *entry* that represents a period of time.
 
 > Examples: `1h`, `5m`, `4h12m`, `-8h30m`
 
-*Durations* contain an amount of hours and/or an amount of minutes.
+*Durations* MUST contain an amount of hours and/or an amount of minutes.
 (So they MUST either contain one of these two or both.)
 The hour part MUST be written first.
 
 The hour part MUST be an “integer”
-which MUST be immediately followed by the character `h`.
+which MUST be followed by the character `h`.
 It MAY be `0h`.
 It MAY be greater than `24h`,
 e.g. `50h`.
 If the hour part is missing, a value of `0h` is assumed.
 
 The minute part MUST be an “integer”
-which MUST be immediately followed by the character `m`.
+which MUST be followed by the character `m`.
 It MAY be `0m`.
 When the hour part is present,
 the minute part MUST NOT be greater than `59m`,

--- a/Specification.md
+++ b/Specification.md
@@ -35,7 +35,7 @@ Any amount of *entries* MAY appear afterwards.
 ### Date
 A *date* is a day that is representable in the Gregorian calendar.
 
-> Examples: `2020-01-01`, `1984-08-30`, `2004/12/24`.
+> Examples: `2020-01-01`, `1984-08-30`, `2004/12/24`
 
 *Dates* MUST be formatted according to one of the following patterns:
 - `YYYY-MM-DD` (RECOMMENDED),
@@ -46,7 +46,7 @@ A *date* is a day that is representable in the Gregorian calendar.
 ### Should-Total
 A *should-total* denotes the targeted total time of a *record*.
 
-> Examples: `(8h!)`, `(5h15m!)`, `(-3h30m!)`.
+> Examples: `(8h!)`, `(5h15m!)`, `(-3h30m!)`
 
 *Should-totals* MUST be a *duration* value
 followed by a `!`
@@ -69,7 +69,7 @@ There are two places where *summary* text MAY appear in *records*:
 ### Tags
 The purpose of *tags* is to help categorise *records* and *entries*.
 
-> Examples: `#gym`, `#24hours`, `#home_office`, `#読む`.
+> Examples: `#gym`, `#24hours`, `#home_office`, `#読む`
 
 Any amount of *tags* MAY appear anywhere within *summaries*.
 A *tag* MUST be a sequence of “letters”, “digits” or the `_` character,
@@ -79,7 +79,7 @@ preceded by a single `#` character.
 *Entry* is an abstract term for time-related data.
 *Durations*, *ranges* and *open ranges* are instances of *entries*.
 
-> Examples (indentation omitted): `5h`, `5h Gardening`, `11:00 - 14:15`, `8:00 - 15:00 Long day at #school`.
+> Examples (indentation omitted): `5h`, `5h Gardening`, `11:00 - 14:15`, `8:00 - 15:00 Long day at #school`
 
 Each *entry* MUST appear on its own line and
 MUST be indented in one of the following ways:
@@ -97,7 +97,7 @@ A *time* is a value that represents a point in time throughout a day
 as it would be displayed by a wall clock (which divides a day into
 24 hours and every hour into 60 minutes).
 
-> Examples: `9:00`, `23:18`, `6:30am`, `9:23pm`, `1:00>`, `1:00am>`, `<23:00`.
+> Examples: `9:00`, `23:18`, `6:30am`, `9:23pm`, `1:00>`, `1:00am>`, `<23:00`
 
 *Time* values MUST consist of an hour part and a minute part,
 separated by a `:` in between.
@@ -125,7 +125,7 @@ Single-figure hour parts MAY be padded with a `0`.
 ### Range
 A *range* is an *entry* that represents the time span between two points in time.
 
-> Examples: `8:00 - 9:00`, `11:00am - 1:00pm`, `<23:40 - 3:12`, `0:30> - 4:00>`.
+> Examples: `8:00 - 9:00`, `11:00am - 1:00pm`, `<23:40 - 3:12`, `0:30> - 4:00>`
 
 *Ranges* MUST consist of two values that denote the start and the end.
 Start and end MUST be written in chronological order.
@@ -140,7 +140,7 @@ An *open range* is an *entry*
 that can be used to track the start *time* of an activity,
 i.e. the end *time* is not determined yet.
 
-> Examples: `05:17 - ?`, `4:00pm - ?`.
+> Examples: `05:17 - ?`, `4:00pm - ?`
 
 *Open ranges* are formatted in the same way as *ranges*,
 except that the end *time* MUST be replaced by a placeholder.
@@ -154,7 +154,7 @@ The placeholder MUST NOT be *shifted*.
 ### Duration
 A *duration* is an *entry* that represents a period of time.
 
-> Examples: `1h`, `5m`, `4h12m`, `-8h30m`.
+> Examples: `1h`, `5m`, `4h12m`, `-8h30m`
 
 *Durations* contain an amount of hours and/or an amount of minutes.
 (So they MUST either contain one of these two or both.)

--- a/Specification.md
+++ b/Specification.md
@@ -15,6 +15,8 @@ Whenever a word has special meaning in klog, it is formatted in *italics*.
 
 Other technical terms are surrounded by “quotes”. These are defined in the appendix.
 
+Character sequences that are wrapped in `backticks` are meant to be read exactly (character by character).
+
 ## I. Records
 
 A *record* is a self-contained data structure that contains time-tracking information.

--- a/Specification.md
+++ b/Specification.md
@@ -97,6 +97,16 @@ as it would be displayed by a wall clock (which divides a day into
 
 > Examples: `9:00`, `23:18`, `6:30am`, `9:23pm`, `1:00>`, `1:00am>`, `<23:00`.
 
+A *time* value MUST consist of both an hour part and a minute part:
+- The minute part MUST be between 0-59 (inclusive).
+  Single-figure minute parts MUST be padded with a `0`.
+- The hour part MUST be between 0-23 (inclusive).
+  Single-figure hour parts MAY be padded with a `0`.
+
+As default, *times* are to be interpreted as 24-hour clock values.
+An `am` or `pm` suffix MAY be used to denote that the value is
+to be interpreted as 12-hour clock value.
+
 *Time* values MAY be *shifted* to the next or to the previous day:
 - To associate the *time* with the day before the *record’s* *date*,
   a `<` prefix MUST be used,
@@ -104,16 +114,6 @@ as it would be displayed by a wall clock (which divides a day into
 - To associate the *time* with the day after the *record’s* *date*,
   a `>` suffix MUST be used,
   e.g. `1:30>`.
-
-A *time* value MUST consist of both an hour part and a minute part:
-- The minute part MUST be between 0-59 (inclusive).
-  The minute part MUST always contain two “digits”.
-- The hour part MUST be between 0-23 (inclusive).
-  Single-digit hour parts MAY be padded with a `0`.
-
-As default, *times* are to be interpreted as 24-hour clock values.
-An `am` or `pm` suffix MAY be used to denote that the value is
-to be interpreted as 12-hour clock value.
 
 ### Range
 A *range* is an *entry* that represents the time span between two points in time.

--- a/Specification.md
+++ b/Specification.md
@@ -48,7 +48,7 @@ A *should-total* denotes the targeted total time of a *record*.
 
 > Examples: `(8h!)`, `(5h15m!)`, `(-3h30m!)`
 
-*Should-totals* MUST be a *duration* value
+A *should-total* MUST be a *duration* value
 followed by a `!`
 and wrapped in “parentheses”.
 

--- a/Specification.md
+++ b/Specification.md
@@ -84,7 +84,7 @@ preceded by a single `#` character.
 *Entry* is an abstract term for time-related data.
 *Durations*, *ranges* and *open ranges* are instances of *entries*.
 
-> Examples (indentation omitted): `5h`, `5h Gardening`, `11:00 - 14:15`, `8:00 - 15:00 Long day at #school`
+> Examples (indentation omitted): `2h30m`, `-1h Lunch break`, `11:00 - 14:15`, `8:00am - 2:00pm Long day at #school`
 
 Each *entry* MUST appear on its own line and
 MUST be indented in one of the following ways:
@@ -102,9 +102,9 @@ A *time* is a value that represents a point in time throughout a day
 as it would be displayed by a wall clock (which divides a day into
 24 hours and every hour into 60 minutes).
 
-> Examples: `9:00`, `23:18`, `6:30am`, `9:23pm`, `1:00>`, `1:00am>`, `<23:00`
+> Examples: `14:18`, `6:30am`, `01:00>`, `<23:00am`
 
-*Time* values MUST consist of an hour part and a minute part,
+*Time* values MUST contain an hour part and a minute part,
 separated by a `:` in between.
 The hour part MUST be written first.
 
@@ -132,8 +132,8 @@ A *range* is an *entry* that represents the time span between two points in time
 
 > Examples: `8:00 - 9:00`, `11:00am - 1:00pm`, `<23:40 - 3:12`, `0:30> - 4:00>`
 
-*Ranges* MUST consist of two values that denote the start and the end.
-Start and end MUST be written in chronological order.
+*Ranges* MUST contain two *time* values that denote the start and the end.
+Start *time* and end *time* MUST be written in chronological order.
 They MAY be equal.
 
 There MUST be a `-` between the two values.


### PR DESCRIPTION
“Non-functional” refactoring of the specification for improved clarity.

## Changes
- Add examples for all concepts (except summaries) and structure every section in the same way:
  - Brief explanation of what it is on a high-level
  - Examples (formatted as markdown blockquote)
  - Detailed instructions
- Remove redundant statement “Each record must contain a date”, since that’s already clear from the record specification.
- Remove statement for entry summaries “there may be multiple spaces”. This is superfluous, because everything after the first space is treated as part of the summary copy, and an entry summary is allowed to contain (and hence start with) any character.
- Remove term “immediately” (e.g. `MUST be immediately followed by the character`) – that sounds a bit dramatic and doesn’t add any meaning.
- Rewrite section for dates
- Move statements about shifting to section “Time”, because shifting is actually a concept of the time value itself, and not of a range as a whole.
  - Reduce number of examples for shifted ranges, I think the rules should be clear without a complete enumeration.
- Specify value ranges for the hour and minute parts, and distinguish between the rules for 24- and 12-hour clock.
- Explain the general purpose of backticks in the document’s preface.