### PR TITLE
Only support single `--date` filter

### DIFF
--- a/src/app/cli/lib/args.go
+++ b/src/app/cli/lib/args.go
@@ -90,8 +90,8 @@ func (args *NowArgs) Total(reference gotime.Time, rs ...Record) Duration {
 
 type FilterArgs struct {
 	// General filters
-	Tags   []Tag         `name:"tag" group:"Filter" help:"Records (or entries) that match this tag"`
-	Date   []Date        `name:"date" group:"Filter" help:"Records at this date"`
+	Tags   []Tag         `name:"tag" group:"Filter" help:"Records (or entries) that match these tags"`
+	Date   Date          `name:"date" group:"Filter" help:"Records at this date"`
 	Since  Date          `name:"since" group:"Filter" help:"Records since this date (inclusive)"`
 	Until  Date          `name:"until" group:"Filter" help:"Records until this date (inclusive)"`
 	After  Date          `name:"after" group:"Filter" help:"Records after this date (exclusive)"`
@@ -129,7 +129,7 @@ func (args *FilterArgs) ApplyFilter(now gotime.Time, rs []Record) []Record {
 		BeforeOrEqual: args.Until,
 		AfterOrEqual:  args.Since,
 		Tags:          args.Tags,
-		Dates:         args.Date,
+		AtDate:        args.Date,
 	}
 	if args.Period != nil {
 		qry.BeforeOrEqual = args.Period.Until()
@@ -142,13 +142,13 @@ func (args *FilterArgs) ApplyFilter(now gotime.Time, rs []Record) []Record {
 		qry.BeforeOrEqual = args.Before.PlusDays(-1)
 	}
 	if args.Today {
-		qry.Dates = append(qry.Dates, today)
+		qry.AtDate = today
 	}
 	if args.Yesterday {
-		qry.Dates = append(qry.Dates, today.PlusDays(-1))
+		qry.AtDate = today.PlusDays(-1)
 	}
 	if args.Tomorrow {
-		qry.Dates = append(qry.Dates, today.PlusDays(+1))
+		qry.AtDate = today.PlusDays(+1)
 	}
 	shortcutPeriod := func() period.Period {
 		if args.ThisWeek || args.ThisWeekAlias {

--- a/src/service/query.go
+++ b/src/service/query.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	. "github.com/jotaen/klog/src"
-	"github.com/jotaen/klog/src/service/period"
 	gosort "sort"
 )
 
@@ -11,16 +10,15 @@ type FilterQry struct {
 	Tags          []Tag
 	BeforeOrEqual Date
 	AfterOrEqual  Date
-	Dates         []Date
+	AtDate        Date
 }
 
 // Filter returns all records the matches the query.
 // A matching record must satisfy *all* query clauses.
 func Filter(rs []Record, o FilterQry) []Record {
-	dates := newDateSet(o.Dates)
 	var records []Record
 	for _, r := range rs {
-		if len(dates) > 0 && !dates[period.NewDayFromDate(r.Date()).Hash()] {
+		if o.AtDate != nil && !o.AtDate.IsEqualTo(r.Date()) {
 			continue
 		}
 		if o.BeforeOrEqual != nil && !o.BeforeOrEqual.IsAfterOrEqual(r.Date()) {
@@ -79,12 +77,4 @@ func isSubsetOf(queriedTags []Tag, allTags TagSet) bool {
 		}
 	}
 	return true
-}
-
-func newDateSet(ds []Date) map[period.DayHash]bool {
-	dict := make(map[period.DayHash]bool, len(ds))
-	for _, d := range ds {
-		dict[period.NewDayFromDate(d).Hash()] = true
-	}
-	return dict
 }

--- a/src/service/query_test.go
+++ b/src/service/query_test.go
@@ -45,6 +45,12 @@ func TestQueryWithNoClauses(t *testing.T) {
 	assert.Equal(t, NewDuration(5+6+7+8, -30+15), Total(rs...))
 }
 
+func TestQueryWithAtDate(t *testing.T) {
+	rs := Filter(sampleRecordsForQuerying(), FilterQry{AtDate: Ɀ_Date_(2000, 1, 2)})
+	require.Len(t, rs, 1)
+	assert.Equal(t, NewDuration(7, 0), Total(rs...))
+}
+
 func TestQueryWithAfter(t *testing.T) {
 	rs := Filter(sampleRecordsForQuerying(), FilterQry{AfterOrEqual: Ɀ_Date_(2000, 1, 1)})
 	require.Len(t, rs, 3)


### PR DESCRIPTION
This is a small fix that’s needed so that filtering follows a consistent system, which is that the filter flags are combined via a logical `AND`. E.g.

```
klog total --since 2020-04-01 --until 2020-04-30 --tag foo --tag bar`
```

would match all records in April 2020, that contain both tags `#foo` and `#bar`.

A specific date is necessarily exclusive, though, so it doesn’t make sense that multiple ones can be specified.