### PR TITLE
Support assigning values to tags

### DIFF
--- a/src/app/cli/lib/args.go
+++ b/src/app/cli/lib/args.go
@@ -90,7 +90,7 @@ func (args *NowArgs) Total(reference gotime.Time, rs ...Record) Duration {
 
 type FilterArgs struct {
 	// General filters
-	Tags   []string      `name:"tag" group:"Filter" help:"Records (or entries) that match this tag"`
+	Tags   []Tag         `name:"tag" group:"Filter" help:"Records (or entries) that match this tag"`
 	Date   []Date        `name:"date" group:"Filter" help:"Records at this date"`
 	Since  Date          `name:"since" group:"Filter" help:"Records since this date (inclusive)"`
 	Until  Date          `name:"until" group:"Filter" help:"Records until this date (inclusive)"`

--- a/src/app/cli/main/cli.go
+++ b/src/app/cli/main/cli.go
@@ -42,6 +42,10 @@ func Run(homeDir string, meta app.Meta, isDebug bool, args []string) (int, error
 			f, _ := service.NewRounding(30)
 			return kong.TypeMapper(reflect.TypeOf(&f).Elem(), roundingDecoder())
 		}(),
+		func() kong.Option {
+			t := klog.NewTagOrPanic("test", "")
+			return kong.TypeMapper(reflect.TypeOf(&t).Elem(), tagDecoder())
+		}(),
 		kong.ConfigureHelp(kong.HelpOptions{
 			Compact: true,
 		}),

--- a/src/app/cli/main/cli_test.go
+++ b/src/app/cli/main/cli_test.go
@@ -135,3 +135,23 @@ func TestDecodesRounding(t *testing.T) {
 	assert.True(t, strings.Contains(out[0], "`asdf` is not a valid rounding value"), out)
 	assert.True(t, strings.Contains(out[1], "- ?"), out)
 }
+
+func TestDecodesTags(t *testing.T) {
+	klog := &Env{
+		files: map[string]string{
+			"test.klg": "2020-01-01\n#foo\n\n2020-01-02\n\t1h #bar=1",
+		},
+	}
+	out := klog.run(
+		[]string{"print", "--tag", "asdf=asdf=asdf", "test.klg"},
+		[]string{"print", "--tag", "foo&bar", "test.klg"},
+		[]string{"print", "--tag", "foo", "test.klg"},
+		[]string{"print", "--tag", "bar=1", "test.klg"},
+		[]string{"print", "--tag", "#bar='1'", "test.klg"},
+	)
+	assert.True(t, strings.Contains(out[0], "`asdf=asdf=asdf` is not a valid tag"), out)
+	assert.True(t, strings.Contains(out[1], "`foo&bar` is not a valid tag"), out)
+	assert.True(t, strings.Contains(out[2], "#foo"), out)
+	assert.True(t, strings.Contains(out[3], "#bar=1"), out)
+	assert.True(t, strings.Contains(out[4], "#bar=1"), out)
+}

--- a/src/app/cli/main/decoder.go
+++ b/src/app/cli/main/decoder.go
@@ -101,3 +101,21 @@ func roundingDecoder() kong.MapperFunc {
 		return nil
 	}
 }
+
+func tagDecoder() kong.MapperFunc {
+	return func(ctx *kong.DecodeContext, target reflect.Value) error {
+		var value string
+		if err := ctx.Scan.PopValueInto("tag", &value); err != nil {
+			return err
+		}
+		if value == "" {
+			return errors.New("Please provide a valid tag")
+		}
+		t, err := klog.NewTagFromString(value)
+		if err != nil {
+			return errors.New("`" + value + "` is not a valid tag")
+		}
+		target.Set(reflect.ValueOf(t))
+		return nil
+	}
+}

--- a/src/app/cli/print.go
+++ b/src/app/cli/print.go
@@ -23,11 +23,11 @@ func (opt *Print) Run(ctx app.Context) error {
 	if err != nil {
 		return err
 	}
+	now := ctx.Now()
+	records = opt.ApplyFilter(now, records)
 	if len(records) == 0 {
 		return nil
 	}
-	now := ctx.Now()
-	records = opt.ApplyFilter(now, records)
 	records = opt.ApplySort(records)
 	ctx.Print("\n" + ctx.Serialiser().SerialiseRecords(records...) + "\n")
 

--- a/src/app/cli/tags_test.go
+++ b/src/app/cli/tags_test.go
@@ -47,3 +47,18 @@ Was #sick, need to compensate later
 #sports    8h   
 `, state.printBuffer)
 }
+
+func TestPrintTagsOverviewWithValueGrouping(t *testing.T) {
+	state, err := NewTestingContext()._SetRecords(`
+1995-03-17
+	3h #ticket=481
+	1h #ticket=105
+	1h
+`)._Run((&Tags{}).Run)
+	require.Nil(t, err)
+	assert.Equal(t, `
+#ticket 4h
+ 105    1h
+ 481    3h
+`, state.printBuffer)
+}

--- a/src/app/cli/tags_test.go
+++ b/src/app/cli/tags_test.go
@@ -54,11 +54,24 @@ func TestPrintTagsOverviewWithValueGrouping(t *testing.T) {
 	3h #ticket=481
 	1h #ticket=105
 	1h
+`)._Run((&Tags{Values: true}).Run)
+	require.Nil(t, err)
+	assert.Equal(t, `
+#ticket 4h   
+ 105       1h
+ 481       3h
+`, state.printBuffer)
+}
+
+func TestPrintTagsOverviewWithoutValueGrouping(t *testing.T) {
+	state, err := NewTestingContext()._SetRecords(`
+1995-03-17
+	3h #ticket=481
+	1h #ticket=105
+	1h
 `)._Run((&Tags{}).Run)
 	require.Nil(t, err)
 	assert.Equal(t, `
 #ticket 4h
- 105    1h
- 481    3h
 `, state.printBuffer)
 }

