### PR TITLE
Support `--now` on `klog tags` and improve error handling

### DIFF
--- a/src/app/cli/lib/args.go
+++ b/src/app/cli/lib/args.go
@@ -80,11 +80,11 @@ type NowArgs struct {
 	Now bool `name:"now" short:"n" help:"Assume open ranges to be closed at this moment"`
 }
 
-func (args *NowArgs) Total(reference gotime.Time, rs ...Record) Duration {
+func (args *NowArgs) ApplyNow(reference gotime.Time, rs ...Record) ([]Record, error) {
 	if args.Now {
-		return service.HypotheticalTotal(reference, rs...)
+		return service.CloseOpenRanges(reference, rs...)
 	}
-	return service.Total(rs...)
+	return rs, nil
 }
 
 type FilterArgs struct {

--- a/src/app/cli/lib/args.go
+++ b/src/app/cli/lib/args.go
@@ -82,7 +82,16 @@ type NowArgs struct {
 
 func (args *NowArgs) ApplyNow(reference gotime.Time, rs ...Record) ([]Record, error) {
 	if args.Now {
-		return service.CloseOpenRanges(reference, rs...)
+		rs, err := service.CloseOpenRanges(reference, rs...)
+		if err != nil {
+			return nil, app.NewErrorWithCode(
+				app.LOGICAL_ERROR,
+				"Cannot apply --now flag",
+				"There are records with uncloseable time ranges",
+				err,
+			)
+		}
+		return rs, nil
 	}
 	return rs, nil
 }

--- a/src/app/cli/lib/args.go
+++ b/src/app/cli/lib/args.go
@@ -82,8 +82,7 @@ type NowArgs struct {
 
 func (args *NowArgs) Total(reference gotime.Time, rs ...Record) Duration {
 	if args.Now {
-		d, _ := service.HypotheticalTotal(reference, rs...)
-		return d
+		return service.HypotheticalTotal(reference, rs...)
 	}
 	return service.Total(rs...)
 }

--- a/src/app/cli/report.go
+++ b/src/app/cli/report.go
@@ -33,6 +33,10 @@ func (opt *Report) Run(ctx app.Context) error {
 	}
 	now := ctx.Now()
 	records = opt.ApplyFilter(now, records)
+	records, nErr := opt.ApplyNow(now, records...)
+	if nErr != nil {
+		return nErr
+	}
 	records = service.Sort(records, true)
 	aggregator := opt.findAggregator()
 	recordGroups, dates := groupByDate(aggregator.DateHash, records)
@@ -74,7 +78,7 @@ func (opt *Report) Run(ctx app.Context) error {
 			continue
 		}
 
-		total := opt.NowArgs.Total(now, rs...)
+		total := service.Total(rs...)
 		table.CellR(ctx.Serialiser().Duration(total))
 
 		if opt.Diff {
@@ -90,7 +94,7 @@ func (opt *Report) Run(ctx app.Context) error {
 		table.Fill("=").Fill("=")
 	}
 	ctx.Print("\n")
-	grandTotal := opt.NowArgs.Total(now, records...)
+	grandTotal := service.Total(records...)
 
 	// Footer
 	table.Skip(aggregator.NumberOfPrefixColumns())

--- a/src/app/cli/tags.go
+++ b/src/app/cli/tags.go
@@ -11,6 +11,7 @@ type Tags struct {
 	Values bool `name:"values" short:"v" help:"Display breakdown of tag values"`
 	lib.FilterArgs
 	lib.WarnArgs
+	lib.NowArgs
 	lib.NoStyleArgs
 	lib.InputFilesArgs
 }
@@ -23,6 +24,10 @@ func (opt *Tags) Run(ctx app.Context) error {
 	}
 	now := ctx.Now()
 	records = opt.ApplyFilter(now, records)
+	records, nErr := opt.ApplyNow(now, records...)
+	if nErr != nil {
+		return nErr
+	}
 	totalByTag := service.AggregateTotalsByTags(records...)
 	if len(totalByTag) == 0 {
 		return nil

--- a/src/app/cli/today.go
+++ b/src/app/cli/today.go
@@ -173,11 +173,11 @@ func handle(opt *Today, ctx app.Context) error {
 }
 
 func (opt *Today) evaluate(now gotime.Time, records []Record) (Duration, Duration, Duration) {
-	total, _ := func() (Duration, bool) {
+	total := func() Duration {
 		if opt.Now {
 			return service.HypotheticalTotal(now, records...)
 		}
-		return service.Total(records...), false
+		return service.Total(records...)
 	}()
 	shouldTotal := service.ShouldTotalSum(records...)
 	diff := service.Diff(shouldTotal, total)

--- a/src/app/cli/total.go
+++ b/src/app/cli/total.go
@@ -32,7 +32,11 @@ func (opt *Total) Run(ctx app.Context) error {
 	}
 	now := ctx.Now()
 	records = opt.ApplyFilter(now, records)
-	total := opt.NowArgs.Total(now, records...)
+	records, nErr := opt.ApplyNow(now, records...)
+	if nErr != nil {
+		return nErr
+	}
+	total := service.Total(records...)
 	ctx.Print(fmt.Sprintf("Total: %s\n", ctx.Serialiser().Duration(total)))
 	if opt.Diff {
 		should := service.ShouldTotalSum(records...)

--- a/src/app/cli/total_test.go
+++ b/src/app/cli/total_test.go
@@ -40,3 +40,26 @@ func TestTotalWithDiffing(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, "\nTotal: 16h30m\nShould: 15h45m!\nDiff: +45m\n(In 2 records)\n", state.printBuffer)
 }
+
+func TestTotalWithNow(t *testing.T) {
+	state, err := NewTestingContext()._SetRecords(`
+2018-11-08 (8h!)
+	8h30m
+
+2018-11-09 (7h45m!)
+	8:00 - ?
+`)._SetNow(2018, 11, 9, 8, 30)._Run((&Total{NowArgs: lib.NowArgs{Now: true}}).Run)
+	require.Nil(t, err)
+	assert.Equal(t, "\nTotal: 9h\n(In 2 records)\n", state.printBuffer)
+}
+
+func TestTotalWithNowUncloseable(t *testing.T) {
+	_, err := NewTestingContext()._SetRecords(`
+2018-11-08 (8h!)
+	8h30m
+
+2018-11-09 (7h45m!)
+	8:00 - ?
+`)._SetNow(2018, 13, 9, 8, 30)._Run((&Total{NowArgs: lib.NowArgs{Now: true}}).Run)
+	require.Error(t, err)
+}

--- a/src/service/evaluate.go
+++ b/src/service/evaluate.go
@@ -19,9 +19,8 @@ func Total(rs ...Record) Duration {
 
 // HypotheticalTotal calculates the overall total time of records,
 // assuming all open ranges would be closed at the `until` time.
-func HypotheticalTotal(until gotime.Time, rs ...Record) (Duration, bool) {
+func HypotheticalTotal(until gotime.Time, rs ...Record) Duration {
 	total := NewDuration(0, 0)
-	isCurrent := false
 	thisDay := NewDateFromGo(until)
 	theDayBefore := thisDay.PlusDays(-1)
 	for _, r := range rs {
@@ -39,7 +38,6 @@ func HypotheticalTotal(until gotime.Time, rs ...Record) (Duration, bool) {
 					}
 					tr, err := NewRange(o.Start(), end)
 					if err == nil {
-						isCurrent = true
 						return tr.Duration()
 					}
 					return NewDuration(0, 0)
@@ -47,7 +45,7 @@ func HypotheticalTotal(until gotime.Time, rs ...Record) (Duration, bool) {
 			total = total.Plus(t)
 		}
 	}
-	return total, isCurrent
+	return total
 }
 
 // ShouldTotalSum calculates the overall should-total time of records.

--- a/src/service/evaluate.go
+++ b/src/service/evaluate.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	. "github.com/jotaen/klog/src"
-	gotime "time"
 )
 
 // Total calculates the overall time spent in records.
@@ -12,37 +11,6 @@ func Total(rs ...Record) Duration {
 	for _, r := range rs {
 		for _, e := range r.Entries() {
 			total = total.Plus(e.Duration())
-		}
-	}
-	return total
-}
-
-// HypotheticalTotal calculates the overall total time of records,
-// assuming all open ranges would be closed at the `until` time.
-func HypotheticalTotal(until gotime.Time, rs ...Record) Duration {
-	total := NewDuration(0, 0)
-	thisDay := NewDateFromGo(until)
-	theDayBefore := thisDay.PlusDays(-1)
-	for _, r := range rs {
-		for _, e := range r.Entries() {
-			t := Unbox[Duration](&e,
-				func(r Range) Duration { return r.Duration() },
-				func(d Duration) Duration { return d },
-				func(o OpenRange) Duration {
-					if !(r.Date().IsEqualTo(thisDay) || r.Date().IsEqualTo(theDayBefore)) {
-						return NewDuration(0, 0)
-					}
-					end := NewTimeFromGo(until)
-					if r.Date().IsEqualTo(theDayBefore) {
-						end, _ = NewTimeTomorrow(end.Hour(), end.Minute())
-					}
-					tr, err := NewRange(o.Start(), end)
-					if err == nil {
-						return tr.Duration()
-					}
-					return NewDuration(0, 0)
-				})
-			total = total.Plus(t)
 		}
 	}
 	return total

--- a/src/service/evaluate_test.go
+++ b/src/service/evaluate_test.go
@@ -4,7 +4,6 @@ import (
 	. "github.com/jotaen/klog/src"
 	"github.com/stretchr/testify/assert"
 	"testing"
-	gotime "time"
 )
 
 func TestTotalSumUpZeroIfNoTimesSpecified(t *testing.T) {
@@ -22,23 +21,4 @@ func TestTotalSumsUpTimesAndRangesButNotOpenRanges(t *testing.T) {
 	r2 := NewRecord(Ɀ_Date_(2020, 1, 2))
 	r2.AddDuration(NewDuration(7, 55), nil)
 	assert.Equal(t, NewDuration(3+1+(16+24+12)+3+7, 33+11+12+55), Total(r1, r2))
-}
-
-func TestSumUpHypotheticalTotalAtGivenTime(t *testing.T) {
-	r := NewRecord(Ɀ_Date_(2020, 1, 1))
-	r.AddDuration(NewDuration(2, 14), nil)
-	r.AddRange(Ɀ_Range_(Ɀ_TimeYesterday_(23, 0), Ɀ_Time_(4, 0)), nil)
-	_ = r.StartOpenRange(Ɀ_Time_(5, 7), nil)
-
-	time1, _ := gotime.Parse("2006-01-02T15:04:05-0700", "2020-01-01T05:06:59-0000")
-	ht1 := HypotheticalTotal(time1, r)
-	assert.Equal(t, NewDuration(2+(1+4), 14), ht1)
-
-	time2, _ := gotime.Parse("2006-01-02T15:04:05-0700", "2020-01-01T10:48:13-0000")
-	ht2 := HypotheticalTotal(time2, r)
-	assert.Equal(t, NewDuration(2+(1+4)+4, 14+53+48), ht2)
-
-	time3, _ := gotime.Parse("2006-01-02T15:04:05-0700", "2020-01-02T03:01:29-0000")
-	ht3 := HypotheticalTotal(time3, r)
-	assert.Equal(t, NewDuration(2+(1+4)+18+3, 14+53+1), ht3)
 }

--- a/src/service/evaluate_test.go
+++ b/src/service/evaluate_test.go
@@ -31,17 +31,14 @@ func TestSumUpHypotheticalTotalAtGivenTime(t *testing.T) {
 	_ = r.StartOpenRange(Ɀ_Time_(5, 7), nil)
 
 	time1, _ := gotime.Parse("2006-01-02T15:04:05-0700", "2020-01-01T05:06:59-0000")
-	ht1, isOngoing1 := HypotheticalTotal(time1, r)
-	assert.False(t, isOngoing1)
+	ht1 := HypotheticalTotal(time1, r)
 	assert.Equal(t, NewDuration(2+(1+4), 14), ht1)
 
 	time2, _ := gotime.Parse("2006-01-02T15:04:05-0700", "2020-01-01T10:48:13-0000")
-	ht2, isOngoing2 := HypotheticalTotal(time2, r)
-	assert.True(t, isOngoing2)
+	ht2 := HypotheticalTotal(time2, r)
 	assert.Equal(t, NewDuration(2+(1+4)+4, 14+53+48), ht2)
 
 	time3, _ := gotime.Parse("2006-01-02T15:04:05-0700", "2020-01-02T03:01:29-0000")
-	ht3, isOngoing3 := HypotheticalTotal(time3, r)
-	assert.True(t, isOngoing3)
+	ht3 := HypotheticalTotal(time3, r)
 	assert.Equal(t, NewDuration(2+(1+4)+18+3, 14+53+1), ht3)
 }

--- a/src/service/record.go
+++ b/src/service/record.go
@@ -1,0 +1,38 @@
+package service
+
+import (
+	"errors"
+	. "github.com/jotaen/klog/src"
+	gotime "time"
+)
+
+// CloseOpenRanges closes open ranges at the time of `endTime`. Returns an error
+// if a range is not closeable at that point in time.
+// This method alters the provided records!
+func CloseOpenRanges(endTime gotime.Time, rs ...Record) ([]Record, error) {
+	thisDay := NewDateFromGo(endTime)
+	theDayBefore := thisDay.PlusDays(-1)
+	for _, r := range rs {
+		if r.OpenRange() == nil {
+			continue
+		}
+		end, tErr := func() (Time, error) {
+			end := NewTimeFromGo(endTime)
+			if r.Date().IsEqualTo(thisDay) {
+				return end, nil
+			}
+			if r.Date().IsEqualTo(theDayBefore) {
+				return end.Plus(NewDuration(24, 0))
+			}
+			return nil, errors.New("Encountered uncloseable open range")
+		}()
+		if tErr != nil {
+			return nil, tErr
+		}
+		eErr := r.EndOpenRange(end)
+		if eErr != nil {
+			return nil, errors.New("Encountered uncloseable open range")
+		}
+	}
+	return rs, nil
+}

--- a/src/service/record_test.go
+++ b/src/service/record_test.go
@@ -1,0 +1,67 @@
+package service
+
+import (
+	. "github.com/jotaen/klog/src"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	gotime "time"
+)
+
+func TestReturnsOriginalRecordsIfNoOpenRange(t *testing.T) {
+	r := NewRecord(Ɀ_Date_(2020, 1, 1))
+	r.AddDuration(NewDuration(1, 0), nil)
+	r.AddRange(Ɀ_Range_(Ɀ_Time_(1, 0), Ɀ_Time_(2, 0)), nil)
+
+	result, err := CloseOpenRanges(gotime.Now(), r)
+	require.Nil(t, err)
+	assert.Equal(t, NewDuration(2, 0), Total(result...))
+}
+
+func TestReturnsRecordsWithClosedOpenRange(t *testing.T) {
+	r := NewRecord(Ɀ_Date_(2020, 1, 1))
+	r.AddDuration(NewDuration(1, 0), nil)
+	r.AddRange(Ɀ_Range_(Ɀ_Time_(1, 0), Ɀ_Time_(2, 0)), nil)
+	r.StartOpenRange(Ɀ_Time_(3, 0), nil)
+
+	endTime, _ := gotime.Parse("2006-01-02T15:04:05-0700", "2020-01-01T05:30:00-0000")
+	result, err := CloseOpenRanges(endTime, r)
+	require.Nil(t, err)
+	assert.Equal(t, NewDuration(2+2, 30), Total(result...))
+}
+
+func TestReturnsRecordsWithClosedOpenRangeAndShiftedTime(t *testing.T) {
+	r := NewRecord(Ɀ_Date_(2020, 1, 1))
+	r.AddDuration(NewDuration(1, 0), nil)
+	r.AddRange(Ɀ_Range_(Ɀ_Time_(1, 0), Ɀ_Time_(2, 0)), nil)
+	r.StartOpenRange(Ɀ_Time_(3, 0), nil)
+
+	endTime, _ := gotime.Parse("2006-01-02T15:04:05-0700", "2020-01-02T05:30:00-0000")
+	result, err := CloseOpenRanges(endTime, r)
+	require.Nil(t, err)
+	assert.Equal(t, NewDuration(2+24+2, 30), Total(result...))
+}
+
+func TestReturnsErrorIfOpenRangeCannotBeClosedAnymore(t *testing.T) {
+	r := NewRecord(Ɀ_Date_(2020, 1, 1))
+	r.AddDuration(NewDuration(1, 0), nil)
+	r.AddRange(Ɀ_Range_(Ɀ_Time_(1, 0), Ɀ_Time_(2, 0)), nil)
+	r.StartOpenRange(Ɀ_Time_(3, 0), nil)
+
+	endTime, _ := gotime.Parse("2006-01-02T15:04:05-0700", "2020-01-03T05:30:00-0000")
+	result, err := CloseOpenRanges(endTime, r)
+	require.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestReturnsErrorIfOpenRangeCannotBeClosedYet(t *testing.T) {
+	r := NewRecord(Ɀ_Date_(2020, 1, 1))
+	r.AddDuration(NewDuration(1, 0), nil)
+	r.AddRange(Ɀ_Range_(Ɀ_Time_(1, 0), Ɀ_Time_(2, 0)), nil)
+	r.StartOpenRange(Ɀ_Time_(3, 0), nil)
+
+	endTime, _ := gotime.Parse("2006-01-02T15:04:05-0700", "2020-01-01T01:30:00-0000")
+	result, err := CloseOpenRanges(endTime, r)
+	require.Error(t, err)
+	assert.Nil(t, result)
+}


### PR DESCRIPTION
Fixes https://github.com/jotaen/klog/issues/196.

The `--now` flag is now available for `klog tags` as well.

Also, the error handling is improved now: previously, it would just ignore uncloseable time ranges, i.e. when the record’s date was before yesterday, so that the open range cannot be closed with a shifted time anymore. Now, all commands that consume `--now` will raise an error in that case.