### PR TITLE
Improve multiline summary support on the CLI

### DIFF
--- a/src/parser/reconciling/append_entry.go
+++ b/src/parser/reconciling/append_entry.go
@@ -2,6 +2,6 @@ package reconciling
 
 // AppendEntry adds a new entry to the end of the record.
 func (r *Reconciler) AppendEntry(newEntry string) (*Result, error) {
-	r.insert(r.lastLinePointer, []insertableText{{newEntry, 1}})
+	r.insert(r.lastLinePointer, toMultilineEntryTexts("", newEntry))
 	return r.MakeResult()
 }

--- a/src/parser/reconciling/append_entry_test.go
+++ b/src/parser/reconciling/append_entry_test.go
@@ -62,6 +62,38 @@ func TestReconcilerAddsNewlyCreatedEntryAtEndOfFile(t *testing.T) {
 `, result.AllSerialised)
 }
 
+func TestReconcilerSplitsUpSummaryText(t *testing.T) {
+	original := "\n2018-01-01\n    1h"
+	rs, _ := parser.Parse(original)
+
+	reconciler := NewReconcilerAtRecord(rs, Ɀ_Date_(2018, 1, 1))
+	require.NotNil(t, reconciler)
+	result, err := reconciler.AppendEntry("2h This is a\nmultiline summary")
+	require.Nil(t, err)
+	assert.Equal(t, `
+2018-01-01
+    1h
+    2h This is a
+        multiline summary
+`, result.AllSerialised)
+}
+
+func TestReconcilerStartsSummaryTextOnNextLine(t *testing.T) {
+	original := "\n2018-01-01\n    1h"
+	rs, _ := parser.Parse(original)
+
+	reconciler := NewReconcilerAtRecord(rs, Ɀ_Date_(2018, 1, 1))
+	require.NotNil(t, reconciler)
+	result, err := reconciler.AppendEntry("2h\nSome activity")
+	require.Nil(t, err)
+	assert.Equal(t, `
+2018-01-01
+    1h
+    2h
+        Some activity
+`, result.AllSerialised)
+}
+
 func TestReconcilerRejectsInvalidEntry(t *testing.T) {
 	original := "2018-01-01\n"
 	rs, _ := parser.Parse(original)

--- a/src/parser/reconciling/close_open_range.go
+++ b/src/parser/reconciling/close_open_range.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	. "github.com/jotaen/klog/src"
 	"regexp"
+	"strings"
 )
 
 // CloseOpenRange tries to close the open time range.
@@ -25,16 +26,28 @@ func (r *Reconciler) CloseOpenRange(endTime Time, additionalSummary string) (*Re
 			"${1}"+endTime.ToStringWithFormat(r.style.TimeFormat())+"${2}",
 		)
 
+	additionalSummary = strings.ReplaceAll(additionalSummary, "\\n", "\n")
+	summaryLines := strings.Split(additionalSummary, "\n")
+
 	// Append additional summary text. Due to multiline entry summaries, that might
 	// not be the same line as the time value.
 	openRangeLastSummaryLineIndex := openRangeValueLineIndex + countLines([]Entry{r.record.Entries()[openRangeEntryIndex]}) - 1
-	if len(additionalSummary) > 0 {
+	firstSummaryLine := summaryLines[0] // Index `0` will always exist
+	if len(firstSummaryLine) > 0 {
 		// If there is additional summary text, always prepend a space to delimit
 		// the additional summary from either the time value or from an already
 		// existing summary text.
-		additionalSummary = " " + additionalSummary
+		r.lines[openRangeLastSummaryLineIndex].Text += " "
 	}
-	r.lines[openRangeLastSummaryLineIndex].Text += additionalSummary
+	r.lines[openRangeLastSummaryLineIndex].Text += firstSummaryLine
+
+	if len(summaryLines) > 1 {
+		var subsequentSummaryLines []insertableText
+		for _, nextLine := range summaryLines[1:] {
+			subsequentSummaryLines = append(subsequentSummaryLines, insertableText{nextLine, 2})
+		}
+		r.insert(openRangeLastSummaryLineIndex+1, subsequentSummaryLines)
+	}
 
 	return r.MakeResult()
 }

--- a/src/parser/reconciling/close_open_range_test.go
+++ b/src/parser/reconciling/close_open_range_test.go
@@ -24,30 +24,6 @@ func TestReconcilerClosesOpenRangeWithStyle(t *testing.T) {
 `, result.AllSerialised)
 }
 
