### PR TITLE
Allow `--period` filtering by week and quarter

### DIFF
--- a/src/app/cli/lib/args.go
+++ b/src/app/cli/lib/args.go
@@ -96,7 +96,7 @@ type FilterArgs struct {
 	Until  Date          `name:"until" group:"Filter" help:"Records until this date (inclusive)"`
 	After  Date          `name:"after" group:"Filter" help:"Records after this date (exclusive)"`
 	Before Date          `name:"before" group:"Filter" help:"Records before this date (exclusive)"`
-	Period period.Period `name:"period" group:"Filter" help:"Records in this period (YYYY-MM or YYYY)"`
+	Period period.Period `name:"period" group:"Filter" help:"Records in period: YYYY (year), YYYY-MM (month), YYYY-Www (week), or YYYY-Qq (quarter)"`
 
 	// Shortcut filters
 	// The `XXX` ones are dummy entries just for the help output

--- a/src/app/cli/main/cli_test.go
+++ b/src/app/cli/main/cli_test.go
@@ -111,11 +111,15 @@ func TestDecodesPeriod(t *testing.T) {
 	out := klog.run(
 		[]string{"total", "--period", "2000", "test.klg"},
 		[]string{"total", "--period", "2000-01", "test.klg"},
+		[]string{"total", "--period", "2000-Q1", "test.klg"},
+		[]string{"total", "--period", "2000-W21", "test.klg"},
 		[]string{"total", "--period", "foo", "test.klg"},
 	)
 	assert.True(t, strings.Contains(out[0], "2h"), out)
 	assert.True(t, strings.Contains(out[1], "1h"), out)
-	assert.True(t, strings.Contains(out[2], "`foo` is not a valid period"), out)
+	assert.True(t, strings.Contains(out[2], "1h"), out)
+	assert.True(t, strings.Contains(out[3], "1h"), out)
+	assert.True(t, strings.Contains(out[4], "`foo` is not a valid period"), out)
 }
 
 func TestDecodesRounding(t *testing.T) {

--- a/src/app/cli/main/decoder.go
+++ b/src/app/cli/main/decoder.go
@@ -75,18 +75,8 @@ func periodDecoder() kong.MapperFunc {
 		if value == "" {
 			return errors.New("Please provide a valid period")
 		}
-		p := func() period.Period {
-			yearPeriod, yErr := period.NewYearFromString(value)
-			if yErr == nil {
-				return yearPeriod.Period()
-			}
-			monthPeriod, mErr := period.NewMonthFromString(value)
-			if mErr == nil {
-				return monthPeriod.Period()
-			}
-			return nil
-		}()
-		if p == nil {
+		p, err := period.NewPeriodFromPatternString(value)
+		if err != nil {
 			return errors.New("`" + value + "` is not a valid period")
 		}
 		target.Set(reflect.ValueOf(p))

--- a/src/service/period/period.go
+++ b/src/service/period/period.go
@@ -1,6 +1,7 @@
 package period
 
 import (
+	"errors"
 	. "github.com/jotaen/klog/src"
 	"math"
 )
@@ -18,6 +19,22 @@ type periodData struct {
 
 func NewPeriod(since Date, until Date) Period {
 	return &periodData{since, until}
+}
+
+func NewPeriodFromPatternString(pattern string) (Period, error) {
+	type PeriodCreator interface{ Period() Period }
+	for _, create := range []func(string) (PeriodCreator, error){
+		func(s string) (PeriodCreator, error) { return NewYearFromString(s) },
+		func(s string) (PeriodCreator, error) { return NewMonthFromString(s) },
+		func(s string) (PeriodCreator, error) { return NewQuarterFromString(s) },
+		func(s string) (PeriodCreator, error) { return NewWeekFromString(s) },
+	} {
+		p, err := create(pattern)
+		if err == nil {
+			return p.Period(), nil
+		}
+	}
+	return nil, errors.New("INVALID_PERIOD_PATTERN")
 }
 
 func (p *periodData) Since() Date {

--- a/src/service/period/period_test.go
+++ b/src/service/period/period_test.go
@@ -6,6 +6,25 @@ import (
 	"testing"
 )
 
+func TestDeserialisePattern(t *testing.T) {
+	for _, x := range []string{
+		"2022",
+		"2022-05",
+		"2022-Q2",
+		"2022-W18",
+	} {
+		period, err := NewPeriodFromPatternString(x)
+		assert.Nil(t, err)
+		assert.IsType(t, NewPeriod(Ɀ_Date_(1, 1, 1), Ɀ_Date_(1, 1, 1)), period)
+	}
+}
+
+func TestDeserialisePatternFails(t *testing.T) {
+	period, err := NewPeriodFromPatternString("x")
+	assert.Error(t, err)
+	assert.Nil(t, period)
+}
+
 func TestHashYieldsDistinctValues(t *testing.T) {
 	dayHashes := make(map[DayHash]bool)
 	weekHashes := make(map[WeekHash]bool)

--- a/src/service/period/quarter.go
+++ b/src/service/period/quarter.go
@@ -1,6 +1,12 @@
 package period
 
-import . "github.com/jotaen/klog/src"
+import (
+	"errors"
+	. "github.com/jotaen/klog/src"
+	"regexp"
+	"strconv"
+	"strings"
+)
 
 type Quarter struct {
 	date Date
@@ -8,8 +14,28 @@ type Quarter struct {
 
 type QuarterHash Hash
 
+var quarterPattern = regexp.MustCompile(`^\d{4}-Q\d$`)
+
 func NewQuarterFromDate(d Date) Quarter {
 	return Quarter{d}
+}
+
+func NewQuarterFromString(yyyyQq string) (Quarter, error) {
+	if !quarterPattern.MatchString(yyyyQq) {
+		return Quarter{}, errors.New("INVALID_QUARTER_PERIOD")
+	}
+	parts := strings.Split(yyyyQq, "-")
+	year, _ := strconv.Atoi(parts[0])
+	quarter, _ := strconv.Atoi(strings.TrimPrefix(parts[1], "Q"))
+	if quarter < 1 || quarter > 4 {
+		return Quarter{}, errors.New("INVALID_QUARTER_PERIOD")
+	}
+	month := quarter * 3
+	d, err := NewDate(year, month, 1)
+	if err != nil {
+		return Quarter{}, errors.New("INVALID_QUARTER_PERIOD")
+	}
+	return Quarter{d}, nil
 }
 
 func (q Quarter) Period() Period {

--- a/src/service/period/quarter_test.go
+++ b/src/service/period/quarter_test.go
@@ -3,6 +3,7 @@ package period
 import (
 	. "github.com/jotaen/klog/src"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -30,6 +31,41 @@ func TestQuarterPeriod(t *testing.T) {
 		{NewQuarterFromDate(Ɀ_Date_(1998, 9, 30)).Period(), NewPeriod(Ɀ_Date_(1998, 7, 1), Ɀ_Date_(1998, 9, 30))},
 	} {
 		assert.Equal(t, x.expected, x.actual)
+	}
+}
+
+func TestParseValidQuarter(t *testing.T) {
+	for _, x := range []struct {
+		text   string
+		expect Period
+	}{
+		{"0000-Q1", NewPeriod(Ɀ_Date_(0, 1, 1), Ɀ_Date_(0, 3, 31))},
+		{"0475-Q2", NewPeriod(Ɀ_Date_(475, 4, 1), Ɀ_Date_(475, 6, 30))},
+		{"2008-Q3", NewPeriod(Ɀ_Date_(2008, 7, 1), Ɀ_Date_(2008, 9, 30))},
+		{"8641-Q4", NewPeriod(Ɀ_Date_(8641, 10, 1), Ɀ_Date_(8641, 12, 31))},
+	} {
+		quarter, err := NewQuarterFromString(x.text)
+		require.Nil(t, err)
+		assert.True(t, x.expect.Since().IsEqualTo(quarter.Period().Since()))
+		assert.True(t, x.expect.Until().IsEqualTo(quarter.Period().Until()))
+	}
+}
+
+func TestParseRejectsInvalidQuarter(t *testing.T) {
+	for _, x := range []string{
+		"2000-Q5",
+		"2000-Q0",
+		"2000-Q-1",
+		"2000-Q",
+		"2000-q2",
+		"2000-asdf",
+		"2000-Q01",
+		"2000-",
+		"273888-Q2",
+		"Q3",
+	} {
+		_, err := NewQuarterFromString(x)
+		require.Error(t, err)
 	}
 }
 

--- a/src/service/period/week_test.go
+++ b/src/service/period/week_test.go
@@ -3,6 +3,7 @@ package period
 import (
 	. "github.com/jotaen/klog/src"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -30,6 +31,44 @@ func TestWeekPeriod(t *testing.T) {
 		{NewWeekFromDate(Ɀ_Date_(1998, 11, 1)).Period(), NewPeriod(Ɀ_Date_(1998, 10, 26), Ɀ_Date_(1998, 11, 1))},
 	} {
 		assert.Equal(t, x.expected, x.actual)
+	}
+}
+
+func TestParseValidWeek(t *testing.T) {
+	for _, x := range []struct {
+		text   string
+		expect Period
+	}{
+		{"2022-W01", NewPeriod(Ɀ_Date_(2022, 1, 3), Ɀ_Date_(2022, 1, 9))},
+		{"2022-W1", NewPeriod(Ɀ_Date_(2022, 1, 3), Ɀ_Date_(2022, 1, 9))},
+		{"2017-W26", NewPeriod(Ɀ_Date_(2017, 6, 26), Ɀ_Date_(2017, 7, 2))},
+		{"2017-W27", NewPeriod(Ɀ_Date_(2017, 7, 3), Ɀ_Date_(2017, 7, 9))},
+		{"2012-W09", NewPeriod(Ɀ_Date_(2012, 2, 27), Ɀ_Date_(2012, 3, 4))},
+		{"2022-W02", NewPeriod(Ɀ_Date_(2022, 1, 10), Ɀ_Date_(2022, 1, 16))},
+		{"2022-W52", NewPeriod(Ɀ_Date_(2022, 12, 26), Ɀ_Date_(2023, 1, 1))},
+		{"2025-W01", NewPeriod(Ɀ_Date_(2024, 12, 30), Ɀ_Date_(2025, 1, 5))},
+	} {
+		week, err := NewWeekFromString(x.text)
+		require.Nil(t, err)
+		assert.True(t, x.expect.Since().IsEqualTo(week.Period().Since()), x.text)
+		assert.True(t, x.expect.Until().IsEqualTo(week.Period().Until()))
+	}
+}
+
+func TestParseRejectsInvalidWeekString(t *testing.T) {
+	for _, x := range []string{
+		"2000-W00",
+		"2000-W-1",
+		"2000-W001",
+		"2000-W54",
+		"2000-W",
+		"2000-w14",
+		"2000-w14",
+		"2000-asdf",
+		"12873612-W02",
+	} {
+		_, err := NewWeekFromString(x)
+		require.Error(t, err)
 	}
 }
 


### PR DESCRIPTION
Resolves https://github.com/jotaen/klog/issues/178.

Add two new patterns for period filtering:

- `YYYY-Qq`, e.g. `2022-Q1` for all records in the first quarter of 2022
- `YYYY-Www`, e.g. `2022-W04`/`2022-W4` for all records in the fourth week of 2022 (week number as of ISO 8601)