### PR TITLE
Re-enable staticcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,10 @@ jobs:
           if [[ "${dirty_files}" != "" ]]; then $(exit 1); fi
       - name: Run vet
         run: go vet ./...
-#      - name: Run staticcheck
-#        uses: dominikh/staticcheck-action@v1.1.0
-#        with:
-#          version: "2021.1.2"
+      - name: Run staticcheck
+        uses: dominikh/staticcheck-action@v1.1.0
+        with:
+          version: "2021.1.2"
   test:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,10 @@ jobs:
       - name: Run vet
         run: go vet ./...
       - name: Run staticcheck
-        uses: dominikh/staticcheck-action@v1.1.0
+        uses: dominikh/staticcheck-action@v1.2.0
         with:
-          version: "2021.1.2"
+          version: "2022.1"
+          install-go: false
   test:
     name: Unit Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Bring back staticcheck, once it’s compatible with Go 1.18. (Should be included in the [next release](https://github.com/dominikh/go-tools/releases).)

(Originally disabled via https://github.com/jotaen/klog/pull/164.)