### PR TITLE
Specify how to deal with invalid input

### DIFF
--- a/Specification.md
+++ b/Specification.md
@@ -212,8 +212,6 @@ If the *duration* is supposed to be negative, it MUST be preceded by a `-` chara
 ## II. Organising records in files
 
 A file MAY hold any amount of *records*.
-Apart from that it MUST NOT contain anything
-but what is allowed by this specification.
 
 There MUST appear one “blank line” between subsequent *records*;
 additional “blank lines” MAY appear.
@@ -221,6 +219,9 @@ additional “blank lines” MAY appear.
 *Records* MAY appear in any order in the file.
 
 There MAY exist multiple *records* with the same *date*.
+
+A file MUST NOT contain anything but what is allowed by this specification.
+Otherwise, it SHOULD be treated as invalid altogether.
 
 The file extension SHOULD be `.klg`, e.g. `times.klg`.
 The file encoding MUST be UTF-8.

--- a/Specification.md
+++ b/Specification.md
@@ -221,7 +221,7 @@ additional “blank lines” MAY appear.
 There MAY exist multiple *records* with the same *date*.
 
 A file MUST NOT contain anything but what is allowed by this specification.
-Otherwise, it SHOULD be treated as invalid altogether.
+Otherwise, it SHOULD NOT be evaluated.
 
 The file extension SHOULD be `.klg`, e.g. `times.klg`.
 The file encoding MUST be UTF-8.


### PR DESCRIPTION
Resolves https://github.com/jotaen/klog/issues/163 (see https://github.com/jotaen/klog/discussions/162 originally).

@vladdeSV what do you think? Would that cover the question sufficiently?

I’m not 100% sure whether this should only be recommended (`SHOULD`) or mandatory (`MUST`). If it was mandatory, it could be interpreted that e.g. a syntax highlighter would have to stop working completely if there is an invalid token in the file, but that wouldn’t be very helpful. A recommendation would avoid that, as it leaves some room for “common sense”, while still having a clear opinion basically.