### PR TITLE
Add footnotes for preserving contextual background info

### DIFF
--- a/Specification.md
+++ b/Specification.md
@@ -1,6 +1,6 @@
 # klog – File Format Specification
 
-**Version 1.3**
+**Version x.x**
 
 klog is a file format for tracking time.
 
@@ -42,7 +42,7 @@ To signify the second level of indentation,
 the indentation sequence MUST appear twice.
 
 The indentation style MUST be uniform within *records*.
-(It MAY differ between *records*, though.)
+(It MAY differ between *records*, though.)[^1]
 
 ### Date
 A *date* is a day in the calendar.
@@ -76,7 +76,7 @@ The *record summary* is considered to be associated with the entire *record*.
 
 It MUST appear underneath the *date*,
 and it MAY span multiple lines.
-Each of its lines MUST NOT start with “blank characters”.
+Each of its lines MUST NOT start with “blank characters”.[^2]
 
 #### Entry Summary
 The *entry summary* is considered to be referring to one particular *entry*.
@@ -87,7 +87,7 @@ or it MUST start on the subsequent line.
 
 The *entry summary* MAY span multiple lines.
 All lines following the *entry* line MUST be indented twice;
-they also MUST NOT only consist of “blank characters”.
+they also MUST NOT only consist of “blank characters”.[^3]
 
 #### Tag
 The purpose of *tags* is to help categorise *records* and *entries*.
@@ -95,7 +95,7 @@ The purpose of *tags* is to help categorise *records* and *entries*.
 > Examples: `#gym`, `#24hours`, `#home_office`, `#読む`
 
 Any amount of *tags* MAY appear anywhere within *summaries*.
-A *tag* MUST be a sequence of “letters”, “digits” or the `_` character,
+A *tag* MUST be a sequence of “letters”, “digits” or the `_` character[^4],
 preceded by a single `#` character.
 
 ### Entry
@@ -169,10 +169,10 @@ i.e. the end *time* is not determined yet.
 except that the end *time* MUST be replaced by a placeholder.
 The placeholder MUST be denoted by the character `?`,
 e.g. `9:00 - ?`. 
-The `?` MAY be repeated, e.g. `9:00 - ???`.
+The `?` MAY be repeated, e.g. `9:00 - ???`.[^5]
 The placeholder MUST NOT be *shifted*.
 
-*Open ranges* MUST NOT appear more than once per *record*.
+*Open ranges* MUST NOT appear more than once per *record*.[^6]
 
 ### Duration
 A *duration* is an *entry* that represents a period of time.
@@ -213,7 +213,7 @@ If the *duration* is supposed to be negative, it MUST be preceded by a `-` chara
 
 A file MAY hold any amount of *records*.
 Apart from that it MUST NOT contain anything
-but what is allowed by this specification.
+but what is allowed by this specification.[^7]
 
 There MUST appear one “blank line” between subsequent *records*;
 additional “blank lines” MAY appear.
@@ -271,6 +271,9 @@ and MUST NOT be combined into a single *record*.
 
 ## V. Changelog
 
+## Version x.x
+- Add footnotes for preserving background info.
+
 ## Version 1.3
 - Specify additional rules for multiline entry summaries.
 
@@ -283,3 +286,29 @@ and MUST NOT be combined into a single *record*.
   to be uniform within a record.
 - Remove technical term “whitespace”, since its meaning is ambiguous and the definition lacked clarity.
   Replace it with “blank character” and base the definition on the Unicode category.