-func TestReconcilerClosesOpenRangeWithExtendingSummary(t *testing.T) {
-	original := `
-2018-01-01
-    1h Multiline...
-        ...entry summary
-    15:00-??? Will this close?
-        I hope so.
-    2m
-`
-	rs, _ := parser.Parse(original)
-	reconciler := NewReconcilerAtRecord(rs, Ɀ_Date_(2018, 1, 1))
-	require.NotNil(t, reconciler)
-	result, err := reconciler.CloseOpenRange(Ɀ_Time_(16, 42), "Yes!")
-	require.Nil(t, err)
-	assert.Equal(t, `
-2018-01-01
-    1h Multiline...
-        ...entry summary
-    15:00-16:42 Will this close?
-        I hope so. Yes!
-    2m
-`, result.AllSerialised)
-}
-
 func TestReconcilerClosesOpenRangeWithNewSummary(t *testing.T) {
 	original := `
 2018-01-01
@@ -78,5 +54,48 @@ func TestReconcilerClosesOpenRangeWithNewMultilineSummary(t *testing.T) {
 2018-01-01
     15:00 - 15:22
         Finished.
+`, result.AllSerialised)
+}
+
+func TestReconcilerClosesOpenRangeWithExtendingSummary(t *testing.T) {
+	original := `
+2018-01-01
+    1h Multiline...
+        ...entry summary
+    15:00-??? Will this close?
+        I hope so.
+    2m
+`
+	rs, _ := parser.Parse(original)
+	reconciler := NewReconcilerAtRecord(rs, Ɀ_Date_(2018, 1, 1))
+	require.NotNil(t, reconciler)
+	result, err := reconciler.CloseOpenRange(Ɀ_Time_(16, 42), "Yes!")
+	require.Nil(t, err)
+	assert.Equal(t, `
+2018-01-01
+    1h Multiline...
+        ...entry summary
+    15:00-16:42 Will this close?
+        I hope so. Yes!
+    2m
+`, result.AllSerialised)
+}
+
+func TestReconcilerClosesOpenRangeWithExtendingSummaryOnNextLine(t *testing.T) {
+	original := `
+2018-01-01
+    16:00-? Started...
+    -45m break
+`
+	rs, _ := parser.Parse(original)
+	reconciler := NewReconcilerAtRecord(rs, Ɀ_Date_(2018, 1, 1))
+	require.NotNil(t, reconciler)
+	result, err := reconciler.CloseOpenRange(Ɀ_Time_(18, 01), "\nStopped.")
+	require.Nil(t, err)
+	assert.Equal(t, `
+2018-01-01
+    16:00-18:01 Started...
+        Stopped.
+    -45m break
 `, result.AllSerialised)
 }

--- a/src/parser/reconciling/close_open_range_test.go
+++ b/src/parser/reconciling/close_open_range_test.go
@@ -63,3 +63,20 @@ func TestReconcilerClosesOpenRangeWithNewSummary(t *testing.T) {
     15:00 - 15:22 Finished.
 `, result.AllSerialised)
 }
+
+func TestReconcilerClosesOpenRangeWithNewMultilineSummary(t *testing.T) {
+	original := `
+2018-01-01
+    15:00 - ?
+`
+	rs, _ := parser.Parse(original)
+	reconciler := NewReconcilerAtRecord(rs, Ɀ_Date_(2018, 1, 1))
+	require.NotNil(t, reconciler)
+	result, err := reconciler.CloseOpenRange(Ɀ_Time_(15, 22), "\nFinished.")
+	require.Nil(t, err)
+	assert.Equal(t, `
+2018-01-01
+    15:00 - 15:22
+        Finished.
+`, result.AllSerialised)
+}

--- a/src/parser/reconciling/pause_open_range.go
+++ b/src/parser/reconciling/pause_open_range.go
@@ -51,11 +51,7 @@ func (r *Reconciler) PauseOpenRange(pause Duration, summary string) (*Result, er
 	// If there is no existing pause that matches, create a new entry underneath
 	// the open range entry.
 	if existingPause == nil {
-		entryLine := pause.ToString()
-		if summary != "" {
-			entryLine += " " + summary
-		}
-		r.insert(openRangeEntryLastLineIndex+1, []insertableText{{entryLine, 1}})
+		r.insert(openRangeEntryLastLineIndex+1, toMultilineEntryTexts(pause.ToString(), summary))
 		return r.MakeResult()
 	}
 

--- a/src/parser/reconciling/reconciler.go
+++ b/src/parser/reconciling/reconciler.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/jotaen/klog/src"
 	"github.com/jotaen/klog/src/parser"
 	"github.com/jotaen/klog/src/parser/engine"
+	"strings"
 )
 
 // Reconciler is a mechanism to manipulate record data in a file.
@@ -90,10 +91,7 @@ func (r *Reconciler) insert(lineIndex int, texts []insertableText) {
 	offset := 0
 	for i := range result {
 		if i >= lineIndex && offset < len(texts) {
-			line := ""
-			if texts[offset].indentation > 0 {
-				line += r.style.Indentation()
-			}
+			line := strings.Repeat(r.style.Indentation(), texts[offset].indentation)
 			line += texts[offset].text + r.style.LineEnding()
 			result[i] = engine.NewLineFromString(line, -1)
 			offset++
@@ -106,4 +104,26 @@ func (r *Reconciler) insert(lineIndex int, texts []insertableText) {
 		result[lineIndex-1].LineEnding = r.style.LineEnding()
 	}
 	r.lines = result
+}
+
+func toMultilineEntryTexts(entryValue string, entrySummary string) []insertableText {
+	var result []insertableText
+	// Normalize potentially redundant escaping.
+	entrySummary = strings.ReplaceAll(entrySummary, "\\n", "\n")
+	for i, summaryLine := range strings.Split(entrySummary, "\n") {
+		indent := 1
+		if i > 0 {
+			indent = 2
+		}
+		text := ""
+		if i == 0 {
+			text += entryValue
+			if text != "" && summaryLine != "" {
+				text += " "
+			}
+		}
+		text += summaryLine
+		result = append(result, insertableText{text, indent})
+	}
+	return result
 }

--- a/src/parser/reconciling/start_open_range.go
+++ b/src/parser/reconciling/start_open_range.go
@@ -10,9 +10,7 @@ func (r *Reconciler) StartOpenRange(startTime Time, entrySummary string) (*Resul
 	if r.findOpenRangeIndex() != -1 {
 		return nil, errors.New("There is already an open range in this record")
 	}
-	newEntryLine := startTime.ToStringWithFormat(r.style.TimeFormat()) + r.style.SpacingInRange() + "-" + r.style.SpacingInRange() + "?"
-	if len(entrySummary) > 0 {
-		newEntryLine += " " + entrySummary
-	}
-	return r.AppendEntry(newEntryLine)
+	entryValue := startTime.ToStringWithFormat(r.style.TimeFormat()) + r.style.SpacingInRange() + "-" + r.style.SpacingInRange() + "?"
+	r.insert(r.lastLinePointer, toMultilineEntryTexts(entryValue, entrySummary))
+	return r.MakeResult()
 }

--- a/src/parser/reconciling/start_open_range_test.go
+++ b/src/parser/reconciling/start_open_range_test.go
@@ -44,7 +44,7 @@ func TestReconcilerStartsOpenRangeWithSummary(t *testing.T) {
 `, result.AllSerialised)
 }
 
