### PR TITLE
Specify how multiline entry summaries work

### DIFF
--- a/Specification.md
+++ b/Specification.md
@@ -82,13 +82,12 @@ An *entry summary* MAY appear behind an *entry*.
 It is considered to be referring to that particular *entry*.
 
 The *entry summary* MAY span multiple lines.
-All lines following the *entry* line MUST be indented twice.
-It MUST either start on the same line as the *entry*,
+All lines following the *entry* line MUST be indented twice;
+they also MUST NOT only consist of “blank characters”.
+
+The *entry summary* MUST either start on the same line as the *entry*,
 separated from it by one “space”;
 or, it MUST start on the subsequent line.
-
-Except for the line where the *entry* is,
-none of the other lines of the *entry summary* MUST only consist of “blank characters”.
 
 #### Tags
 The purpose of *tags* is to help categorise *records* and *entries*.

--- a/Specification.md
+++ b/Specification.md
@@ -29,8 +29,19 @@ On the same line there MAY follow a *should-total*,
 which MUST be separated by one “space” from the *date*
 (additional “spaces” MAY appear).
 
-A *summary* MAY appear on the subsequent lines.
-Any amount of *entries* MAY appear afterwards.
+A *record summary* MAY appear on the subsequent lines.
+Any amount of *entries* (along with *entry summaries*) MAY appear afterwards.
+
+In order to indent a line, it MUST start with one of the following sequences:
+- Four “spaces” (RECOMMENDED)
+- Two or three “spaces”
+- One “tab”
+
+To signify the second level of indentation,
+the indentation sequence MUST appear twice.
+
+The indentation style MUST be uniform within *records*.
+(It MAY differ between *records*, though.)
 
 ### Date
 A *date* is a day in the calendar.
@@ -55,21 +66,31 @@ A *should-total* MUST be a *duration* value
 followed by a `!`
 and wrapped in “parentheses”.
 
-### Summary
-A *summary* is user-provided text for holding arbitrary information.
+### Summaries
+A *summary* is user-provided text for capturing arbitrary information
+about a *record* or an *entry*.
 
-There are two places where *summary* text MAY appear in *records*:
-- Underneath the *date*:
-  In this case the *summary* is considered to be associated with the entire *record*.
-  The *summary* MAY span multiple lines.
-  Each of its lines MUST NOT start with “blank characters”.
-- Behind *entries*:
-  In this case the *summary* is only considered to be referring to the corresponding *entry*.
-  The *summary* text follows the *entry* on the same line,
-  and it ends at the end of that line.
-  It MUST be separated from the *entry* by one “space”.
+#### Record Summary
+The *record summary* MAY appear underneath the *date*.
+It is considered to be associated with the entire *record*.
 
-### Tags
+The *record summary* MAY span multiple lines.
+Each of its lines MUST NOT start with “blank characters”.
+
+#### Entry Summary
+An *entry summary* MAY appear behind an *entry*.
+It is considered to be referring to that particular *entry*.
+
+The *entry summary* MAY span multiple lines.
+All lines following the *entry* line MUST be indented twice.
+It MUST either start on the same line as the *entry*,
+separated from it by one “space”;
+or, it MUST start on the subsequent line.
+
+Except for the line where the *entry* is,
+none of the other lines of the *entry summary* MUST only consist of “blank characters”.
+
+#### Tags
 The purpose of *tags* is to help categorise *records* and *entries*.
 
 > Examples: `#gym`, `#24hours`, `#home_office`, `#読む`
@@ -85,13 +106,7 @@ preceded by a single `#` character.
 > Examples (indentation omitted): `2h30m`, `-1h Lunch break`, `11:00 - 14:15`, `8:00am - 2:00pm Long day at #school`
 
 Each *entry* MUST appear on its own line and
-MUST be indented in one of the following ways:
-- by four “spaces” (RECOMMENDED)
-- by two or three “spaces”
-- by one “tab”
-
-The indentation style MUST be uniform within *records*.
-(It MAY differ between *records*, though.)
+MUST be indented once.
 
 A *summary* MAY be associated with an *entry* (see section Summary).
 

--- a/Specification.md
+++ b/Specification.md
@@ -272,6 +272,9 @@ and MUST NOT be combined into a single *record*.
 
 ## V. Changelog
 
+## Version 1.3
+- Specify additional rules for multiline entry summaries.
+
 ## Version 1.2
 - Allow times to be `24:00`.
 - Some minor restructurings for enhanced clarity.


### PR DESCRIPTION
Here’s the spec part of https://github.com/jotaen/klog/issues/51.

@vladdeSV would you mind having a look over this? 💃 

Some notes:
- I pulled up the rules about indentation, because they apply to multiple parts of the spec now.
- The section about summaries is slightly rewritten, to account for the increased extent of the text. I actually don’t like having a fourth heading level, but I cannot think of a better way to structure it.

As noted [in the PR](https://github.com/jotaen/klog/pull/152), this is an example of what is allowed:

```
2020-01-01
    5h30m A multiline entry summary
        can contain multiple lines of
        text, which are indented twice.
    8:00 - 9:00
        Or, you can also directly start on
        the subsequent line.
    9:00 - 10:00 If you like, you can also
                 add more whitespace, for visual
                 alignment. (I.e. the indentation
                 is *at least* twice.) All additional
                 whitespace is treated as part of
                 the summary copy.
````

These would be examples of what’s **not** allowed:

```
2020-01-01
    5h30m A multiline entry summary cannot

        contain blank lines. That’s not new, actually,
        because a blank line terminates the record.
    1h It can’t be continued on the next line.
    without increasing (doubling) the indentation
    1h The following line is invalid,
       because it’s only preceded by 7 spaces, not 8.
       Likewise, it’s invalid to mix tabs and spaces, etc.
  1h And, just as before, the indentation style must be uniform.
````