+
+## VI. Footnotes
+
+These footnotes are purely informational.
+Their purpose is to preserve contextual background info that would otherwise be left implicit.
+
+[^1]: The indentation must be uniform, otherwise the levels can’t be determined
+      unambiguously. E.g., if 4 spaces are encountered at the beginning of the line,
+      it would be unclear whether that is 2 * 2 spaces or 1 * 4 spaces.
+[^2]: This is mainly to avoid ambiguity with the indented entries. There is no strict
+      technical reason that would forbid that.
+[^3]: In contrast to record summaries, entry summaries can start with whitespace.
+      That is for allowing the user to vertically align the text of all the lines.
+      A by-effect of this rule is that there can’t be a third indentation level.
+[^4]: The character set that a tag is allowed to consist of is deliberately limited,
+      so that tags can appear naturally in the flow of a sentence. E.g.:
+      Went to the #office, then to the #gym!
+[^5]: The `?` placeholder can be repeated, to allow users to visually align it with
+      other entries. E.g. `8:00-?????` has the same width as `8:00-9:00`.
+[^6]: This is an arbitrary constraint, but it’s important for making interactions with
+      tools easier. Otherwise, when doing `klog stop` on the CLI, it would be ambiguous
+      which of the open ranges it should apply to.
+[^7]: By allowing a file only to contain records and nothing else, the file effectively
+      becomes an ordered collection of records. That makes it easy to automatically
+      process files, because e.g. they can just be concatenated without having to regard
+      any potential previous context.

--- a/Specification.md
+++ b/Specification.md
@@ -277,8 +277,7 @@ The resulting *total time* MAY be 0;
 it MAY be negative;
 it MAY be greater than 24 hours.
 
-Overlapping *ranges* MUST be counted individually
-and MUST each be counted fully.
+Overlapping *ranges* MUST be each be counted fully.
 E.g., the two *entries* `12:00 - 13:00` and `12:30 - 13:30` result in *total time* of `2h`.
 
 *Ranges* with *shifted times* MUST be fully counted towards

--- a/Specification.md
+++ b/Specification.md
@@ -277,7 +277,7 @@ The resulting *total time* MAY be 0;
 it MAY be negative;
 it MAY be greater than 24 hours.
 
-Overlapping *ranges* MUST be each be counted fully.
+Overlapping *ranges* MUST each be counted fully.
 E.g., the two *entries* `12:00 - 13:00` and `12:30 - 13:30` result in *total time* of `2h`.
 
 *Ranges* with *shifted times* MUST be fully counted towards

--- a/Specification.md
+++ b/Specification.md
@@ -122,6 +122,7 @@ which MUST either be `"` (RECOMMENDED) or `'`.
   or a “newline”.
   In case no matching closing quote appears on the same line,
   the *tag value* MUST be treated as absent.
+  [^qutvl]
 - If the *tag value* is not quoted, it MUST only contain
   “letters”, “digits”, or the characters `_` or `-`.
 
@@ -277,7 +278,7 @@ it MAY be negative;
 it MAY be greater than 24 hours.
 
 Overlapping *ranges* MUST be counted individually
-and MUST NOT be offset against each other.
+and MUST each be counted fully.
 E.g., the two *entries* `12:00 - 13:00` and `12:30 - 13:30` result in *total time* of `2h`.
 
 *Ranges* with *shifted times* MUST be fully counted towards
@@ -310,7 +311,7 @@ and MUST NOT be combined into a single *record*.
 - Release the specification document under the CC0/OWFa license.
 - Support for tags to (optionally) have values assigned to them.
 - Allow hyphens (`-`) to appear in tags.
-- Annotate rules with context information.
+- Add footnotes to make context information explicit.
 
 #### Version 1.3
 - Specify additional rules for multiline entry summaries.
@@ -333,20 +334,24 @@ Their purpose is to preserve contextual info that would otherwise be left implic
 [^indst]: The indentation must be uniform, otherwise the levels can’t be determined
     unambiguously. E.g., if 4 spaces are encountered at the beginning of the line, it would
     be unclear whether that is 2 * 2 spaces or 1 * 4 spaces.
-[^resui]: This is mainly to avoid ambiguity with the indented entries. There is no strict
-    technical reason that would forbid that.
+[^resui]: A line in the record summary can’t start with blank characters, so that they can’t
+    be visually confused with the (indented) entries. There is no strict technical reason for
+    this, though.
 [^iwses]: In contrast to record summaries, entry summaries can start with whitespace.