--- a/src/service/evaluate.go
+++ b/src/service/evaluate.go
@@ -17,16 +17,6 @@ func Total(rs ...Record) Duration {
 	return total
 }
 
-// TotalEntries calculates the overall of entries.
-// It disregards open ranges.
-func TotalEntries(es ...Entry) Duration {
-	total := NewDuration(0, 0)
-	for _, e := range es {
-		total = total.Plus(e.Duration())
-	}
-	return total
-}
-
 // HypotheticalTotal calculates the overall total time of records,
 // assuming all open ranges would be closed at the `until` time.
 func HypotheticalTotal(until gotime.Time, rs ...Record) (Duration, bool) {

--- a/src/service/tags.go
+++ b/src/service/tags.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	. "github.com/jotaen/klog/src"
+	"sort"
+)
+
+type TagTotal struct {
+	Tag     Tag
+	Total   Duration
+	forSort string
+}
+
+// AggregateTotalsByTags returns a map for looking up matching entries for a given tag.
+func AggregateTotalsByTags(rs ...Record) []TagTotal {
+	result := make(totalByTag)
+	for _, r := range rs {
+		for _, e := range r.Entries() {
+			alreadyCounted := make(map[Tag]bool)
+			allTags := Merge(r.Summary().Tags(), e.Summary().Tags())
+			for tag := range allTags {
+				if alreadyCounted[tag] {
+					continue
+				}
+				result.put(tag, e.Duration())
+			}
+		}
+	}
+	return result.toSortedList()
+}
+
+type totalByTag map[string]map[string]Duration
+
+func (tbt totalByTag) put(t Tag, d Duration) {
+	if tbt[t.Name()] == nil {
+		tbt[t.Name()] = make(map[string]Duration)
+	}
+
+	if tbt[t.Name()][t.Value()] == nil {
+		tbt[t.Name()][t.Value()] = NewDuration(0, 0)
+	}
+	tbt[t.Name()][t.Value()] = tbt[t.Name()][t.Value()].Plus(d)
+}
+
+func (tbt totalByTag) toSortedList() []TagTotal {
+	var result []TagTotal
+	for tagName, totalsByValue := range tbt {
+		for tagValue, total := range totalsByValue {
+			result = append(result, TagTotal{
+				forSort: tagName + "=" + tagValue,
+				Tag:     NewTagOrPanic(tagName, tagValue),
+				Total:   total,
+			})
+		}
+	}
+	sort.Slice(result, func(i int, j int) bool {
+		return result[i].forSort < result[j].forSort
+	})
+	return result
+}

