### PR TITLE
Allow tags to have values

### DIFF
--- a/Specification.md
+++ b/Specification.md
@@ -97,25 +97,26 @@ The purpose of *tags* is to help categorise *records* and *entries*.
 Any amount of *tags* MAY appear anywhere within *summaries*.
 
 A *tag* MUST consist of a *tag name*,
-and MAY additionally consist of a *tag value*.
+which MUST be preceded by a single `#` character.
+The *tag name* MAY be followed by a `=` character
+and a *tag value*.
 
-The *tag name* MUST be preceded by a `#` character.
-It MUST only contain “letters”, “digits”, or the characters `_` or `-`.
-The *tag name* MUST be interpreted as if it was all lower-case.
+The *tag name* MUST only contain
+“letters”, “digits”, or the characters `_` or `-`.
+It MUST be interpreted as if it was all lower-case.
 
-The *tag value* MUST be separated by a `=` character from the *tag name*.
-It MAY be surrounded by a pair of matching quotes,
+The *tag value* MAY be surrounded by a pair of matching quotes,
 which MUST either be `"` (RECOMMENDED) or `'`.
 - If the *tag value* is quoted, it MAY contain any character
   except for the quote character itself,
   or a “newline”.
   In case no matching closing quote appears on the same line,
-  the *tag value* MUST be treated as absent altogether.
+  the *tag value* MUST be treated as absent.
 - If the *tag value* is not quoted, it MUST only contain
   “letters”, “digits”, or the characters `_` or `-`.
 
-An empty *tag value* (e.g. `#tag=`, or `#tag=""`)
-MUST be treated the same as an absent *tag value* (`#tag`).
+An empty *tag value* (e.g. `#tag=` or `#tag=""`)
+MUST be treated the same as an absent *tag value* (e.g. `#tag`).
 
 ### Entry
 *Entry* is an abstract term for time-related data.

--- a/Specification.md
+++ b/Specification.md
@@ -92,7 +92,7 @@ they also MUST NOT only consist of “blank characters”.
 #### Tag
 The purpose of *tags* is to help categorise *records* and *entries*.
 
-> Examples: `#gym`, `#24hours`, `#home-office`, `#読む`, `#ticket=891`, `#song="Yellow Submarine"`
+> Examples: `#gym`, `#home-office`, `#読む`, `#ticket=891`, `#project="22/48.3"`
 
 Any amount of *tags* MAY appear anywhere within *summaries*.
 
@@ -108,7 +108,7 @@ It MUST be interpreted as if it was all lower-case.
 The *tag value* MAY be surrounded by a pair of matching quotes,
 which MUST either be `"` (RECOMMENDED) or `'`.
 - If the *tag value* is quoted, it MAY contain any character
-  except for the quote character itself,
+  except for the respective quote character itself,
   or a “newline”.
   In case no matching closing quote appears on the same line,
   the *tag value* MUST be treated as absent.

--- a/Specification.md
+++ b/Specification.md
@@ -92,12 +92,30 @@ they also MUST NOT only consist of “blank characters”.
 #### Tag
 The purpose of *tags* is to help categorise *records* and *entries*.
 
-> Examples: `#gym`, `#24hours`, `#home-office`, `#読む`, `#ticket_127`
+> Examples: `#gym`, `#24hours`, `#home-office`, `#読む`, `#ticket=891`, `#song="Yellow Submarine"`
 
 Any amount of *tags* MAY appear anywhere within *summaries*.
 
-A *tag* MUST only contain “letters”, “digits”, or the characters `_` or `-`.
-It MUST be preceded by a single `#` character.
+A *tag* MUST consist of a *tag name*,
+and MAY additionally consist of a *tag value*.
+
+The *tag name* MUST be preceded by a `#` character.
+It MUST only contain “letters”, “digits”, or the characters `_` or `-`.
+The *tag name* MUST be interpreted as if it was all lower-case.
+
+The *tag value* MUST be separated by a `=` character from the *tag name*.
+It MAY be surrounded by a pair of matching quotes,
+which MUST either be `"` (RECOMMENDED) or `'`.
+- If the *tag value* is quoted, it MAY contain any character
+  except for the quote character itself,
+  or a “newline”.
+  In case no matching closing quote appears on the same line,
+  the *tag value* MUST be treated as absent altogether.
+- If the *tag value* is not quoted, it MUST only contain
+  “letters”, “digits”, or the characters `_` or `-`.
+
+An empty *tag value* (e.g. `#tag=`, or `#tag=""`)
+MUST be treated the same as an absent *tag value* (`#tag`).
 
 ### Entry
 *Entry* is an abstract term for time-related data.
@@ -226,12 +244,12 @@ There MAY exist multiple *records* with the same *date*.
 The file extension SHOULD be `.klg`, e.g. `times.klg`.
 The file encoding MUST be UTF-8.
 
-Newlines MUST be encoded with either the
+“Newlines” MUST be encoded with either the
 linefeed character (LF, escape sequence `\n`),
 or carriage return and linefeed character (CRLF, escape sequences `\r\n`).
 These two styles SHOULD NOT be mixed within the same file.
 
-There SHOULD be a newline at the end of the file.
+There SHOULD be a “newline” at the end of the file.
 
 ## III. Evaluating data
 
@@ -262,13 +280,14 @@ and MUST NOT be combined into a single *record*.
 ### Glossary of technical terms
 
 - “space”: The character ` ` (U+0020)
-- “tab”: The tab character (U+0009), escape sequence `\t`
+- “tab”: The tab character (U+0009, escape sequence `\t`)
 - “blank character”: A “tab”, or a character as defined by the Unicode Space Separator category (Zs)
 - “blank line”: A line that only contains “blank characters”
 - “parenthesis”: The opening and closing parentheses `(` and `)` (U+0028 and U+0029)
 - “letter”: A character as defined by the Unicode Letter category (L)
 - “digit”: Any of 0, 1, 2, 3, 4, 5, 6, 7, 8, 9
 - “integer”: An unsigned number without fractional component
+- “newline”: Either a linefeed (U+0010, escape sequence `\n`), or a carriage return and linefeed (U+0013 and U+0010, escape sequence `\r\n`)
 
 ### Changelog
 


### PR DESCRIPTION
Along with https://github.com/jotaen/klog/pull/180, resolves https://github.com/jotaen/klog/issues/169.

This change is backwards compatible, i.e. tags *without* values work the same as before.