### PR TITLE
Parse and process multiline entry summaries

### DIFF
--- a/src/parser/engine/indentation_test.go
+++ b/src/parser/engine/indentation_test.go
@@ -33,7 +33,7 @@ func TestCreatesIndentedParseable(t *testing.T) {
 	p1 := indentator.NewIndentedParseable(NewLineFromString("Hello", 0), 0)
 	require.NotNil(t, p1)
 	assert.Equal(t, p1.PointerPosition, 0)
-	assert.Equal(t, p1.Text, "Hello")
+	assert.Equal(t, "Hello", p1.Text)
 
 	p2 := indentator.NewIndentedParseable(NewLineFromString("\tHello", 0), 1)
 	require.NotNil(t, p2)

--- a/src/parser/integration_test.go
+++ b/src/parser/integration_test.go
@@ -12,6 +12,10 @@ lines and contains a #tag as well.
     5h30m This and that
     -2h Something else
     <18:00 - 4:00 Foo
+        Bar
+    19:00 - 20:00
+                            Baz
+                          Bar
     19:00 - 20:00
     20:01 - 0:15>
     1:00am - 3:12pm

--- a/src/parser/reconciling/reconciler.go
+++ b/src/parser/reconciling/reconciler.go
@@ -47,6 +47,10 @@ func (r *Reconciler) CloseOpenRange(endTime Time, additionalSummary string) (*Re
 	if openRangeEntryIndex == -1 {
 		return nil, errors.New("No open time range")
 	}
+	eErr := r.record.EndOpenRange(endTime)
+	if eErr != nil {
+		return nil, errors.New("Start and end time must be in chronological order")
+	}
 
 	// Replace question mark with end time.
 	openRangeValueLineIndex := r.lastLinePointer - countLines(r.record.Entries()[openRangeEntryIndex:])

--- a/src/parser/reconciling/reconciler.go
+++ b/src/parser/reconciling/reconciler.go
@@ -43,49 +43,36 @@ func (r *Reconciler) AppendEntry(newEntry string) (*Result, error) {
 
 // CloseOpenRange tries to close the open time range.
 func (r *Reconciler) CloseOpenRange(endTime Time, additionalSummary string) (*Result, error) {
-	openRangeEntryIndex := -1
-	for i, e := range r.record.Entries() {
-		e.Unbox(
-			func(Range) interface{} { return nil },
-			func(Duration) interface{} { return nil },
-			func(OpenRange) interface{} {
-				openRangeEntryIndex = i
-				return nil
-			},
-		)
-	}
+	openRangeEntryIndex := r.findOpenRangeIndex()
 	if openRangeEntryIndex == -1 {
 		return nil, errors.New("No open time range")
 	}
-	openRangeLineIndex := r.lastLinePointer - len(r.record.Entries()) + openRangeEntryIndex
+
+	// Replace question mark with end time.
+	openRangeValueLineIndex := r.lastLinePointer - countLines(r.record.Entries()[openRangeEntryIndex:])
+	r.lines[openRangeValueLineIndex].Text = regexp.MustCompile(`^(.*?)\?+(.*)$`).
+		ReplaceAllString(
+			r.lines[openRangeValueLineIndex].Text,
+			"${1}"+endTime.ToStringWithFormat(r.style.TimeFormat())+"${2}",
+		)
+
+	// Append additional summary text. Due to multiline entry summaries, that might
+	// not be the same line as the time value.
+	openRangeLastSummaryLineIndex := openRangeValueLineIndex + countLines([]Entry{r.record.Entries()[openRangeEntryIndex]}) - 1
 	if len(additionalSummary) > 0 {
 		// If there is additional summary text, always prepend a space to delimit
 		// the additional summary from either the time value or from an already
 		// existing summary text.
 		additionalSummary = " " + additionalSummary
 	}
-	r.lines[openRangeLineIndex].Text = regexp.MustCompile(`^(.*?)\?+(.*)$`).
-		ReplaceAllString(
-			r.lines[openRangeLineIndex].Text,
-			"${1}"+endTime.ToStringWithFormat(r.style.TimeFormat())+"${2}"+additionalSummary,
-		)
+	r.lines[openRangeLastSummaryLineIndex].Text += additionalSummary
+
 	return r.MakeResult()
 }
 
 // StartOpenRange appends a new open range entry in a record.
 func (r *Reconciler) StartOpenRange(startTime Time, entrySummary string) (*Result, error) {
-	openRangeEntryIndex := -1
-	for i, e := range r.record.Entries() {
-		e.Unbox(
-			func(Range) interface{} { return nil },
-			func(Duration) interface{} { return nil },
-			func(OpenRange) interface{} {
-				openRangeEntryIndex = i
-				return nil
-			},
-		)
-	}
-	if openRangeEntryIndex != -1 {
+	if r.findOpenRangeIndex() != -1 {
 		return nil, errors.New("There is already an open range in this record")
 	}
 	newEntryLine := startTime.ToStringWithFormat(r.style.TimeFormat()) + r.style.SpacingInRange() + "-" + r.style.SpacingInRange() + "?"
@@ -93,6 +80,14 @@ func (r *Reconciler) StartOpenRange(startTime Time, entrySummary string) (*Resul
 		newEntryLine += " " + entrySummary
 	}
 	return r.AppendEntry(newEntryLine)
+}
+
+func countLines(es []Entry) int {
+	result := 0
+	for _, e := range es {
+		result += len(e.Summary())
+	}
+	return result
 }
 
 // MakeResult returns the reconciled data.
@@ -113,6 +108,22 @@ func (r *Reconciler) MakeResult() (*Result, error) {
 		AllRecords:    newRecords,
 		AllSerialised: text,
 	}, nil
+}
+
+// findOpenRangeIndex returns the index of the open range entry, or -1 if no open range.
+func (r *Reconciler) findOpenRangeIndex() int {
+	openRangeEntryIndex := -1
+	for i, e := range r.record.Entries() {
+		e.Unbox(
+			func(Range) interface{} { return nil },
+			func(Duration) interface{} { return nil },
+			func(OpenRange) interface{} {
+				openRangeEntryIndex = i
+				return nil
+			},
+		)
+	}
+	return openRangeEntryIndex
 }
 
 var blankLine = insertableText{"", 0}

--- a/src/parser/reconciling/reconciler_test.go
+++ b/src/parser/reconciling/reconciler_test.go
@@ -17,7 +17,8 @@ func TestReconcilerAddsNewEntry(t *testing.T) {
 2018-01-02
 Hello World
     1h
-    1h45m
+    1h45m Multiline...
+        ....entry summary
 
 2018-01-03
     5h
@@ -37,7 +38,8 @@ Hello World
 2018-01-02
 Hello World
     1h
-    1h45m
+    1h45m Multiline...
+        ....entry summary
     2h30m
 
 2018-01-03
@@ -221,8 +223,10 @@ func TestReconcilerClosesOpenRangeWithStyle(t *testing.T) {
 func TestReconcilerClosesOpenRangeWithExtendingSummary(t *testing.T) {
 	original := `
 2018-01-01
-    1h
-    15:00-??? Will this close? I hope so!?!?
+    1h Multiline...
+        ...entry summary
+    15:00-??? Will this close?
+        I hope so.
     2m
 `
 	rs, _ := parser.Parse(original)
@@ -232,8 +236,10 @@ func TestReconcilerClosesOpenRangeWithExtendingSummary(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, `
 2018-01-01
-    1h
-    15:00-16:42 Will this close? I hope so!?!? Yes!
+    1h Multiline...
+        ...entry summary
+    15:00-16:42 Will this close?
+        I hope so. Yes!
     2m
 `, result.AllSerialised)
 }

--- a/src/summary.go
+++ b/src/summary.go
@@ -30,9 +30,6 @@ func NewRecordSummary(line ...string) (RecordSummary, error) {
 // NewEntrySummary creates an EntrySummary from individual lines of text.
 // Except for the first line, none of the lines can be empty or blank.
 func NewEntrySummary(line ...string) (EntrySummary, error) {
-	if len(line) == 1 && line[0] == "" {
-		return nil, nil
-	}
 	for i, l := range line {
 		if i == 0 {
 			continue

--- a/src/summary_test.go
+++ b/src/summary_test.go
@@ -16,11 +16,6 @@ func TestCreatesEmptySummary(t *testing.T) {
 	require.Nil(t, eErr)
 	assert.Nil(t, entrySummary.Lines())
 	assert.Empty(t, entrySummary.Tags())
-
-	entrySummaryBlank, ebErr := NewEntrySummary("")
-	require.Nil(t, ebErr)
-	assert.Nil(t, entrySummaryBlank.Lines())
-	assert.Empty(t, entrySummaryBlank.Tags())
 }
 
 func TestCreatesValidSingleLineSummary(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/jotaen/klog/issues/51 by allowing to continue an entry summary on the next line (on the next indentation level).

```
2020-01-01
    5h30m A multiline entry summary
        can contain multiple lines of
        text, which are indented twice.
    8:00 - 9:00
        Or, you can also directly start on
        the subsequent line.
    9:00 - 10:00 If you like, you can also
                 add more whitespace, for visual
                 alignment. (I.e. the indentation
                 is *at least* twice.)
````

~It’s still WIP, since I want to do some more testing. Also, the spec needs to be updated.~ Spec changes will follow in separate PR.