--- a/src/service/tags_test.go
+++ b/src/service/tags_test.go
@@ -1,0 +1,72 @@
+package service
+
+import (
+	. "github.com/jotaen/klog/src"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestAggregateTotalTimesByTagSortsAlphabetically(t *testing.T) {
+	r1 := NewRecord(Ɀ_Date_(2020, 1, 1))
+	r1.AddDuration(NewDuration(1, 0), Ɀ_EntrySummary_("#bbb"))
+	r1.AddDuration(NewDuration(3, 0), Ɀ_EntrySummary_("#aaa"))
+	r1.AddDuration(NewDuration(3, 0), Ɀ_EntrySummary_("#ddd"))
+
+	r2 := NewRecord(Ɀ_Date_(2020, 1, 2))
+	r2.AddDuration(NewDuration(0, 30), Ɀ_EntrySummary_("#ccc=1"))
+	r2.AddDuration(NewDuration(0, 30), Ɀ_EntrySummary_("#ccc=2"))
+
+	totals := AggregateTotalsByTags(r1, r2)
+	require.Len(t, totals, 6)
+
+	i := 0
+	assert.Equal(t, NewTagOrPanic("aaa", ""), totals[i].Tag)
+	i += 1
+	assert.Equal(t, NewTagOrPanic("bbb", ""), totals[i].Tag)
+	i += 1
+	assert.Equal(t, NewTagOrPanic("ccc", ""), totals[i].Tag)
+	i += 1
+	assert.Equal(t, NewTagOrPanic("ccc", "1"), totals[i].Tag)
+	i += 1
+	assert.Equal(t, NewTagOrPanic("ccc", "2"), totals[i].Tag)
+	i += 1
+	assert.Equal(t, NewTagOrPanic("ddd", ""), totals[i].Tag)
+}
+
+func TestAggregateTotalTimesByTag(t *testing.T) {
+	r := NewRecord(Ɀ_Date_(2020, 1, 1))
+	r.SetSummary(Ɀ_RecordSummary_("#foo"))
+	r.AddDuration(NewDuration(1, 0), Ɀ_EntrySummary_("#foo=1"))
+	r.AddDuration(NewDuration(3, 0), Ɀ_EntrySummary_("#foo"))
+
+	totals := AggregateTotalsByTags(r)
+	require.Len(t, totals, 2)
+	i := 0
+
+	assert.Equal(t, NewTagOrPanic("foo", ""), totals[i].Tag)
+	assert.Equal(t, NewDuration(4, 0), totals[i].Total)
+	i += 1
+	assert.Equal(t, NewTagOrPanic("foo", "1"), totals[i].Tag)
+	assert.Equal(t, NewDuration(1, 0), totals[i].Total)
+}
+
+func TestAggregateTotalIgnoresRedundantTags(t *testing.T) {
+	r := NewRecord(Ɀ_Date_(2020, 1, 1))
+	r.SetSummary(Ɀ_RecordSummary_("#foo #foo #foo=1"))
+	r.AddDuration(NewDuration(1, 0), Ɀ_EntrySummary_("#foo=1 #foo"))
+	r.AddDuration(NewDuration(3, 0), Ɀ_EntrySummary_("#foo=2 #foo=1 #foo"))
+
+	totals := AggregateTotalsByTags(r)
+	require.Len(t, totals, 3)
+	i := 0
+
+	assert.Equal(t, NewTagOrPanic("foo", ""), totals[i].Tag)
+	assert.Equal(t, NewDuration(4, 0), totals[i].Total)
+	i += 1
+	assert.Equal(t, NewTagOrPanic("foo", "1"), totals[i].Tag)
+	assert.Equal(t, NewDuration(4, 0), totals[i].Total)
+	i += 1
+	assert.Equal(t, NewTagOrPanic("foo", "2"), totals[i].Tag)
+	assert.Equal(t, NewDuration(3, 0), totals[i].Total)
+}

--- a/src/summary.go
+++ b/src/summary.go
@@ -3,8 +3,6 @@ package klog
 import (
 	"errors"
 	"regexp"
-	"sort"
-	"strings"
 )
 
 // RecordSummary contains the summary lines of the overall summary that
@@ -50,16 +48,17 @@ func (s EntrySummary) Lines() []string {
 }
 
 func (s RecordSummary) Tags() TagSet {
-	tags := NewTagSet()
+	tags := NewEmptyTagSet()
 	for _, l := range s {
 		for _, m := range HashTagPattern.FindAllStringSubmatch(l, -1) {
-			tag := NewTag(m[1])
-			tags[tag] = true
+			tag, _ := NewTagFromString(m[0])
+			tags.Put(tag)
 		}
 	}
 	return tags
 }
 
+// Tags returns the tags that the entry summary contains.
 func (s EntrySummary) Tags() TagSet {
 	return RecordSummary(s).Tags()
 }
@@ -82,67 +81,4 @@ func (s EntrySummary) Equals(summary EntrySummary) bool {
 		return true
 	}
 	return RecordSummary(s).Equals(RecordSummary(summary))
-}
-
-var HashTagPattern = regexp.MustCompile(`#([\p{L}\d_-]+)`)
-
-type Tag string
-
-func (t Tag) ToString() string {
-	return "#" + string(t)
-}
-
-func (ts TagSet) ToStrings() []string {
-	var tags []string
-	for t := range ts {
-		tags = append(tags, t.ToString())
-	}
-	sort.Slice(tags, func(i, j int) bool {
-		return tags[i] < tags[j]
-	})
-	return tags
-}
-
-func (ts TagSet) Contains(queryTag string) bool {
-	if !strings.HasSuffix(queryTag, "...") {
-		return ts[NewTag(queryTag)]
-	}
-	queryBaseTag := NewTag(strings.TrimSuffix(queryTag, "..."))
-	for t := range ts {
-		if strings.HasPrefix(t.ToString(), queryBaseTag.ToString()) {
-			return true
-		}
-	}
-	return false
-}
-
-type TagSet map[Tag]bool
-
-func NewTag(value string) Tag {
-	if value[0] == '#' {
-		value = value[1:]
-	}
-	return Tag(strings.ToLower(value))
-}
-
-func NewTagSet(tags ...string) TagSet {
-	result := make(map[Tag]bool, len(tags))
-	for _, v := range tags {
-		if len(v) == 0 {
-			continue
-		}
-		tag := NewTag(v)
-		result[tag] = true
-	}
-	return result
-}
-
-func Merge(tagSets ...TagSet) TagSet {
-	result := NewTagSet()
-	for _, ts := range tagSets {
-		for t := range ts {
-			result[t] = true
-		}
-	}
-	return result
 }