-    That is for allowing the user to vertically align the text of all the lines.
-    A by-effect of this rule is that there can’t be a third indentation level.
+    That is for allowing the user to vertically align the summary text on all entry lines.
+    A by-effect of this rule is that there can never be a third indentation level.
 [^csitn]: The character set that a tag is allowed to consist of is deliberately limited,
-    so that tags can appear naturally in the flow of a sentence. E.g.:
-    Went to the #office, then to the #gym!
-[^plrep]: The `?` placeholder can be repeated, to allow users to visually align it with
-    other entries. E.g. `8:00-?????` has the same width as `8:00-9:00`.
-[^oasor]: This is an arbitrary constraint, but it’s important for making interactions with
-    tools easier. Otherwise, when doing `klog stop` on the CLI, it would be ambiguous
-    which of the open ranges it should apply to.
-[^fcocr]: By allowing a file only to contain records and nothing else, the file effectively
-    becomes an ordered collection of records. That makes it easy to automatically
-    process files, because e.g. they can just be concatenated without having to regard
-    any potential previous context.
+    so that tags can appear as natural words in the flow of a sentence. E.g.:
+    `Went to the #office, then to the #gym!`. That’s also why tag names should be interpreted
+    as case-insensitive. (Tag values, on the other hand, are always to be interpreted literally.)
+[^qutvl]: The main use-case for quoted tag values is for literal references, such as a project id,
+    or a name: `#project="2022/7.2"` or `#call="Liz Jones"`. That’s also why tag values
+    are always to be interpreted as case-sensitive (in contrast to tag names).
+[^plrep]: The `?` placeholder in open ranges can be repeated, to allow users to visually
+    align it with other entries. E.g. `8:00-?????` has the same width as `8:00-9:00`.
+[^oasor]: Open ranges to be only allowed to appear once per record has a mere practical motivation.
+    It’s important for making interactions with tools easier. Otherwise, when stopping activities
+    via a tool, it might be ambiguous which of the open ranges it should apply to.
+[^fcocr]: By allowing a file to only contain records and nothing else, a klog file can effectively
+    be treated as a plain-text database. That makes it easy to process files programmatically,
+    because every record acts as a self-contained unit of data.

--- a/Specification.md
+++ b/Specification.md
@@ -42,7 +42,8 @@ To signify the second level of indentation,
 the indentation sequence MUST appear twice.
 
 The indentation style MUST be uniform within *records*.
-(It MAY differ between *records*, though.)[^1]
+(It MAY differ between *records*, though.)
+[^indst]
 
 ### Date
 A *date* is a day in the calendar.
@@ -76,7 +77,8 @@ The *record summary* is considered to be associated with the entire *record*.
 
 It MUST appear underneath the *date*,
 and it MAY span multiple lines.
-Each of its lines MUST NOT start with “blank characters”.[^2]
+Each of its lines MUST NOT start with “blank characters”.
+[^resui]
 
 #### Entry Summary
 The *entry summary* is considered to be referring to one particular *entry*.
@@ -87,7 +89,8 @@ or it MUST start on the subsequent line.
 
 The *entry summary* MAY span multiple lines.
 All lines following the *entry* line MUST be indented twice;
-they also MUST NOT only consist of “blank characters”.[^3]
+they also MUST NOT only consist of “blank characters”.
+[^iwses]
 
 #### Tag
 The purpose of *tags* is to help categorise *records* and *entries*.
@@ -95,8 +98,9 @@ The purpose of *tags* is to help categorise *records* and *entries*.
 > Examples: `#gym`, `#24hours`, `#home_office`, `#読む`
 
 Any amount of *tags* MAY appear anywhere within *summaries*.
-A *tag* MUST be a sequence of “letters”, “digits” or the `_` character[^4],
+A *tag* MUST be a sequence of “letters”, “digits” or the `_` character,
 preceded by a single `#` character.
+[^csitn]
 
 ### Entry
 *Entry* is an abstract term for time-related data.
@@ -169,10 +173,12 @@ i.e. the end *time* is not determined yet.
 except that the end *time* MUST be replaced by a placeholder.
 The placeholder MUST be denoted by the character `?`,
 e.g. `9:00 - ?`. 
