### PR TITLE
Go 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,10 @@ jobs:
           if [[ "${dirty_files}" != "" ]]; then $(exit 1); fi
       - name: Run vet
         run: go vet ./...
-      - name: Run staticcheck
-        uses: dominikh/staticcheck-action@v1.1.0
-        with:
-          version: "2021.1.2"
+#      - name: Run staticcheck
+#        uses: dominikh/staticcheck-action@v1.1.0
+#        with:
+#          version: "2021.1.2"
   test:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run staticcheck
         uses: dominikh/staticcheck-action@v1.1.0
         with:
-          version: "2021.1.1"
+          version: "2021.1.2"
   test:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on: push
 env:
-  GO_VERSION: '1.17'
+  GO_VERSION: '1.18'
 jobs:
   statistics:
     name: Statistics

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - name: Truncate changelog # Truncate to the last 5 entries
         run: |
           mv CHANGELOG.md CHANGELOG_ORIG.md

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,10 @@
 module github.com/jotaen/klog
 
-go 1.17
+go 1.18
 
 require (
 	cloud.google.com/go v0.97.0
 	github.com/alecthomas/kong v0.2.22
-	github.com/caseymrm/askm v1.0.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,6 @@ github.com/alecthomas/kong v0.2.22/go.mod h1:uzxf/HUh0tj43x1AyJROl3JT7SgsZ5m+icO
 github.com/alecthomas/repr v0.0.0-20210801044451-80ca428c5142 h1:8Uy0oSf5co/NZXje7U1z8Mpep++QJOldL2hs/sBQf48=
 github.com/alecthomas/repr v0.0.0-20210801044451-80ca428c5142/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/caseymrm/askm v1.0.0 h1:Ff5QN5GwuyCzg63++hU1jV+1JVYHYd0sw6KUkVd2GiQ=
-github.com/caseymrm/askm v1.0.0/go.mod h1:raj+vtH8SsGkuSg1/970qaONNyNlIb7zFv2LDVk6j+U=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/src/parser/json/serialiser.go
+++ b/src/parser/json/serialiser.go
@@ -73,8 +73,8 @@ func toTagViews(ts TagSet) []string {
 	return result
 }
 
-func toEntryViews(es []Entry) []interface{} {
-	views := []interface{}{}
+func toEntryViews(es []Entry) []any {
+	views := []any{}
 	for _, e := range es {
 		base := EntryView{
 			Summary:   parser.SummaryText(e.Summary()).ToString(),
@@ -82,7 +82,7 @@ func toEntryViews(es []Entry) []interface{} {
 			Total:     e.Duration().ToString(),
 			TotalMins: e.Duration().InMinutes(),
 		}
-		view := e.Unbox(func(r Range) interface{} {
+		view := Unbox(&e, func(r Range) any {
 			base.Type = "range"
 			return RangeView{
 				OpenRangeView: OpenRangeView{
@@ -93,10 +93,10 @@ func toEntryViews(es []Entry) []interface{} {
 				End:     r.End().ToString(),
 				EndMins: r.End().MidnightOffset().InMinutes(),
 			}
-		}, func(d Duration) interface{} {
+		}, func(d Duration) any {
 			base.Type = "duration"
 			return base
-		}, func(o OpenRange) interface{} {
+		}, func(o OpenRange) any {
 			base.Type = "open_range"
 			return OpenRangeView{
 				EntryView: base,

--- a/src/parser/json/view.go
+++ b/src/parser/json/view.go
@@ -10,16 +10,16 @@ type Envelop struct {
 // RecordView is the JSON representation of a record.
 // It also contains some evaluation data, such as the total time.
 type RecordView struct {
-	Date            string        `json:"date"`
-	Summary         string        `json:"summary"`
-	Total           string        `json:"total"`
-	TotalMins       int           `json:"total_mins"`
-	ShouldTotal     string        `json:"should_total"`
-	ShouldTotalMins int           `json:"should_total_mins"`
-	Diff            string        `json:"diff"`
-	DiffMins        int           `json:"diff_mins"`
-	Tags            []string      `json:"tags"`
-	Entries         []interface{} `json:"entries"`
+	Date            string   `json:"date"`
+	Summary         string   `json:"summary"`
+	Total           string   `json:"total"`
+	TotalMins       int      `json:"total_mins"`
+	ShouldTotal     string   `json:"should_total"`
+	ShouldTotalMins int      `json:"should_total_mins"`
+	Diff            string   `json:"diff"`
+	DiffMins        int      `json:"diff_mins"`
+	Tags            []string `json:"tags"`
+	Entries         []any    `json:"entries"`
 }
 
 // EntryView is the JSON representation of an entry.

--- a/src/parser/parser.go
+++ b/src/parser/parser.go
@@ -34,7 +34,7 @@ func Parse(recordsAsText string) ([]ParsedRecord, []Error) {
 			continue
 		}
 		if block[0].LineEnding != "" {
-			style.SetLineEnding(block[0].LineEnding)
+			style.LineEnding.Set(block[0].LineEnding)
 		}
 		results = append(results, ParsedRecord{
 			Record: record,
@@ -74,7 +74,7 @@ func parseRecord(lines []Line) (Record, *Style, []Error) {
 		headline.Advance(dateText.Length())
 		headline.SkipWhile(IsSpaceOrTab)
 		r := NewRecord(rDate)
-		style.SetDateFormat(rDate.Format())
+		style.DateFormat.Set(rDate.Format())
 
 		// Check if there is a should-total set, and if so, parse it.
 		if headline.Peek() == '(' {
@@ -152,7 +152,7 @@ func parseRecord(lines []Line) (Record, *Style, []Error) {
 			// We should never make it here if the indentation could not be determined.
 			panic("Could not detect indentation")
 		}
-		style.SetIndentation(indentator.Style())
+		style.Indentation.Set(indentator.Style())
 		// Check for correct indentation.
 		entry := indentator.NewIndentedParseable(l, 1)
 		if entry == nil || IsSpaceOrTab(entry.Peek()) {
@@ -187,14 +187,14 @@ func parseRecord(lines []Line) (Record, *Style, []Error) {
 			}
 			entryStartPosition := startCandidate.PointerPosition
 			entry.Advance(startCandidate.Length())
-			style.SetTimeFormat(start.Format())
+			style.TimeFormat.Set(start.Format())
 
 			entryStartPositionEnds := entry.PointerPosition
 			entry.SkipWhile(Is(' '))
 			if entryStartPositionEnds != entry.PointerPosition {
-				style.SetSpacingInRange(strings.Repeat(" ", entry.PointerPosition-entryStartPositionEnds))
+				style.SpacingInRange.Set(strings.Repeat(" ", entry.PointerPosition-entryStartPositionEnds))
 			} else {
-				style.SetSpacingInRange("")
+				style.SpacingInRange.Set("")
 			}
 
 			if entry.Peek() != '-' {

--- a/src/parser/parser_test.go
+++ b/src/parser/parser_test.go
@@ -127,18 +127,15 @@ func TestParseAlternativeFormatting(t *testing.T) {
 }
 
 func TestAcceptTabOrSpacesAsIndentation(t *testing.T) {
-	for _, test := range []struct {
-		text   string
-		expect interface{}
-	}{
-		{"2000-01-01\n\t8h", nil},
-		{"2000-01-01\n\t8h\n\t15m", nil},
-		{"2000-05-31\n  6h", nil},
-		{"2000-05-31\n  6h\n  20m", nil},
-		{"2000-05-31\n   6h", nil},
-		{"2000-05-31\n    6h", nil},
+	for _, x := range []string{
+		"2000-01-01\n\t8h",
+		"2000-01-01\n\t8h\n\t15m",
+		"2000-05-31\n  6h",
+		"2000-05-31\n  6h\n  20m",
+		"2000-05-31\n   6h",
+		"2000-05-31\n    6h",
 	} {
-		rs, errs := Parse(test.text)
+		rs, errs := Parse(x)
 		require.Nil(t, errs)
 		require.Len(t, rs, 1)
 	}
@@ -147,7 +144,7 @@ func TestAcceptTabOrSpacesAsIndentation(t *testing.T) {
 func TestParseDocumentSucceedsWithCorrectEntryValues(t *testing.T) {
 	for _, test := range []struct {
 		text        string
-		expectEntry interface{}
+		expectEntry any
 	}{
 		// Durations
 		{"1234-12-12\n\t5h", NewDuration(5, 0)},
@@ -188,10 +185,10 @@ func TestParseDocumentSucceedsWithCorrectEntryValues(t *testing.T) {
 		require.Nil(t, errs, test.text)
 		require.Len(t, rs, 1, test.text)
 		require.Len(t, rs[0].Entries(), 1, test.text)
-		value := rs[0].Entries()[0].Unbox(
-			func(r Range) interface{} { return r },
-			func(d Duration) interface{} { return d },
-			func(o OpenRange) interface{} { return o },
+		value := Unbox(&rs[0].Entries()[0],
+			func(r Range) any { return r },
+			func(d Duration) any { return d },
+			func(o OpenRange) any { return o },
 		)
 		assert.Equal(t, test.expectEntry, value, test.text)
 	}
@@ -200,7 +197,7 @@ func TestParseDocumentSucceedsWithCorrectEntryValues(t *testing.T) {
 func TestParsesDocumentsWithEntrySummaries(t *testing.T) {
 	for _, test := range []struct {
 		text          string
-		expectEntry   interface{}
+		expectEntry   any
 		expectSummary EntrySummary
 	}{
 		// Single line entries
@@ -237,10 +234,10 @@ func TestParsesDocumentsWithEntrySummaries(t *testing.T) {
 		require.Nil(t, errs, test.text)
 		require.Len(t, rs, 1, test.text)
 		require.Len(t, rs[0].Entries(), 1, test.text)
-		value := rs[0].Entries()[0].Unbox(
-			func(r Range) interface{} { return r },
-			func(d Duration) interface{} { return d },
-			func(o OpenRange) interface{} { return o },
+		value := Unbox(&rs[0].Entries()[0],
+			func(r Range) any { return r },
+			func(d Duration) any { return d },
+			func(o OpenRange) any { return o },
 		)
 		assert.Equal(t, test.expectEntry, value, test.text)
 		assert.Equal(t, test.expectSummary, rs[0].Entries()[0].Summary(), test.text)

--- a/src/parser/reconciling/close_open_range.go
+++ b/src/parser/reconciling/close_open_range.go
@@ -22,7 +22,7 @@ func (r *Reconciler) CloseOpenRange(endTime Time, additionalSummary string) (*Re
 	r.lines[openRangeValueLineIndex].Text = regexp.MustCompile(`^(.*?)\?+(.*)$`).
 		ReplaceAllString(
 			r.lines[openRangeValueLineIndex].Text,
-			"${1}"+endTime.ToStringWithFormat(r.style.TimeFormat())+"${2}",
+			"${1}"+endTime.ToStringWithFormat(r.style.TimeFormat.Get())+"${2}",
 		)
 
 	// Append additional summary text. Due to multiline entry summaries, that might

--- a/src/parser/reconciling/creator.go
+++ b/src/parser/reconciling/creator.go
@@ -23,7 +23,7 @@ func NewReconcilerForNewRecord(parsedRecords []parser.ParsedRecord, newDate Date
 		lines:           flatten(parsedRecords),
 	}
 	headline := func() insertableText {
-		result := newDate.ToStringWithFormat(reconciler.style.DateFormat())
+		result := newDate.ToStringWithFormat(reconciler.style.DateFormat.Get())
 		if shouldTotal != nil {
 			result += " (" + shouldTotal.ToString() + ")"
 		}

--- a/src/parser/reconciling/pause_open_range.go
+++ b/src/parser/reconciling/pause_open_range.go
@@ -36,11 +36,11 @@ func (r *Reconciler) PauseOpenRange(pause Duration, summary string) (*Result, er
 			return nil
 		}
 		// Find next duration entry.
-		pauseCandidate := nextEntry.Unbox(
-			func(r Range) interface{} { return nil },
-			func(d Duration) interface{} { return d },
-			func(or OpenRange) interface{} { return nil },
-		).(Duration)
+		pauseCandidate := Unbox[Duration](&nextEntry,
+			func(r Range) Duration { return nil },
+			func(d Duration) Duration { return d },
+			func(or OpenRange) Duration { return nil },
+		)
 		// Only return it if it’s negative.
 		if pauseCandidate.InMinutes() < 0 {
 			return pauseCandidate

--- a/src/parser/reconciling/reconciler.go
+++ b/src/parser/reconciling/reconciler.go
@@ -66,10 +66,10 @@ func (r *Reconciler) MakeResult() (*Result, error) {
 func (r *Reconciler) findOpenRangeIndex() int {
 	openRangeEntryIndex := -1
 	for i, e := range r.record.Entries() {
-		e.Unbox(
-			func(Range) interface{} { return nil },
-			func(Duration) interface{} { return nil },
-			func(OpenRange) interface{} {
+		Unbox(&e,
+			func(Range) any { return nil },
+			func(Duration) any { return nil },
+			func(OpenRange) any {
 				openRangeEntryIndex = i
 				return nil
 			},
@@ -92,9 +92,9 @@ func (r *Reconciler) insert(lineIndex int, texts []insertableText) {
 		if i >= lineIndex && offset < len(texts) {
 			line := ""
 			if texts[offset].indentation > 0 {
-				line += r.style.Indentation()
+				line += r.style.Indentation.Get()
 			}
-			line += texts[offset].text + r.style.LineEnding()
+			line += texts[offset].text + r.style.LineEnding.Get()
 			result[i] = engine.NewLineFromString(line, -1)
 			offset++
 		} else {
@@ -103,7 +103,7 @@ func (r *Reconciler) insert(lineIndex int, texts []insertableText) {
 		result[i].LineNumber = i + 1
 	}
 	if lineIndex > 0 && result[lineIndex-1].LineEnding == "" {
-		result[lineIndex-1].LineEnding = r.style.LineEnding()
+		result[lineIndex-1].LineEnding = r.style.LineEnding.Get()
 	}
 	r.lines = result
 }

--- a/src/parser/reconciling/start_open_range.go
+++ b/src/parser/reconciling/start_open_range.go
@@ -10,7 +10,7 @@ func (r *Reconciler) StartOpenRange(startTime Time, entrySummary string) (*Resul
 	if r.findOpenRangeIndex() != -1 {
 		return nil, errors.New("There is already an open range in this record")
 	}
-	newEntryLine := startTime.ToStringWithFormat(r.style.TimeFormat()) + r.style.SpacingInRange() + "-" + r.style.SpacingInRange() + "?"
+	newEntryLine := startTime.ToStringWithFormat(r.style.TimeFormat.Get()) + r.style.SpacingInRange.Get() + "-" + r.style.SpacingInRange.Get() + "?"
 	if len(entrySummary) > 0 {
 		newEntryLine += " " + entrySummary
 	}

--- a/src/parser/serialiser.go
+++ b/src/parser/serialiser.go
@@ -23,26 +23,26 @@ func (h *Serialiser) serialiseRecord(r Record) string {
 	if r.ShouldTotal().InMinutes() != 0 {
 		text += " (" + h.ShouldTotal(r.ShouldTotal()) + ")"
 	}
-	text += canonicalStyle.lineEnding
+	text += canonicalStyle.LineEnding.Get()
 	if r.Summary() != nil {
-		text += h.Summary(SummaryText(r.Summary())) + canonicalStyle.lineEnding
+		text += h.Summary(SummaryText(r.Summary())) + canonicalStyle.LineEnding.Get()
 	}
 	for _, e := range r.Entries() {
-		text += canonicalStyle.indentation
-		text += (e.Unbox(
-			func(r Range) interface{} { return h.Range(r) },
-			func(d Duration) interface{} { return h.Duration(d) },
-			func(o OpenRange) interface{} { return h.OpenRange(o) },
-		)).(string)
+		text += canonicalStyle.Indentation.Get()
+		text += Unbox[string](&e,
+			func(r Range) string { return h.Range(r) },
+			func(d Duration) string { return h.Duration(d) },
+			func(o OpenRange) string { return h.OpenRange(o) },
+		)
 		for i, l := range e.Summary().Lines() {
 			if i == 0 && l != "" {
 				text += " " // separator
 			} else if i >= 1 {
-				text += canonicalStyle.lineEnding + canonicalStyle.indentation + canonicalStyle.indentation
+				text += canonicalStyle.LineEnding.Get() + canonicalStyle.Indentation.Get() + canonicalStyle.Indentation.Get()
 			}
 			text += l
 		}
-		text += canonicalStyle.lineEnding
+		text += canonicalStyle.LineEnding.Get()
 	}
 	return text
 }
@@ -50,7 +50,7 @@ func (h *Serialiser) serialiseRecord(r Record) string {
 type SummaryText []string
 
 func (s SummaryText) ToString() string {
-	return strings.Join(s, canonicalStyle.lineEnding)
+	return strings.Join(s, canonicalStyle.LineEnding.Get())
 }
 
 // Serialiser is used when the output should be modified, e.g. coloured.

--- a/src/parser/style_test.go
+++ b/src/parser/style_test.go
@@ -9,55 +9,44 @@ import (
 
 func TestDefaultStyle(t *testing.T) {
 	assert.Equal(t, &Style{
-		lineEnding:     "\n",
-		indentation:    "    ",
-		dateFormat:     DateFormat{UseDashes: true},
-		timeFormat:     TimeFormat{Use24HourClock: true},
-		spacingInRange: " ",
+		LineEnding:     styleProp[string]{"\n", false},
+		Indentation:    styleProp[string]{"    ", false},
+		DateFormat:     styleProp[DateFormat]{DateFormat{UseDashes: true}, false},
+		TimeFormat:     styleProp[TimeFormat]{TimeFormat{Use24HourClock: true}, false},
+		SpacingInRange: styleProp[string]{" ", false},
 	}, DefaultStyle())
 }
 
 func TestDetectsStyleFromMinimalFile(t *testing.T) {
 	rs := parseOrPanic("2000-01-01")
 	assert.Equal(t, &Style{
-		lineEnding:     "\n",
-		indentation:    "    ",
-		dateFormat:     DateFormat{UseDashes: true},
-		dateFormatSet:  true,
-		timeFormat:     TimeFormat{Use24HourClock: true},
-		spacingInRange: " ",
+		LineEnding:     styleProp[string]{"\n", false},
+		Indentation:    styleProp[string]{"    ", false},
+		DateFormat:     styleProp[DateFormat]{DateFormat{UseDashes: true}, true},
+		TimeFormat:     styleProp[TimeFormat]{TimeFormat{Use24HourClock: true}, false},
+		SpacingInRange: styleProp[string]{" ", false},
 	}, rs[0].Style)
 }
 
 func TestDetectCanonicalStyle(t *testing.T) {
 	rs := parseOrPanic("2000-01-01\nTest\n    8:00 - 9:00\n")
 	assert.Equal(t, &Style{
-		lineEnding:        "\n",
-		lineEndingSet:     true,
-		indentation:       "    ",
-		indentationSet:    true,
-		spacingInRange:    " ",
-		spacingInRangeSet: true,
-		dateFormat:        DateFormat{UseDashes: true},
-		dateFormatSet:     true,
-		timeFormat:        TimeFormat{Use24HourClock: true},
-		timeFormatSet:     true,
+		LineEnding:     styleProp[string]{"\n", true},
+		Indentation:    styleProp[string]{"    ", true},
+		DateFormat:     styleProp[DateFormat]{DateFormat{UseDashes: true}, true},
+		TimeFormat:     styleProp[TimeFormat]{TimeFormat{Use24HourClock: true}, true},
+		SpacingInRange: styleProp[string]{" ", true},
 	}, rs[0].Style)
 }
 
 func TestDetectsCustomStyle(t *testing.T) {
 	rs := parseOrPanic("2000/01/01\r\nTest\r\n\t8:00am-9:00am\r\n")
 	assert.Equal(t, &Style{
-		lineEnding:        "\r\n",
-		lineEndingSet:     true,
-		indentation:       "\t",
-		indentationSet:    true,
-		spacingInRange:    "",
-		spacingInRangeSet: true,
-		dateFormat:        DateFormat{UseDashes: false},
-		dateFormatSet:     true,
-		timeFormat:        TimeFormat{Use24HourClock: false},
-		timeFormatSet:     true,
+		LineEnding:     styleProp[string]{"\r\n", true},
+		Indentation:    styleProp[string]{"\t", true},
+		DateFormat:     styleProp[DateFormat]{DateFormat{UseDashes: false}, true},
+		TimeFormat:     styleProp[TimeFormat]{TimeFormat{Use24HourClock: false}, true},
+		SpacingInRange: styleProp[string]{"", true},
 	}, rs[0].Style)
 }
 
@@ -71,16 +60,11 @@ func TestElectStyle(t *testing.T) {
 	)
 	result := Elect(*DefaultStyle(), rs)
 	assert.Equal(t, &Style{
-		lineEnding:        "\r\n",
-		lineEndingSet:     true,
-		indentation:       "  ",
-		indentationSet:    true,
-		spacingInRange:    "",
-		spacingInRangeSet: true,
-		dateFormat:        DateFormat{UseDashes: true},
-		dateFormatSet:     true,
-		timeFormat:        TimeFormat{Use24HourClock: false},
-		timeFormatSet:     true,
+		LineEnding:     styleProp[string]{"\r\n", true},
+		Indentation:    styleProp[string]{"  ", true},
+		DateFormat:     styleProp[DateFormat]{DateFormat{UseDashes: true}, true},
+		TimeFormat:     styleProp[TimeFormat]{TimeFormat{Use24HourClock: false}, true},
+		SpacingInRange: styleProp[string]{"", true},
 	}, result)
 }
 
@@ -94,16 +78,11 @@ func TestElectStyleDoesNotOverrideSetPreferences(t *testing.T) {
 	)
 	result := Elect(*parseOrPanic("2018/01/01\n\t8:00 - 9:00")[0].Style, rs)
 	assert.Equal(t, &Style{
-		lineEnding:        "\n",
-		lineEndingSet:     true,
-		indentation:       "\t",
-		indentationSet:    true,
-		spacingInRange:    " ",
-		spacingInRangeSet: true,
-		dateFormat:        DateFormat{UseDashes: false},
-		dateFormatSet:     true,
-		timeFormat:        TimeFormat{Use24HourClock: true},
-		timeFormatSet:     true,
+		LineEnding:     styleProp[string]{"\n", true},
+		Indentation:    styleProp[string]{"\t", true},
+		DateFormat:     styleProp[DateFormat]{DateFormat{UseDashes: false}, true},
+		TimeFormat:     styleProp[TimeFormat]{TimeFormat{Use24HourClock: true}, true},
+		SpacingInRange: styleProp[string]{" ", true},
 	}, result)
 }
 

--- a/src/record.go
+++ b/src/record.go
@@ -90,11 +90,11 @@ func (r *record) SetEntries(es []Entry) {
 }
 
 func (r *record) AddDuration(d Duration, s EntrySummary) {
-	r.entries = append(r.entries, NewEntry(d, s))
+	r.entries = append(r.entries, NewEntryFromDuration(d, s))
 }
 
 func (r *record) AddRange(tr Range, s EntrySummary) {
-	r.entries = append(r.entries, NewEntry(tr, s))
+	r.entries = append(r.entries, NewEntryFromRange(tr, s))
 }
 
 func (r *record) OpenRange() OpenRange {
@@ -111,7 +111,7 @@ func (r *record) StartOpenRange(t Time, s EntrySummary) error {
 	if r.OpenRange() != nil {
 		return errors.New("DUPLICATE_OPEN_RANGE")
 	}
-	r.entries = append(r.entries, NewEntry(NewOpenRange(t), s))
+	r.entries = append(r.entries, NewEntryFromOpenRange(NewOpenRange(t), s))
 	return nil
 }
 
@@ -123,7 +123,7 @@ func (r *record) EndOpenRange(end Time) error {
 			if err != nil {
 				return err
 			}
-			r.entries[i] = NewEntry(tr, e.summary)
+			r.entries[i] = NewEntryFromRange(tr, e.summary)
 			return nil
 		}
 	}

--- a/src/service/evaluate.go
+++ b/src/service/evaluate.go
@@ -36,10 +36,10 @@ func HypotheticalTotal(until gotime.Time, rs ...Record) (Duration, bool) {
 	theDayBefore := thisDay.PlusDays(-1)
 	for _, r := range rs {
 		for _, e := range r.Entries() {
-			t := (e.Unbox(
-				func(r Range) interface{} { return r.Duration() },
-				func(d Duration) interface{} { return d },
-				func(o OpenRange) interface{} {
+			t := Unbox[Duration](&e,
+				func(r Range) Duration { return r.Duration() },
+				func(d Duration) Duration { return d },
+				func(o OpenRange) Duration {
 					if !(r.Date().IsEqualTo(thisDay) || r.Date().IsEqualTo(theDayBefore)) {
 						return NewDuration(0, 0)
 					}
@@ -53,7 +53,7 @@ func HypotheticalTotal(until gotime.Time, rs ...Record) (Duration, bool) {
 						return tr.Duration()
 					}
 					return NewDuration(0, 0)
-				})).(Duration)
+				})
 			total = total.Plus(t)
 		}
 	}


### PR DESCRIPTION
Upgrade to Go 1.18, and make some use of generics here and there.

The CI still fails, because the latest version of staticcheck isn’t compatible with Go 1.18 yet. [That should be resolved next week, though](https://github.com/dominikh/go-tools/issues/1200#issuecomment-1069113830).