### PR TITLE
Fix output when setting bookmark

### DIFF
--- a/src/app/cli/bookmarks.go
+++ b/src/app/cli/bookmarks.go
@@ -106,7 +106,9 @@ func (opt *BookmarksSet) Run(ctx app.Context) error {
 		}
 		return app.NewBookmark(opt.Name, file)
 	})()
+	didBookmarkAlreadyExist := false
 	mErr := ctx.ManipulateBookmarks(func(bc app.BookmarksCollection) app.Error {
+		didBookmarkAlreadyExist = bc.Get(bookmark.Name()) != nil
 		bc.Set(bookmark)
 		return nil
 	})
@@ -114,7 +116,11 @@ func (opt *BookmarksSet) Run(ctx app.Context) error {
 		return mErr
 	}
 	if !opt.Quiet {
-		ctx.Print("Created new bookmark:\n")
+		if didBookmarkAlreadyExist {
+			ctx.Print("Changed bookmark:\n")
+		} else {
+			ctx.Print("Created new bookmark:\n")
+		}
 	}
 	ctx.Print(bookmark.Name().ValuePretty() + " -> " + bookmark.Target().Path() + "\n")
 	return nil

--- a/src/app/cli/main/cli_test.go
+++ b/src/app/cli/main/cli_test.go
@@ -31,14 +31,21 @@ func TestBookmarkFile(t *testing.T) {
 	}
 	out := klog.run(
 		[]string{"bookmarks", "set", "test.klg", "tst"},
+		[]string{"bookmarks", "set", "test.klg", "tst"},
 		[]string{"bookmarks", "list"},
 		[]string{"total", "@tst"},
 	)
-	// Out 1 like: `@tst -> /tmp/.../test.klg`
+	// Out 0 like: `Created new bookmark`, `@tst -> /tmp/.../test.klg`
+	assert.True(t, strings.Contains(out[0], "Created new bookmark"), out)
+	assert.True(t, strings.Contains(out[0], "@tst"), out)
+	assert.True(t, strings.Contains(out[0], "test.klg"), out)
+	// Out 1 like: `Changed bookmark`, `@tst -> /tmp/.../test.klg`
+	assert.True(t, strings.Contains(out[1], "Changed bookmark"), out)
 	assert.True(t, strings.Contains(out[1], "@tst"), out)
-	assert.True(t, strings.Contains(out[1], "test.klg"), out)
-	// Out 2 like: `Total: 1h7m`
-	assert.True(t, strings.Contains(out[2], "1h7m"), out)
+	// Out 2 like: `@tst -> /tmp/.../test.klg`
+	assert.True(t, strings.Contains(out[2], "@tst"), out)
+	// Out 3 like: `Total: 1h7m`
+	assert.True(t, strings.Contains(out[3], "1h7m"), out)
 }
 
 func TestWriteToFile(t *testing.T) {


### PR DESCRIPTION
Tiny fix: when setting a bookmark, the output now differentiates between whether the bookmark was new or overriden.

```
$ klog bookmark set ~/foo.klg foo
Created new bookmark:
@foo -> ~/foo.klg

$ klog bookmark set ~/bar.klg foo
Changed bookmark:
@foo -> ~/bar.klg
```