-The `?` MAY be repeated, e.g. `9:00 - ???`.[^5]
+The `?` MAY be repeated, e.g. `9:00 - ???`.
+[^plrep]
 The placeholder MUST NOT be *shifted*.
 
-*Open ranges* MUST NOT appear more than once per *record*.[^6]
+*Open ranges* MUST NOT appear more than once per *record*.
+[^oasor]
 
 ### Duration
 A *duration* is an *entry* that represents a period of time.
@@ -213,7 +219,8 @@ If the *duration* is supposed to be negative, it MUST be preceded by a `-` chara
 
 A file MAY hold any amount of *records*.
 Apart from that it MUST NOT contain anything
-but what is allowed by this specification.[^7]
+but what is allowed by this specification.
+[^fcocr]
 
 There MUST appear one “blank line” between subsequent *records*;
 additional “blank lines” MAY appear.
@@ -286,26 +293,26 @@ and MUST NOT be combined into a single *record*.
 
 ## V. Footnotes
 
-These footnotes are purely informational.
-Their purpose is to preserve contextual background info that would otherwise be left implicit.
+The following footnotes are purely informational.
+Their purpose is to preserve contextual info that would otherwise be left implicit.
 
-[^1]: The indentation must be uniform, otherwise the levels can’t be determined
-      unambiguously. E.g., if 4 spaces are encountered at the beginning of the line,
-      it would be unclear whether that is 2 * 2 spaces or 1 * 4 spaces.
-[^2]: This is mainly to avoid ambiguity with the indented entries. There is no strict
-      technical reason that would forbid that.
-[^3]: In contrast to record summaries, entry summaries can start with whitespace.
-      That is for allowing the user to vertically align the text of all the lines.
-      A by-effect of this rule is that there can’t be a third indentation level.
-[^4]: The character set that a tag is allowed to consist of is deliberately limited,
-      so that tags can appear naturally in the flow of a sentence. E.g.:
-      Went to the #office, then to the #gym!
-[^5]: The `?` placeholder can be repeated, to allow users to visually align it with
-      other entries. E.g. `8:00-?????` has the same width as `8:00-9:00`.
-[^6]: This is an arbitrary constraint, but it’s important for making interactions with
-      tools easier. Otherwise, when doing `klog stop` on the CLI, it would be ambiguous
-      which of the open ranges it should apply to.
-[^7]: By allowing a file only to contain records and nothing else, the file effectively
-      becomes an ordered collection of records. That makes it easy to automatically
-      process files, because e.g. they can just be concatenated without having to regard
-      any potential previous context.
+[^indst]: The indentation must be uniform, otherwise the levels can’t be determined
+    unambiguously. E.g., if 4 spaces are encountered at the beginning of the line, it would
+    be unclear whether that is 2 * 2 spaces or 1 * 4 spaces.
+[^resui]: This is mainly to avoid ambiguity with the indented entries. There is no strict
+    technical reason that would forbid that.
+[^iwses]: In contrast to record summaries, entry summaries can start with whitespace.
+    That is for allowing the user to vertically align the text of all the lines.
+    A by-effect of this rule is that there can’t be a third indentation level.
+[^csitn]: The character set that a tag is allowed to consist of is deliberately limited,
+    so that tags can appear naturally in the flow of a sentence. E.g.:
+    Went to the #office, then to the #gym!
+[^plrep]: The `?` placeholder can be repeated, to allow users to visually align it with
+    other entries. E.g. `8:00-?????` has the same width as `8:00-9:00`.
+[^oasor]: This is an arbitrary constraint, but it’s important for making interactions with
+    tools easier. Otherwise, when doing `klog stop` on the CLI, it would be ambiguous
+    which of the open ranges it should apply to.
+[^fcocr]: By allowing a file only to contain records and nothing else, the file effectively
+    becomes an ordered collection of records. That makes it easy to automatically
+    process files, because e.g. they can just be concatenated without having to regard
+    any potential previous context.