--- a/src/summary_test.go
+++ b/src/summary_test.go
@@ -164,46 +164,34 @@ func TestRecognisesAllTags(t *testing.T) {
 	recordSummary, _ := NewRecordSummary(
 		"Hello #world, I feel",
 		"(super #GREAT) today #123_test: #234-foo!",
-		"#太陽 #λουλούδι #पहाड #мир #Léift",
+		"#太陽 #λουλούδι #पहाड #мир #Léift #ΓΕΙΑ-ΣΑΣ",
 	)
 
 	assert.Equal(t, recordSummary.Tags().ToStrings(), []string{
-		"#123_test", "#234-foo", "#great", "#léift", "#world", "#λουλούδι", "#мир", "#पह", "#太陽",
+		"#123_test", "#234-foo", "#great", "#léift", "#world", "#γεια-σασ", "#λουλούδι", "#мир", "#पह", "#太陽",
 	})
 
-	assert.True(t, recordSummary.Tags().Contains("123_test"))
-	assert.True(t, recordSummary.Tags().Contains("234-foo"))
-	assert.True(t, recordSummary.Tags().Contains("太陽"))
-	assert.True(t, recordSummary.Tags().Contains("λουλούδι"))
-	assert.True(t, recordSummary.Tags().Contains("great"))
-	assert.True(t, recordSummary.Tags().Contains("#world")) // Leading `#` or not doesn’t matter
+	assert.True(t, recordSummary.Tags().Contains(NewTagOrPanic("123_test", "")))
+	assert.True(t, recordSummary.Tags().Contains(NewTagOrPanic("234-foo", "")))
+	assert.True(t, recordSummary.Tags().Contains(NewTagOrPanic("太陽", "")))
+	assert.True(t, recordSummary.Tags().Contains(NewTagOrPanic("λουλούδι", "")))
+	assert.True(t, recordSummary.Tags().Contains(NewTagOrPanic("γεια-σασ", "")))
+	assert.True(t, recordSummary.Tags().Contains(NewTagOrPanic("GREAT", "")))
+	assert.True(t, recordSummary.Tags().Contains(NewTagOrPanic("Great", "")))
+	assert.True(t, recordSummary.Tags().Contains(NewTagOrPanic("great", "")))
+	assert.True(t, recordSummary.Tags().Contains(NewTagOrPanic("world", "")))
 
-	assert.False(t, recordSummary.Tags().Contains("foo"))
-	assert.False(t, recordSummary.Tags().Contains("test"))
-	assert.False(t, recordSummary.Tags().Contains("test"))
-	assert.False(t, recordSummary.Tags().Contains("ടെലിഫോണ്"))
-	assert.False(t, recordSummary.Tags().Contains("123"))
-	assert.False(t, recordSummary.Tags().Contains("wor"))
-	assert.False(t, recordSummary.Tags().Contains("super"))
-	assert.False(t, recordSummary.Tags().Contains("маркуч"))
-	assert.False(t, recordSummary.Tags().Contains("grea"))
-	assert.False(t, recordSummary.Tags().Contains("blabla"))
+	assert.False(t, recordSummary.Tags().Contains(NewTagOrPanic("foo", "")))
+	assert.False(t, recordSummary.Tags().Contains(NewTagOrPanic("test", "")))
+	assert.False(t, recordSummary.Tags().Contains(NewTagOrPanic("test", "")))
+	assert.False(t, recordSummary.Tags().Contains(NewTagOrPanic("ടെലിഫോണ്", "")))
+	assert.False(t, recordSummary.Tags().Contains(NewTagOrPanic("123", "")))
+	assert.False(t, recordSummary.Tags().Contains(NewTagOrPanic("wor", "")))
+	assert.False(t, recordSummary.Tags().Contains(NewTagOrPanic("super", "")))
+	assert.False(t, recordSummary.Tags().Contains(NewTagOrPanic("маркуч", "")))
+	assert.False(t, recordSummary.Tags().Contains(NewTagOrPanic("grea", "")))
+	assert.False(t, recordSummary.Tags().Contains(NewTagOrPanic("blabla", "")))
 
 	entrySummary, _ := NewEntrySummary("Hello #world, I feel #great #TODAY")
 	assert.Equal(t, entrySummary.Tags().ToStrings(), []string{"#great", "#today", "#world"})
-}
-
-func TestPerformsFuzzyMatching(t *testing.T) {
-	summary, _ := NewRecordSummary("Hello #world, I feel #gReAt today #123_test: #234-foo! #時計")
-
-	assert.True(t, summary.Tags().Contains("#123_..."))
-	assert.True(t, summary.Tags().Contains("#123_test..."))
-	assert.True(t, summary.Tags().Contains("#234-fo..."))
-	assert.True(t, summary.Tags().Contains("GR..."))
-	assert.True(t, summary.Tags().Contains("WoRl..."))
-	assert.True(t, summary.Tags().Contains("時..."))
-
-	assert.False(t, summary.Tags().Contains("orld..."))
-	assert.False(t, summary.Tags().Contains("gra..."))
-	assert.False(t, summary.Tags().Contains("23-..."))
 }

