### PR TITLE
Release specification into the public domain (CC0/OWFa)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,7 @@ version numbers of both are independent of each other.
 
 ## About
 
-klog is free and open-source software distributed under the [MIT license](LICENSE.txt).
+klog is free and open-source software:
+
+- The command line tool is distributed under the [MIT license](LICENSE.txt).
+- The file format specification is available under the [CC0/OWFa](Specification.md#License) dual license.

--- a/Specification.md
+++ b/Specification.md
@@ -4,7 +4,13 @@
 
 klog is a file format for tracking time.
 
-It is free and open-source software distributed under the MIT-License.
+## License
+
+Per [Creative Commons CC0 1.0 Universal](http://creativecommons.org/publicdomain/zero/1.0/),
+to the extent possible under law, the editors have waived all copyright and related or
+neighbouring rights to this work.
+In addition, as of March 2022, the editors have made this specification available under the
+[Open Web Foundation Agreement 1.0](https://www.openwebfoundation.org/the-agreements/the-owf-1-0-agreements-granted-claims/owfa-1-0).
 
 ## Preface
 


### PR DESCRIPTION
Release the spec into the public domain, under the dual license [CC0 1.0](http://creativecommons.org/publicdomain/zero/1.0/) & [OWFa 1.0](https://www.openwebfoundation.org/the-agreements/the-owf-1-0-agreements-granted-claims/owfa-1-0).

Resolves https://github.com/jotaen/klog/issues/173.

Thank you again @vladdeSV for all your contributions to the spec (and of course for maintaining the VSCode extension)! 🚀 