### PR TITLE
Refactor CLI query/filter mechanism

### DIFF
--- a/src/app/cli/lib/args.go
+++ b/src/app/cli/lib/args.go
@@ -123,67 +123,6 @@ type FilterArgs struct {
 	LastYearAlias    bool `name:"lastyear" hidden:""`
 }
 
-func flagWithValue(args []string) (string, string) {
-	if len(args) == 0 {
-		return "", ""
-	}
-	if len(args) == 1 {
-		return args[0], ""
-	}
-	return args[0], args[1]
-}
-
-//func applyRPNFilter(now gotime.Time, rs []Record) []Record {
-//	var stack []service.Matcher
-//	args := os.Args[2:]
-//
-//	kong.Scan(os.Args[2:]...)
-//
-//	for len(args) > 0 {
-//		flag, value := flagWithValue(args)
-//		switch flag {
-//		// TODO error messages if number of expected operands is invalid
-//		case "--date":
-//			date, _ := NewDateFromString(value)
-//			matcher := service.NewDateMatcher(date)
-//			stack = append(stack, matcher)
-//			args = args[2:]
-//		case "--tag":
-//			tag, _ := NewTagFromString(value)
-//			matcher := service.NewTagMatcher(tag)
-//			stack = append(stack, matcher)
-//			args = args[2:]
-//		case "--and":
-//			if len(stack) >= 2 {
-//				stack = append(stack[0:len(stack)-2], service.NewAndMatcher(stack[len(stack)-2], stack[len(stack)-1]))
-//			}
-//			args = args[1:]
-//		case "--or":
-//			if len(stack) >= 2 {
-//				stack = append(stack[0:len(stack)-2], service.NewOrMatcher(stack[len(stack)-2], stack[len(stack)-1]))
-//			}
-//			args = args[1:]
-//		case "--not":
-//			if len(stack) >= 1 {
-//				stack = append(stack[0:len(stack)-1], service.NewNotMatcher(stack[len(stack)-1]))
-//			}
-//			args = args[1:]
-//		default:
-//			args = args[1:]
-//		}
-//	}
-//
-//	matcher := service.NewIdentityMatcher()
-//	for len(stack) > 1 {
-//		stack = append(stack[0:len(stack)-2], service.NewAndMatcher(stack[len(stack)-2], stack[len(stack)-1]))
-//	}
-//	if len(stack) == 1 {
-//		matcher = stack[0]
-//	}
-//	fmt.Println(matcher.Explain())
-//	return service.Filter(matcher, rs)
-//}
-
 func (args *FilterArgs) ApplyFilter(now gotime.Time, rs []Record) []Record {
 	today := NewDateFromGo(now)
 	qry := service.Query{

--- a/src/app/cli/lib/args.go
+++ b/src/app/cli/lib/args.go
@@ -121,10 +121,72 @@ type FilterArgs struct {
 	ThisYearAlias    bool `name:"thisyear" hidden:""`
 	LastYear         bool `name:"last-year" hidden:""`
 	LastYearAlias    bool `name:"lastyear" hidden:""`
+
+	Forth bool `name:"forth" group:"Forth filters"` // TODO write help text
+	And   bool `name:"and" group:"Forth filters"`
+	Or    bool `name:"or" group:"Forth filters"`
+	Not   bool `name:"not" group:"Forth filters"`
+}
+
+func flagWithValue(args []string) (string, string) {
+	if len(args) == 0 {
+		return "", ""
+	}
+	if len(args) == 1 {
+		return args[0], ""
+	}
+	return args[0], args[1]
+}
+
+func applyForthFilter(now gotime.Time, rs []Record) []Record {
+	var stack []service.Matcher
+	args := os.Args[3:]
+
+	for len(args) > 0 {
+		flag, value := flagWithValue(args)
+		switch flag {
+		case "--date":
+			date, _ := NewDateFromString(value)
+			matcher := service.DateMatcher(date)
+			stack = append(stack, matcher)
+			args = args[2:]
+		case "--tag":
+			tag, _ := NewTagFromString(value)
+			matcher := service.TagMatcher(tag)
+			stack = append(stack, matcher)
+			args = args[2:]
+		case "--and":
+			if len(stack) >= 2 {
+				stack = append(stack[0:len(stack)-2], service.AndMatcher(stack[len(stack)-2], stack[len(stack)-1]))
+			}
+			args = args[1:]
+		case "--or":
+			if len(stack) >= 2 {
+				stack = append(stack[0:len(stack)-2], service.OrMatcher(stack[len(stack)-2], stack[len(stack)-1]))
+			}
+			args = args[1:]
+		case "--not":
+			if len(stack) >= 1 {
+				stack = append(stack[0:len(stack)-1], service.NotMatcher(stack[len(stack)-1]))
+			}
+			args = args[1:]
+		default:
+			args = args[1:]
+		}
+	}
+
+	matcher := service.IdentityMatcher
+	if len(stack) == 1 {
+		matcher = stack[0]
+	}
+	return service.ForthFilter(matcher, rs)
 }
 
 func (args *FilterArgs) ApplyFilter(now gotime.Time, rs []Record) []Record {
 	today := NewDateFromGo(now)
+	if args.Forth {
+		return applyForthFilter(now, rs)
+	}
 	qry := service.FilterQry{
 		BeforeOrEqual: args.Until,
 		AfterOrEqual:  args.Since,

--- a/src/app/cli/lib/args.go
+++ b/src/app/cli/lib/args.go
@@ -129,8 +129,11 @@ func (args *FilterArgs) ApplyFilter(now gotime.Time, rs []Record) []Record {
 		AtDate:   args.Date,
 		UpToDate: args.Until,
 		FromDate: args.Since,
-		InPeriod: args.Period,
+		InPeriod: nil,
 		WithTags: args.Tags,
+	}
+	if args.Period != nil {
+		qry.InPeriod = append(qry.InPeriod, args.Period)
 	}
 	if args.Before != nil {
 		qry.UpToDate = args.Before.PlusDays(-1)
@@ -147,36 +150,29 @@ func (args *FilterArgs) ApplyFilter(now gotime.Time, rs []Record) []Record {
 	if args.Tomorrow {
 		qry.AtDate = today.PlusDays(+1)
 	}
-	shortcutPeriod := func() period.Period {
-		if args.ThisWeek || args.ThisWeekAlias {
-			return period.NewWeekFromDate(today).Period()
-		}
-		if args.LastWeek || args.LastWeekAlias {
-			return period.NewWeekFromDate(today).Previous().Period()
-		}
-		if args.ThisMonth || args.ThisMonthAlias {
-			return period.NewMonthFromDate(today).Period()
-		}
-		if args.LastMonth || args.LastMonthAlias {
-			return period.NewMonthFromDate(today).Previous().Period()
-		}
-		if args.ThisQuarter || args.ThisQuarterAlias {
-			return period.NewQuarterFromDate(today).Period()
-		}
-		if args.LastQuarter || args.LastQuarterAlias {
-			return period.NewQuarterFromDate(today).Previous().Period()
-		}
-		if args.ThisYear || args.ThisYearAlias {
-			return period.NewYearFromDate(today).Period()
-		}
-		if args.LastYear || args.LastYearAlias {
-			return period.NewYearFromDate(today).Previous().Period()
-		}
-		return nil
-	}()
-	if shortcutPeriod != nil {
-		qry.UpToDate = shortcutPeriod.Until()
-		qry.FromDate = shortcutPeriod.Since()
+	if args.ThisWeek || args.ThisWeekAlias {
+		qry.InPeriod = append(qry.InPeriod, period.NewWeekFromDate(today).Period())
+	}
+	if args.LastWeek || args.LastWeekAlias {
+		qry.InPeriod = append(qry.InPeriod, period.NewWeekFromDate(today).Previous().Period())
+	}
+	if args.ThisMonth || args.ThisMonthAlias {
+		qry.InPeriod = append(qry.InPeriod, period.NewMonthFromDate(today).Period())
+	}
+	if args.LastMonth || args.LastMonthAlias {
+		qry.InPeriod = append(qry.InPeriod, period.NewMonthFromDate(today).Previous().Period())
+	}
+	if args.ThisQuarter || args.ThisQuarterAlias {
+		qry.InPeriod = append(qry.InPeriod, period.NewQuarterFromDate(today).Period())
+	}
+	if args.LastQuarter || args.LastQuarterAlias {
+		qry.InPeriod = append(qry.InPeriod, period.NewQuarterFromDate(today).Previous().Period())
+	}
+	if args.ThisYear || args.ThisYearAlias {
+		qry.InPeriod = append(qry.InPeriod, period.NewYearFromDate(today).Period())
+	}
+	if args.LastYear || args.LastYearAlias {
+		qry.InPeriod = append(qry.InPeriod, period.NewYearFromDate(today).Previous().Period())
 	}
 	return service.Filter(qry.ToMatcher(), rs)
 }

--- a/src/service/matcher.go
+++ b/src/service/matcher.go
@@ -1,0 +1,136 @@
+package service
+
+import (
+	. "github.com/jotaen/klog/src"
+	"github.com/jotaen/klog/src/service/period"
+)
+
+type Matcher interface {
+	Apply(Record) Record
+}
+
+type atDateMatcher struct {
+	date Date
+}
+
+func (m *atDateMatcher) Apply(r Record) Record {
+	if r.Date().IsEqualTo(m.date) {
+		return r
+	}
+	return nil
+}
+
+type upToDateMatcher struct {
+	date Date
+}
+
+func (m *upToDateMatcher) Apply(r Record) Record {
+	if m.date.IsAfterOrEqual(r.Date()) {
+		return r
+	}
+	return nil
+}
+
+type fromDateMatcher struct {
+	date Date
+}
+
+func (m *fromDateMatcher) Apply(r Record) Record {
+	if r.Date().IsAfterOrEqual(m.date) {
+		return r
+	}
+	return nil
+}
+
+type inPeriodMatcher struct {
+	period period.Period
+}
+
+func (m *inPeriodMatcher) Apply(r Record) Record {
+	if r.Date().IsAfterOrEqual(m.period.Since()) && m.period.Until().IsAfterOrEqual(r.Date()) {
+		return r
+	}
+	return nil
+}
+
+type tagMatcher struct {
+	tag Tag
+}
+
+func (m *tagMatcher) Apply(r Record) Record {
+	reducedR, hasMatched := reduceRecordToMatchingTags([]Tag{m.tag}, r)
+	if !hasMatched {
+		return nil
+	}
+	return reducedR
+}
+
+func reduceRecordToMatchingTags(queriedTags []Tag, r Record) (Record, bool) {
+	if isSubsetOf(queriedTags, r.Summary().Tags()) {
+		return r, true
+	}
+	var matchingEntries []Entry
+	for _, e := range r.Entries() {
+		allTags := Merge(r.Summary().Tags(), e.Summary().Tags())
+		if isSubsetOf(queriedTags, allTags) {
+			matchingEntries = append(matchingEntries, e)
+		}
+	}
+	if len(matchingEntries) == 0 {
+		return nil, false
+	}
+	r.SetEntries(matchingEntries)
+	return r, true
+}
+
+func isSubsetOf(queriedTags []Tag, allTags TagSet) bool {
+	for _, t := range queriedTags {
+		if !allTags.Contains(t) {
+			return false
+		}
+	}
+	return true
+}
+
+type andMatcher struct {
+	left  Matcher
+	right Matcher
+}
+
+func (m *andMatcher) Apply(r Record) Record {
+	r1 := m.left.Apply(r)
+	if r1 == nil {
+		return nil
+	}
+	return m.right.Apply(r1)
+}
+
+type orMatcher struct {
+	left  Matcher
+	right Matcher
+}
+
+func (m *orMatcher) Apply(r Record) Record {
+	r1 := m.left.Apply(r)
+	if r1 != nil {
+		return r1
+	}
+	return m.right.Apply(r)
+}
+
+type notMatcher struct {
+	matcher Matcher
+}
+
+func (m *notMatcher) Apply(r Record) Record {
+	if m.matcher.Apply(r) == nil {
+		return r
+	}
+	return nil
+}
+
+type identityMatcher struct{}
+
+func (m *identityMatcher) Apply(r Record) Record {
+	return r
+}

--- a/src/service/matcher.go
+++ b/src/service/matcher.go
@@ -105,6 +105,7 @@ func (m *andMatcher) Apply(r Record) Record {
 	return m.right.Apply(r1)
 }
 
+//lint:ignore U1000 Ignore unused code
 type orMatcher struct {
 	left  Matcher
 	right Matcher
@@ -118,6 +119,7 @@ func (m *orMatcher) Apply(r Record) Record {
 	return m.right.Apply(r)
 }
 
+//lint:ignore U1000 Ignore unused code
 type notMatcher struct {
 	matcher Matcher
 }

--- a/src/service/query.go
+++ b/src/service/query.go
@@ -22,7 +22,7 @@ type Query struct {
 	AtDate   Date
 	UpToDate Date
 	FromDate Date
-	InPeriod period.Period
+	InPeriod []period.Period
 	WithTags []Tag
 }
 
@@ -37,8 +37,8 @@ func (q *Query) ToMatcher() Matcher {
 	if q.FromDate != nil {
 		result = &andMatcher{result, &fromDateMatcher{q.FromDate}}
 	}
-	if q.InPeriod != nil {
-		result = &andMatcher{result, &inPeriodMatcher{q.InPeriod}}
+	for _, p := range q.InPeriod {
+		result = &andMatcher{result, &inPeriodMatcher{p}}
 	}
 	for _, t := range q.WithTags {
 		result = &andMatcher{result, &tagMatcher{t}}

--- a/src/service/query_test.go
+++ b/src/service/query_test.go
@@ -73,7 +73,7 @@ func TestQueryWithBefore(t *testing.T) {
 }
 
 func TestQueryInPeriod(t *testing.T) {
-	qry := Query{InPeriod: period.NewPeriod(Ɀ_Date_(2000, 1, 1), Ɀ_Date_(2000, 1, 31))}
+	qry := Query{InPeriod: []period.Period{period.NewPeriod(Ɀ_Date_(2000, 1, 1), Ɀ_Date_(2000, 1, 31))}}
 	rs := Filter(qry.ToMatcher(), sampleRecordsForQuerying())
 	require.Len(t, rs, 3)
 	assert.Equal(t, 1, rs[0].Date().Day())

--- a/src/service/sort.go
+++ b/src/service/sort.go
@@ -1,0 +1,19 @@
+package service
+
+import (
+	. "github.com/jotaen/klog/src"
+	"sort"
+)
+
+// Sort orders the records by date.
+func Sort(rs []Record, startWithOldest bool) []Record {
+	sorted := append([]Record(nil), rs...)
+	sort.Slice(sorted, func(i, j int) bool {
+		isLess := sorted[j].Date().IsAfterOrEqual(sorted[i].Date())
+		if !startWithOldest {
+			return !isLess
+		}
+		return isLess
+	})
+	return sorted
+}

--- a/src/service/sort_test.go
+++ b/src/service/sort_test.go
@@ -1,0 +1,22 @@
+package service
+
+import (
+	. "github.com/jotaen/klog/src"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSortRecordsByDate(t *testing.T) {
+	ss := sampleRecordsForQuerying()
+	for _, x := range []struct{ rs []Record }{
+		{ss},
+		{[]Record{ss[3], ss[1], ss[2], ss[0], ss[4]}},
+		{[]Record{ss[1], ss[4], ss[0], ss[3], ss[2]}},
+	} {
+		ascending := Sort(x.rs, true)
+		assert.Equal(t, []Record{ss[0], ss[1], ss[2], ss[3], ss[4]}, ascending)
+
+		descending := Sort(x.rs, false)
+		assert.Equal(t, []Record{ss[4], ss[3], ss[2], ss[1], ss[0]}, descending)
+	}
+}


### PR DESCRIPTION
This is a non-functional refactoring, which improves the filter/query mechanism of the CLI (e.g. `klog total --since 2022-04-15`).

- The queries are composed of individual matchers now, which will allow [for more complex query use-cases](https://github.com/jotaen/klog/discussions/190) in the future, like grouping/stacking filter expressions, or combining them via “or” or “not” instead of just “and”.
- Potentially redundant filter flags are interpreted strictly now. Before, when passing both `--since` and `--last-week`, the former was silently skipped. Now, all flags are respected.