### PR TITLE
Also issue warnings when manipulating files

### DIFF
--- a/src/app/commands/create.go
+++ b/src/app/commands/create.go
@@ -13,6 +13,7 @@ type Create struct {
 	lib.AtDateArgs
 	lib.NoStyleArgs
 	lib.OutputFileArgs
+	lib.WarnArgs
 }
 
 func (opt *Create) Help() string {
@@ -23,9 +24,7 @@ func (opt *Create) Help() string {
 func (opt *Create) Run(ctx app.Context) error {
 	opt.NoStyleArgs.Apply(&ctx)
 	date, _ := opt.AtDate(ctx.Now())
-	return ctx.ReconcileFile(
-		opt.OutputFileArgs.File,
-
+	return lib.Reconcile(ctx, lib.ReconcileOpts{OutputFileArgs: opt.OutputFileArgs, WarnArgs: opt.WarnArgs},
 		[]reconciling.Creator{
 			func(parsedRecords []parser.ParsedRecord) *reconciling.Reconciler {
 				return reconciling.NewReconcilerAtNewRecord(parsedRecords, date, opt.ShouldTotal)

--- a/src/app/commands/start.go
+++ b/src/app/commands/start.go
@@ -12,6 +12,7 @@ type Start struct {
 	Summary string `name:"summary" short:"s" help:"Summary text for this entry"`
 	lib.NoStyleArgs
 	lib.OutputFileArgs
+	lib.WarnArgs
 }
 
 func (opt *Start) Help() string {
@@ -27,9 +28,7 @@ func (opt *Start) Run(ctx app.Context) error {
 	if err != nil {
 		return err
 	}
-	return ctx.ReconcileFile(
-		opt.OutputFileArgs.File,
-
+	return lib.Reconcile(ctx, lib.ReconcileOpts{OutputFileArgs: opt.OutputFileArgs, WarnArgs: opt.WarnArgs},
 		[]reconciling.Creator{
 			func(parsedRecords []parser.ParsedRecord) *reconciling.Reconciler {
 				return reconciling.NewReconcilerAtRecord(parsedRecords, date)

--- a/src/app/commands/stop.go
+++ b/src/app/commands/stop.go
@@ -13,6 +13,7 @@ type Stop struct {
 	Summary string `name:"summary" short:"s" help:"Text to append to the entry summary"`
 	lib.NoStyleArgs
 	lib.OutputFileArgs
+	lib.WarnArgs
 }
 
 func (opt *Stop) Help() string {
@@ -28,9 +29,7 @@ func (opt *Stop) Run(ctx app.Context) error {
 	if err != nil {
 		return err
 	}
-	return ctx.ReconcileFile(
-		opt.OutputFileArgs.File,
-
+	return lib.Reconcile(ctx, lib.ReconcileOpts{OutputFileArgs: opt.OutputFileArgs, WarnArgs: opt.WarnArgs},
 		[]reconciling.Creator{
 			func(parsedRecords []parser.ParsedRecord) *reconciling.Reconciler {
 				return reconciling.NewReconcilerAtRecord(parsedRecords, date)
@@ -39,7 +38,7 @@ func (opt *Stop) Run(ctx app.Context) error {
 				if isAutoDate && isAutoTime {
 					// Only fall back to yesterday if no explicit date has been given.
 					// Otherwise, it wouldn’t make sense to decrement the day.
-					time, _ = time.Add(NewDuration(24, 0))
+					time, _ = time.Plus(NewDuration(24, 0))
 					return reconciling.NewReconcilerAtRecord(parsedRecords, date.PlusDays(-1))
 				}
 				return nil

--- a/src/app/commands/testutil_test.go
+++ b/src/app/commands/testutil_test.go
@@ -93,13 +93,13 @@ func (ctx *TestingContext) ReadInputs(_ ...app.FileOrBookmarkName) ([]Record, ap
 	return allRecords, nil
 }
 
-func (ctx *TestingContext) ReconcileFile(_ app.FileOrBookmarkName, creators []reconciling.Creator, reconcile reconciling.Reconcile) app.Error {
+func (ctx *TestingContext) ReconcileFile(_ app.FileOrBookmarkName, creators []reconciling.Creator, reconcile reconciling.Reconcile) (*reconciling.Result, app.Error) {
 	result, err := app.ApplyReconciler(ctx.parsedRecords, creators, reconcile)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	ctx.writtenFileContents = result.AllSerialised
-	return nil
+	return result, nil
 }
 
 func (ctx *TestingContext) WriteFile(_ app.File, contents string) app.Error {

--- a/src/app/commands/today.go
+++ b/src/app/commands/today.go
@@ -60,14 +60,14 @@ func handle(opt *Today, ctx app.Context) error {
 	hasCurrentRecords := len(currentRecords) > 0
 
 	currentTotal, currentShouldTotal, currentDiff := opt.evaluate(now, currentRecords)
-	currentEndTime, _ := NewTimeFromTime(now).Add(NewDuration(0, 0).Minus(currentDiff))
+	currentEndTime, _ := NewTimeFromGo(now).Plus(NewDuration(0, 0).Minus(currentDiff))
 
 	otherTotal, otherShouldTotal, otherDiff := opt.evaluate(now, otherRecords)
 
 	grandTotal := currentTotal.Plus(otherTotal)
 	grandShouldTotal := NewShouldTotal(0, currentShouldTotal.Plus(otherShouldTotal).InMinutes())
 	grandDiff := service.Diff(grandShouldTotal, grandTotal)
-	grandEndTime, _ := NewTimeFromTime(now).Add(NewDuration(0, 0).Minus(grandDiff))
+	grandEndTime, _ := NewTimeFromGo(now).Plus(NewDuration(0, 0).Minus(grandDiff))
 
 	numberOfValueColumns := func() int {
 		if opt.Diff {
@@ -183,7 +183,7 @@ func splitIntoCurrentAndOther(now gotime.Time, records []Record) ([]Record, []Re
 	var todaysRecords []Record
 	var yesterdaysRecords []Record
 	var otherRecords []Record
-	today := NewDateFromTime(now)
+	today := NewDateFromGo(now)
 	yesterday := today.PlusDays(-1)
 	for _, r := range records {
 		if r.Date().IsEqualTo(today) {

--- a/src/app/commands/track.go
+++ b/src/app/commands/track.go
@@ -13,6 +13,7 @@ type Track struct {
 	Entry string `arg:"" required:"" help:"The new entry to add"`
 	lib.NoStyleArgs
 	lib.OutputFileArgs
+	lib.WarnArgs
 }
 
 func (opt *Track) Help() string {
@@ -26,11 +27,10 @@ and to avoid the text being processed by your shell.`
 
 func (opt *Track) Run(ctx app.Context) error {
 	opt.NoStyleArgs.Apply(&ctx)
-	date, _ := opt.AtDate(ctx.Now())
+	now := ctx.Now()
+	date, _ := opt.AtDate(now)
 	value := sanitiseQuotedLeadingDash(opt.Entry)
-	return ctx.ReconcileFile(
-		opt.OutputFileArgs.File,
-
+	return lib.Reconcile(ctx, lib.ReconcileOpts{OutputFileArgs: opt.OutputFileArgs, WarnArgs: opt.WarnArgs},
 		[]reconciling.Creator{
 			func(parsedRecords []parser.ParsedRecord) *reconciling.Reconciler {
 				return reconciling.NewReconcilerAtRecord(parsedRecords, date)

--- a/src/app/commands/widget/render.go
+++ b/src/app/commands/widget/render.go
@@ -73,7 +73,7 @@ func render(ctx app.Context, agent *launchAgent) []menuet.MenuItem {
 func renderRecords(ctx app.Context, records []klog.Record, file app.File) []menuet.MenuItem {
 	var items []menuet.MenuItem
 
-	today := service.Filter(records, service.FilterQry{Dates: []klog.Date{klog.NewDateFromTime(ctx.Now())}})
+	today := service.Filter(records, service.FilterQry{Dates: []klog.Date{klog.NewDateFromGo(ctx.Now())}})
 	if today != nil {
 		total, isOngoing := service.HypotheticalTotal(ctx.Now(), today...)
 		indicator := ""

--- a/src/app/lib/args.go
+++ b/src/app/lib/args.go
@@ -19,17 +19,17 @@ type OutputFileArgs struct {
 }
 
 type AtDateArgs struct {
+	Date      Date `name:"date" short:"d" help:"The date of the record"`
 	Today     bool `name:"today" help:"Use today’s date (default)"`
 	Yesterday bool `name:"yesterday" help:"Use yesterday’s date"`
 	Tomorrow  bool `name:"tomorrow" help:"Use tomorrow’s date"`
-	Date      Date `name:"date" short:"d" help:"The date of the record"`
 }
 
 func (args *AtDateArgs) AtDate(now gotime.Time) (Date, bool) {
 	if args.Date != nil {
 		return args.Date, false
 	}
-	today := NewDateFromTime(now) // That’s effectively/implicitly `--today`
+	today := NewDateFromGo(now) // That’s effectively/implicitly `--today`
 	if args.Yesterday {
 		return today.PlusDays(-1), false
 	} else if args.Tomorrow {
@@ -48,14 +48,14 @@ func (args *AtDateAndTimeArgs) AtTime(now gotime.Time) (Time, bool, app.Error) {
 		return args.Time, false, nil
 	}
 	date, _ := args.AtDate(now)
-	today := NewDateFromTime(now)
+	today := NewDateFromGo(now)
 	if today.IsEqualTo(date) {
-		return NewTimeFromTime(now), true, nil
+		return NewTimeFromGo(now), true, nil
 	} else if today.PlusDays(-1).IsEqualTo(date) {
-		shiftedTime, _ := NewTimeFromTime(now).Add(NewDuration(24, 0))
+		shiftedTime, _ := NewTimeFromGo(now).Plus(NewDuration(24, 0))
 		return shiftedTime, true, nil
 	} else if today.PlusDays(1).IsEqualTo(date) {
-		shiftedTime, _ := NewTimeFromTime(now).Add(NewDuration(-24, 0))
+		shiftedTime, _ := NewTimeFromGo(now).Plus(NewDuration(-24, 0))
 		return shiftedTime, true, nil
 	}
 	return nil, false, app.NewErrorWithCode(
@@ -112,10 +112,10 @@ func (args *FilterArgs) ApplyFilter(now gotime.Time, rs []Record) []Record {
 		qry.BeforeOrEqual = args.Before.PlusDays(-1)
 	}
 	if args.Today {
-		qry.Dates = append(qry.Dates, NewDateFromTime(now))
+		qry.Dates = append(qry.Dates, NewDateFromGo(now))
 	}
 	if args.Yesterday {
-		qry.Dates = append(qry.Dates, NewDateFromTime(now.AddDate(0, 0, -1)))
+		qry.Dates = append(qry.Dates, NewDateFromGo(now.AddDate(0, 0, -1)))
 	}
 	return service.Filter(rs, qry)
 }

--- a/src/app/lib/commons.go
+++ b/src/app/lib/commons.go
@@ -1,0 +1,35 @@
+package lib
+
+import (
+	klog "github.com/jotaen/klog/src"
+	"github.com/jotaen/klog/src/app"
+	"github.com/jotaen/klog/src/parser"
+	"github.com/jotaen/klog/src/parser/reconciling"
+)
+
+type ReconcileOpts struct {
+	OutputFileArgs
+	WarnArgs
+}
+
+func Reconcile(ctx app.Context, opts ReconcileOpts, creators []reconciling.Creator, reconcile reconciling.Reconcile) error {
+	result, err := ctx.ReconcileFile(
+		opts.OutputFileArgs.File,
+		creators,
+		reconcile,
+	)
+	if err != nil {
+		return err
+	}
+	ctx.Print("\n" + ctx.Serialiser().SerialiseRecords(result.Record) + "\n")
+	ctx.Print(opts.WarnArgs.ToString(ctx.Now(), ToRecords(result.AllRecords)))
+	return nil
+}
+
+func ToRecords(prs []parser.ParsedRecord) []klog.Record {
+	result := make([]klog.Record, len(prs))
+	for i, r := range prs {
+		result[i] = r
+	}
+	return result
+}

--- a/src/date.go
+++ b/src/date.go
@@ -88,7 +88,7 @@ func NewDateFromString(yyyymmdd string) (Date, error) {
 	return civil2Date(cd, DateFormat{UseDashes: strings.Contains(yyyymmdd, "-")})
 }
 
-func NewDateFromTime(t gotime.Time) Date {
+func NewDateFromGo(t gotime.Time) Date {
 	d, err := NewDate(t.Year(), int(t.Month()), t.Day())
 	if err != nil {
 		// This can/should never occur

--- a/src/parser/reconciling/reconciler.go
+++ b/src/parser/reconciling/reconciler.go
@@ -28,6 +28,7 @@ type Reconciler struct {
 // Result is the result of an applied reconciler.
 type Result struct {
 	Record        Record
+	AllRecords    []parser.ParsedRecord
 	AllSerialised string
 }
 
@@ -109,6 +110,7 @@ func (r *Reconciler) MakeResult() (*Result, error) {
 
 	return &Result{
 		Record:        newRecords[r.recordPointer],
+		AllRecords:    newRecords,
 		AllSerialised: text,
 	}, nil
 }

--- a/src/parser/reconciling/reconciler_test.go
+++ b/src/parser/reconciling/reconciler_test.go
@@ -350,7 +350,7 @@ func TestReconcileRespectsExistingStylePref(t *testing.T) {
 		expected string
 	}{
 		{"3145/06/15\n", "3145/06/15\n\n3145/06/16\n"},
-		{"3145/06/15\n\n3145-06-15\n", "3145/06/15\n\n3145-06-15\n\n3145/06/16\n"},
+		{"3145/06/14\n\n3145/06/15\n\n3145-06-15\n", "3145/06/14\n\n3145/06/15\n\n3145-06-15\n\n3145/06/16\n"},
 	} {
 		rs, _ := parser.Parse(x.original)
 		reconciler := NewReconcilerAtNewRecord(rs, Ɀ_Date_(3145, 6, 16), nil)

--- a/src/service/datetime.go
+++ b/src/service/datetime.go
@@ -1,0 +1,45 @@
+package service
+
+import (
+	. "github.com/jotaen/klog/src"
+	gotime "time"
+)
+
+// DateTime represents a point in time with a normalized time value.
+type DateTime struct {
+	Date Date
+	Time Time
+}
+
+func NewDateTime(d Date, t Time) DateTime {
+	normalizedTime, _ := NewTime(t.Hour(), t.Minute())
+	dayOffset := func() int {
+		if t.IsTomorrow() {
+			return 1
+		} else if t.IsYesterday() {
+			return -1
+		}
+		return 0
+	}()
+	return DateTime{
+		Date: d.PlusDays(dayOffset),
+		Time: normalizedTime,
+	}
+}
+
+func NewDateTimeFromGo(reference gotime.Time) DateTime {
+	date := NewDateFromGo(reference)
+	time := NewTimeFromGo(reference)
+	return NewDateTime(date, time)
+}
+
+func (dt DateTime) IsEqual(compare DateTime) bool {
+	return dt.Date.IsEqualTo(compare.Date) && dt.Time.IsEqualTo(compare.Time)
+}
+
+func (dt DateTime) IsAfterOrEqual(compare DateTime) bool {
+	if dt.Date.IsEqualTo(compare.Date) {
+		return dt.Time.IsAfterOrEqual(compare.Time)
+	}
+	return dt.Date.IsAfterOrEqual(compare.Date)
+}

--- a/src/service/datetime_test.go
+++ b/src/service/datetime_test.go
@@ -1,0 +1,53 @@
+package service
+
+import (
+	. "github.com/jotaen/klog/src"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestCreatesNormalizedDateTime(t *testing.T) {
+	for _, x := range []struct {
+		date Date
+		time Time
+	}{
+		{Ɀ_Date_(1000, 7, 15), Ɀ_Time_(15, 00)},
+		{Ɀ_Date_(1000, 7, 14), Ɀ_TimeTomorrow_(15, 00)},
+		{Ɀ_Date_(1000, 7, 16), Ɀ_TimeYesterday_(15, 00)},
+	} {
+		dt := NewDateTime(x.date, x.time)
+		assert.Equal(t, "1000-07-15", dt.Date.ToString())
+		assert.Equal(t, "15:00", dt.Time.ToString())
+	}
+}
+
+func TestEqualsDateTime(t *testing.T) {
+	dt1 := NewDateTime(Ɀ_Date_(1000, 7, 15), Ɀ_Time_(12, 00))
+	dt2 := NewDateTime(Ɀ_Date_(1000, 7, 15), Ɀ_Time_(12, 01))
+	dt3 := NewDateTime(Ɀ_Date_(1000, 7, 16), Ɀ_Time_(12, 00))
+	assert.True(t, dt1.IsEqual(dt1))
+	assert.False(t, dt1.IsEqual(dt2))
+	assert.False(t, dt1.IsEqual(dt3))
+	assert.False(t, dt2.IsEqual(dt3))
+}
+
+func TestIsAfterOrEqualsDateTime(t *testing.T) {
+	dt1 := NewDateTime(Ɀ_Date_(1000, 7, 14), Ɀ_Time_(13, 00))
+	dt2 := NewDateTime(Ɀ_Date_(1000, 7, 15), Ɀ_Time_(11, 59))
+	dt3 := NewDateTime(Ɀ_Date_(1000, 7, 15), Ɀ_Time_(12, 00))
+	dt4 := NewDateTime(Ɀ_Date_(1000, 7, 15), Ɀ_Time_(12, 01))
+	dt5 := NewDateTime(Ɀ_Date_(1000, 7, 16), Ɀ_Time_(11, 01))
+
+	assert.True(t, dt2.IsAfterOrEqual(dt1))
+	assert.True(t, dt3.IsAfterOrEqual(dt2))
+	assert.True(t, dt4.IsAfterOrEqual(dt3))
+	assert.True(t, dt5.IsAfterOrEqual(dt4))
+
+	assert.True(t, dt5.IsAfterOrEqual(dt1))
+	assert.True(t, dt5.IsAfterOrEqual(dt1))
+
+	assert.False(t, dt1.IsAfterOrEqual(dt2))
+	assert.False(t, dt1.IsAfterOrEqual(dt3))
+	assert.False(t, dt1.IsAfterOrEqual(dt5))
+	assert.False(t, dt2.IsAfterOrEqual(dt3))
+}

--- a/src/service/evaluate.go
+++ b/src/service/evaluate.go
@@ -2,13 +2,18 @@ package service
 
 import (
 	. "github.com/jotaen/klog/src"
-	"time"
+	gotime "time"
 )
 
 // Total calculates the overall time spent in records.
 // It disregards open ranges.
 func Total(rs ...Record) Duration {
-	total, _ := HypotheticalTotal(time.Time{}, rs...)
+	total := NewDuration(0, 0)
+	for _, r := range rs {
+		for _, e := range r.Entries() {
+			total = total.Plus(e.Duration())
+		}
+	}
 	return total
 }
 
@@ -24,11 +29,10 @@ func TotalEntries(es ...Entry) Duration {
 
 // HypotheticalTotal calculates the overall total time of records,
 // assuming all open ranges would be closed at the `until` time.
-func HypotheticalTotal(until time.Time, rs ...Record) (Duration, bool) {
+func HypotheticalTotal(until gotime.Time, rs ...Record) (Duration, bool) {
 	total := NewDuration(0, 0)
 	isCurrent := false
-	void := time.Time{}
-	thisDay := NewDateFromTime(until)
+	thisDay := NewDateFromGo(until)
 	theDayBefore := thisDay.PlusDays(-1)
 	for _, r := range rs {
 		for _, e := range r.Entries() {
@@ -36,16 +40,17 @@ func HypotheticalTotal(until time.Time, rs ...Record) (Duration, bool) {
 				func(r Range) interface{} { return r.Duration() },
 				func(d Duration) interface{} { return d },
 				func(o OpenRange) interface{} {
-					if until != void && (r.Date().IsEqualTo(thisDay) || r.Date().IsEqualTo(theDayBefore)) {
-						end := NewTimeFromTime(until)
-						if r.Date().IsEqualTo(theDayBefore) {
-							end, _ = NewTimeTomorrow(end.Hour(), end.Minute())
-						}
-						tr, err := NewRange(o.Start(), end)
-						if err == nil {
-							isCurrent = true
-							return tr.Duration()
-						}
+					if !(r.Date().IsEqualTo(thisDay) || r.Date().IsEqualTo(theDayBefore)) {
+						return NewDuration(0, 0)
+					}
+					end := NewTimeFromGo(until)
+					if r.Date().IsEqualTo(theDayBefore) {
+						end, _ = NewTimeTomorrow(end.Hour(), end.Minute())
+					}
+					tr, err := NewRange(o.Start(), end)
+					if err == nil {
+						isCurrent = true
+						return tr.Duration()
 					}
 					return NewDuration(0, 0)
 				})).(Duration)

--- a/src/time.go
+++ b/src/time.go
@@ -28,10 +28,10 @@ type Time interface {
 	IsEqualTo(Time) bool
 	IsAfterOrEqual(Time) bool
 
-	// Add returns a time, where the specified duration was added. It doesn’t modify
+	// Plus returns a time, where the specified duration was added. It doesn’t modify
 	// the original object. If the resulting time would be shifted by more than one
 	// day, it returns an error.
-	Add(Duration) (Time, error)
+	Plus(Duration) (Time, error)
 
 	// ToString serialises the time, e.g. `8:00` or `23:00>`
 	ToString() string
@@ -117,7 +117,7 @@ func NewTimeFromString(hhmm string) (Time, error) {
 	return newTime(hour, minute, dayShift, is24HourClock)
 }
 
-func NewTimeFromTime(t gotime.Time) Time {
+func NewTimeFromGo(t gotime.Time) Time {
 	time, err := NewTime(t.Hour(), t.Minute())
 	if err != nil {
 		// This can/should never occur
@@ -165,7 +165,7 @@ func (t *time) IsAfterOrEqual(otherTime Time) bool {
 	return first.InMinutes() >= second.InMinutes()
 }
 
-func (t *time) Add(d Duration) (Time, error) {
+func (t *time) Plus(d Duration) (Time, error) {
 	ONE_DAY := 24 * 60
 	mins := t.MidnightOffset().Plus(d).InMinutes()
 	if mins >= 2*ONE_DAY || mins < ONE_DAY*-1 {

--- a/src/time_test.go
+++ b/src/time_test.go
@@ -221,7 +221,7 @@ func TestAddDuration(t *testing.T) {
 		{Ɀ_TimeTomorrow_(18, 38), NewDuration(-1, -1), Ɀ_TimeTomorrow_(17, 37)},
 		{Ɀ_TimeTomorrow_(23, 58), NewDuration(0, 1), Ɀ_TimeTomorrow_(23, 59)},
 	} {
-		result, err := x.initial.Add(x.increment)
+		result, err := x.initial.Plus(x.increment)
 		require.Nil(t, err)
 		assert.Equal(t, x.expect, result, x.initial)
 	}
@@ -237,7 +237,7 @@ func TestAddDurationImpossible(t *testing.T) {
 		{Ɀ_TimeYesterday_(0, 0), NewDuration(0, -1)},
 		{Ɀ_TimeTomorrow_(23, 59), NewDuration(0, 1)},
 	} {
-		result, err := x.initial.Add(x.increment)
+		result, err := x.initial.Plus(x.increment)
 		require.Nil(t, result)
 		assert.Error(t, err)
 	}


### PR DESCRIPTION
When evaluating files, klog shows warnings if it detects potential logical problems in the file. These warnings are now also shown when using the manipulation commands.

The warnings also have been slightly improved:
- It detects overlaps for open time ranges now, e.g.:
  ```
  2021-01-01
    8:00-10:00
    9:00-?
  ```
  It also issues a warning if there is a time range that starts *after* the open range start time, because that’s most likely a mistake:
  ```
  2021-01-01
    15:00-16:00
    9:00-?
  ```
- For detecting future entries, it doesn’t just look at the date, but also at the time. E.g., say right now it was `15:00` at the 1.1.2021, then the following would cause a warning:
  ```
  2021-01-01
    12:00 - 16:00
    19:00> - ?
  ```
  What is okay, though, is this: (“tomorrow’s” date, but the times are shifted back)
  ```
  2021-01-02
    <12:00-<14:00
  ```
  There is a grace period of 30m, so in this example it starts complaining for everything from “today”, 15:30 onwards.