--- a/Specification.md
+++ b/Specification.md
@@ -327,30 +327,30 @@ and MUST NOT be combined into a single *record*.
 
 ## V. Footnotes
 
-The following footnotes are purely informational.
-Their purpose is to preserve contextual info that would otherwise be left implicit.
+The following footnotes are purely informational,
+to make contextual background information explicit.
 
 [^indst]: The indentation must be uniform, otherwise the levels can’t be determined
     unambiguously. E.g., if 4 spaces are encountered at the beginning of the line, it would
     be unclear whether that is 2 * 2 spaces or 1 * 4 spaces.
-[^resui]: A line in the record summary can’t start with blank characters, so that they can’t
-    be visually confused with the (indented) entries. There is no strict technical reason for
-    this, though.
-[^iwses]: In contrast to record summaries, entry summaries can start with whitespace.
-    That is for allowing the user to vertically align the summary text on all entry lines.
-    A by-effect of this rule is that there can never be a third indentation level.
+[^resui]: Lines in the record summary can’t start with blank characters, to avoid that they
+    might be visually confused with the (indented) entries. There is no strict technical
+    reason for this, though.
+[^iwses]: In contrast to record summaries, lines in entry summaries can start with blank
+    characters. That is for allowing the user to vertically align the summary text on all
+    entry lines. A by-effect of this rule is that there can never be a third indentation level.
 [^csitn]: The character set that a tag is allowed to consist of is deliberately limited,
     so that tags can appear as natural words in the flow of a sentence. E.g.:
-    `Went to the #office, then to the #gym!`. That’s also why tag names should be interpreted
+    `#Office day (#coding, #meetings)`. That’s also why tag names are to be interpreted
     as case-insensitive. (Tag values, on the other hand, are always to be interpreted literally.)
 [^qutvl]: The main use-case for quoted tag values is for literal references, such as a project id,
     or a name: `#project="2022/7.2"` or `#call="Liz Jones"`. That’s also why tag values
     are always to be interpreted as case-sensitive (in contrast to tag names).
 [^plrep]: The `?` placeholder in open ranges can be repeated, to allow users to visually
     align it with other entries. E.g. `8:00-?????` has the same width as `8:00-9:00`.
-[^oasor]: Open ranges to be only allowed to appear once per record has a mere practical motivation.
-    It’s important for making interactions with tools easier. Otherwise, when stopping activities
-    via a tool, it might be ambiguous which of the open ranges it should apply to.
+[^oasor]: Open ranges only being allowed to appear once per record has a mere practical motivation:
+    it’s important for making interactions with tools easier. Otherwise, when stopping activities
+    via a tool, it might be ambiguous which of the open ranges is meant.
 [^fcocr]: By allowing a file to only contain records and nothing else, a klog file can effectively
-    be treated as a plain-text database. That makes it easy to process files programmatically,
-    because every record acts as a self-contained unit of data.
+    be perceived as a text-based database. That makes it easy to process files programmatically,
+    because every record is a self-contained and strictly structured unit of data.


### PR DESCRIPTION
There are a lot of rules in the spec whose underlying reasoning is implicit, for example [why the `?` placeholder in open ranges can be repeated](https://github.com/jotaen/klog/discussions/92).

It would be good to preserve that knowledge somehow, because it makes it easier to understand how the rules came to be.

I’d think the right place to do that would be in “information” footnotes. That way, the spec keeps reading cleanly, but the context information is still embedded into it.

This PR is WIP for now, in order to experiment with this idea.

Footnotes are also not available in all markdown dialects, so I need to decide how to format it. As an aside, it could be useful to mention a markdown standard that the spec is written in, e.g. CommonMark (and which version).

[See here for a rendered preview](https://github.com/jotaen/klog/blob/spec/footnotes/Specification.md).

## Update

There are no footnotes in CommonMark, but the footnote syntax as used here should be common enough. Instead of ordered numbers, I used (obscure, fixed-length) ids. Otherwise all footnote ids would have to be recalculated every time a new one is inserted in between.