-func TestReconcilerStartsOpenRangeWithNewSummary(t *testing.T) {
+func TestReconcilerStartsOpenRangeWithNewMultilineSummary(t *testing.T) {
 	original := `
 2018-01-01
 	5h22m
@@ -52,13 +52,14 @@ func TestReconcilerStartsOpenRangeWithNewSummary(t *testing.T) {
 	rs, _ := parser.Parse(original)
 	reconciler := NewReconcilerAtRecord(rs, Ɀ_Date_(2018, 1, 1))
 	require.NotNil(t, reconciler)
-	result, err := reconciler.StartOpenRange(Ɀ_Time_(8, 3), "\nStarted!")
+	result, err := reconciler.StartOpenRange(Ɀ_Time_(8, 3), "\nStarted...\nsomething!")
 	require.Nil(t, err)
 	assert.Equal(t, `
 2018-01-01
 	5h22m
 	8:03 - ?
-		Started!
+		Started...
+		something!
 `, result.AllSerialised)
 }
 

--- a/src/parser/reconciling/start_open_range_test.go
+++ b/src/parser/reconciling/start_open_range_test.go
@@ -25,6 +25,25 @@ func TestReconcilerStartsOpenRange(t *testing.T) {
 `, result.AllSerialised)
 }
 
+func TestReconcilerStartsOpenRangeWithSummary(t *testing.T) {
+	original := `
+2018-01-01
+	5h22m
+		Existing entry
+`
+	rs, _ := parser.Parse(original)
+	reconciler := NewReconcilerAtRecord(rs, Ɀ_Date_(2018, 1, 1))
+	require.NotNil(t, reconciler)
+	result, err := reconciler.StartOpenRange(Ɀ_Time_(8, 3), "Test")
+	require.Nil(t, err)
+	assert.Equal(t, `
+2018-01-01
+	5h22m
+		Existing entry
+	8:03 - ? Test
+`, result.AllSerialised)
+}
+
 func TestReconcilerStartsOpenRangeWithNewSummary(t *testing.T) {
 	original := `
 2018-01-01
@@ -33,12 +52,13 @@ func TestReconcilerStartsOpenRangeWithNewSummary(t *testing.T) {
 	rs, _ := parser.Parse(original)
 	reconciler := NewReconcilerAtRecord(rs, Ɀ_Date_(2018, 1, 1))
 	require.NotNil(t, reconciler)
-	result, err := reconciler.StartOpenRange(Ɀ_Time_(8, 3), "Started!")
+	result, err := reconciler.StartOpenRange(Ɀ_Time_(8, 3), "\nStarted!")
 	require.Nil(t, err)
 	assert.Equal(t, `
 2018-01-01
 	5h22m
-	8:03 - ? Started!
+	8:03 - ?
+		Started!
 `, result.AllSerialised)
 }
 


### PR DESCRIPTION
You can now include line breaks (`\n`) when providing an entry summary from the CLI, and it will automatically convert that to a multiline entry summary with correct indentation.

E.g. `klog start --summary 'This note has\nmultiple lines.'`:

```
2000-01-01
    14:00-? This note has
        multiple lines.
```

Or `klog track`, e.g. `klog track '8:30 - 10:00\nIntense workout in the gym'`:

```
2000-01-01
    8:30 - 10:00
        Intense workout in the gym
```