--- a/src/tag.go
+++ b/src/tag.go
@@ -1,0 +1,124 @@
+package klog
+
+import (
+	"errors"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var HashTagPattern = regexp.MustCompile(`#([\p{L}\d_-]+)(=(("[^"]*")|('[^']*')|([\p{L}\d_-]*)))?`)
+var unquotedValuePattern = regexp.MustCompile(`^[\p{L}\d_-]+$`)
+
+type Tag struct {
+	name  string
+	value string
+}
+
+func NewTagFromString(tag string) (Tag, error) {
+	if !strings.HasPrefix(tag, "#") {
+		tag = "#" + tag
+	}
+	match := HashTagPattern.FindStringSubmatch(tag)
+	if match == nil {
+		// The tag pattern didn’t match at all.
+		return Tag{}, errors.New("INVALID_TAG")
+	}
+	name := match[1]
+	value := func() string {
+		v := match[3]
+		if strings.HasPrefix(v, `"`) {
+			return strings.Trim(v, `"`)
+		}
+		if strings.HasPrefix(v, `'`) {
+			return strings.Trim(v, `'`)
+		}
+		return v
+	}()
+	if len(match[0]) != len(tag) {
+		// The original tag contains more/other characters.
+		return Tag{}, errors.New("INVALID_TAG")
+	}
+	return NewTagOrPanic(name, value), nil
+}
+
+// NewTagOrPanic constructs a new tag but will panic if the
+// parameters don’t yield a valid tag.
+func NewTagOrPanic(name string, value string) Tag {
+	if strings.Contains(value, "\"") && strings.Contains(value, "'") {
+		// A tag value can never contain both ' and " at the same time.
+		panic("Invalid tag")
+	}
+	return Tag{strings.ToLower(name), value}
+}
+
+func (t Tag) Name() string {
+	return t.name
+}
+
+func (t Tag) Value() string {
+	return t.value
+}
+
+func (t Tag) Matches(queryTag Tag) bool {
+	if t.Name() != queryTag.Name() {
+		return false
+	}
+	if queryTag.Value() != "" {
+		return t.Value() == queryTag.Value()
+	}
+	return true
+}
+
+func (t Tag) ToString() string {
+	result := "#" + t.name
+	if t.value != "" {
+		result += "="
+		quotation := ""
+		if !unquotedValuePattern.MatchString(t.value) {
+			if strings.Contains(t.value, `"`) {
+				quotation = `'`
+			} else {
+				quotation = "\""
+			}
+		}
+		result += quotation + t.value + quotation
+	}
+	return result
+}
+
+type TagSet map[Tag]bool
+
+func NewEmptyTagSet() TagSet {
+	return make(map[Tag]bool)
+}
+
+func (ts TagSet) Put(tag Tag) {
+	ts[tag] = true
+	ts[NewTagOrPanic(tag.Name(), "")] = true
+}
+
+func (ts TagSet) Contains(tag Tag) bool {
+	return ts[tag]
+}
+
+func (ts TagSet) ToStrings() []string {
+	var tags []string
+	for t := range ts {
+		tags = append(tags, t.ToString())
+	}
+	sort.Slice(tags, func(i, j int) bool {
+		return tags[i] < tags[j]
+	})
+	return tags
+}
+
+func Merge(tagSets ...TagSet) TagSet {
+	result := NewEmptyTagSet()
+	for _, ts := range tagSets {
+		for t := range ts {
+			result[t] = true
+		}
+	}
+	return result
+}

--- a/src/tag_test.go
+++ b/src/tag_test.go
@@ -1,0 +1,160 @@
+package klog
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestCreatesNewTag(t *testing.T) {
+	for _, x := range []struct {
+		tag        string
+		expectName string
+	}{
+		{"#tag", "tag"},
+		{"#TAG", "tag"},
+		{"#t-a-g", "t-a-g"},
+		{"#t_a_g", "t_a_g"},
+		{"#t1a2g3", "t1a2g3"},
+		{"#---", "---"},
+		{"#___", "___"},
+	} {
+		tag, err := NewTagFromString(x.tag)
+		require.Nil(t, err)
+		assert.Equal(t, x.expectName, tag.Name())
+	}
+}
+
+func TestTagMatching(t *testing.T) {
+	for _, x := range []struct {
+		tag   string
+		query string
+	}{
+		// Identity
+		{`#tag`, `#tag`},
+		{`#tag=value`, `#tag=value`},
+
+		// Value empty is the same as value absent
+		{`#tag`, `#tag=`},
+		{`#tag`, `#tag=""`},
+		{`#tag`, `#tag=''`},
+		{`#tag=`, `#tag`},
+		{`#tag=""`, `#tag`},
+		{`#tag=''`, `#tag`},
+		{`#tag=''`, `#tag=""`},
+		{`#tag=''`, `#tag=`},
+
+		// Case-insensitivity of name
+		{`#TAG`, `#tag`},
+		{`#TAG=value`, `#tag=value`},
+
+		// Quotation style is irrelevant
+		{`#tag=value`, `#tag="value"`},
+		{`#tag=value`, `#tag='value'`},
+		{`#tag="value"`, `#tag='value'`},
+
+		// Name-only tag matches tag with value
+		{`#tag=value`, `#tag`},
+	} {
+		first, err1 := NewTagFromString(x.tag)
+		require.Nil(t, err1)
+		second, err2 := NewTagFromString(x.query)
+		require.Nil(t, err2)
+		assert.True(t, first.Matches(second))
+	}
+}
+
+func TestTagIsNotMatching(t *testing.T) {
+	for _, x := range []struct {
+		tag   string
+		query string
+	}{
+		// Name is different
+		{`#tag`, `#t-a-g`},
+		{`#tag`, `#tags`},
+
+		// Query has value, but base hasn’t
+		{`#tag`, `#tag=value`},
+
+		// Query value is different than base’s
+		{`#tag=value`, `#tag=VALUE`},
+		{`#tag=value`, `#tag=foo`},
+		{`#tag='V A L U E'`, `#tag='v a l u e'`},
+		{`#tag=''`, `#tag=' '`},
+	} {
+		first, err1 := NewTagFromString(x.tag)
+		require.Nil(t, err1)
+		second, err2 := NewTagFromString(x.query)
+		require.Nil(t, err2)
+		assert.False(t, first.Matches(second))
+	}
+}
+
+func TestPrecedingHashCharIsOptional(t *testing.T) {
+	tag, err := NewTagFromString("tag")
+	require.Nil(t, err)
+	assert.Equal(t, "tag", tag.Name())
+}
+
+func TestRejectsInvalidTags(t *testing.T) {
+	for _, name := range []string{
+		"",
+		"##tag",
+		"##tag",
+		"a#tag",
+		"a #tag",
+		"#tag#tag",
+		"#tag #tag",
+		"#t^a*g",
+		"#tag?",
+		"#tag:tag",
+		"#tag!!!",
+		"#t-a?g",
+		`#tag=foo=bar`,
+		`#tag='foo`,
+		`#tag='It's great'`,
+		`#tag="foo`,
+		`#tag="foo`,
+		`#tag="`,
+	} {
+		_, err := NewTagFromString(name)
+		require.Error(t, err)
+	}
+}
+
+func TestCreatesNewTagWithValue(t *testing.T) {
+	for _, x := range []struct {
+		tag         string
+		expectValue string
+	}{
+		{`#tag=value`, `value`},
+		{`#tag=VALUE`, `VALUE`},
+		{`#tag=V_A_L_U_E`, `V_A_L_U_E`},
+		{`#tag=v-a-l-u-e`, `v-a-l-u-e`},
+		{`#tag=v-a-l-u-e`, `v-a-l-u-e`},
+		{`#tag="v a l u e"`, `v a l u e`},
+		{`#tag='v!a?l,u=e'`, `v!a?l,u=e`},
+		{`#tag='foo=bar'`, `foo=bar`},
+	} {
+		tag, err := NewTagFromString(x.tag)
+		require.Nil(t, err)
+		assert.Equal(t, x.expectValue, tag.Value())
+	}
+}
+
+func TestSerialiseTag(t *testing.T) {
+	tagWithoutValue := NewTagOrPanic("test", "")
+	assert.Equal(t, "#test", tagWithoutValue.ToString())
+
+	tagWithValue := NewTagOrPanic("test", "value")
+	assert.Equal(t, "#test=value", tagWithValue.ToString())
+
+	tagWithValueNeedingQuoting := NewTagOrPanic("test", "v a l u e")
+	assert.Equal(t, `#test="v a l u e"`, tagWithValueNeedingQuoting.ToString())
+
+	tagWithValueContainingDoubleQuote := NewTagOrPanic("test", `It's great`)
+	assert.Equal(t, `#test="It's great"`, tagWithValueContainingDoubleQuote.ToString())
+
+	tagWithValueContainingSingleQuote := NewTagOrPanic("test", `5"`)
+	assert.Equal(t, `#test='5"'`, tagWithValueContainingSingleQuote.ToString())
+}


### PR DESCRIPTION
Resolves the CLI implementation of https://github.com/jotaen/klog/issues/169, the spec part is yet to be written.

Tags can now (optionally) have values assigned to them, e.g. `#tag=value`, `#ticket=163` or `#team="Super Heros"`.

If you consider this file:

```
2020-04-14
  1h30m Entry 1 #ticket=4
  2h15m Entry 2 #ticket=1

2020-04-16
#ticket
  6h Entry 3
```

Then filtering for…
- `--tag ticket` will match entries 1, 2, 3
- `--tag ticket=4` will only match entry 1
- `--tag ticket=8` won’t match anything

When listing all tags via `klog tags --values`, it outputs:

```
#ticket 9h45m      
 1            2h15m
 4            1h30m
```