### PR TITLE
Support setting a summary when creating a record (via `klog create --summary`)

### DIFF
--- a/src/app/cli/create.go
+++ b/src/app/cli/create.go
@@ -10,6 +10,7 @@ import (
 
 type Create struct {
 	ShouldTotal ShouldTotal `name:"should" help:"The should-total of the record"`
+	Summary     string      `name:"summary" short:"s" help:"Summary text for the new record"`
 	lib.AtDateArgs
 	lib.NoStyleArgs
 	lib.OutputFileArgs
@@ -27,7 +28,7 @@ func (opt *Create) Run(ctx app.Context) error {
 	return lib.Reconcile(ctx, lib.ReconcileOpts{OutputFileArgs: opt.OutputFileArgs, WarnArgs: opt.WarnArgs},
 		[]reconciling.Creator{
 			func(parsedRecords []parser.ParsedRecord) *reconciling.Reconciler {
-				return reconciling.NewReconcilerForNewRecord(parsedRecords, date, opt.ShouldTotal)
+				return reconciling.NewReconcilerForNewRecord(parsedRecords, reconciling.RecordParams{Date: date, ShouldTotal: opt.ShouldTotal})
 			},
 		},
 

--- a/src/app/cli/create.go
+++ b/src/app/cli/create.go
@@ -9,8 +9,8 @@ import (
 )
 
 type Create struct {
-	ShouldTotal ShouldTotal `name:"should" help:"The should-total of the record"`
-	Summary     string      `name:"summary" short:"s" help:"Summary text for the new record"`
+	ShouldTotal ShouldTotal   `name:"should" help:"The should-total of the record"`
+	Summary     RecordSummary `name:"summary" short:"s" help:"Summary text for the new record"`
 	lib.AtDateArgs
 	lib.NoStyleArgs
 	lib.OutputFileArgs
@@ -28,7 +28,10 @@ func (opt *Create) Run(ctx app.Context) error {
 	return lib.Reconcile(ctx, lib.ReconcileOpts{OutputFileArgs: opt.OutputFileArgs, WarnArgs: opt.WarnArgs},
 		[]reconciling.Creator{
 			func(parsedRecords []parser.ParsedRecord) *reconciling.Reconciler {
-				return reconciling.NewReconcilerForNewRecord(parsedRecords, reconciling.RecordParams{Date: date, ShouldTotal: opt.ShouldTotal})
+				return reconciling.NewReconcilerForNewRecord(
+					parsedRecords,
+					reconciling.RecordParams{Date: date, ShouldTotal: opt.ShouldTotal, Summary: opt.Summary},
+				)
 			},
 		},
 

--- a/src/app/cli/create_test.go
+++ b/src/app/cli/create_test.go
@@ -40,6 +40,7 @@ func TestCreateWithValues(t *testing.T) {
 `)._Run((&Create{
 		AtDateArgs:  lib.AtDateArgs{Date: klog.Ɀ_Date_(1976, 1, 2)},
 		ShouldTotal: klog.NewShouldTotal(5, 55),
+		Summary:     klog.Ɀ_RecordSummary_("This is a", "new record!"),
 	}).Run)
 	require.Nil(t, err)
 	assert.Equal(t, `
@@ -52,5 +53,7 @@ func TestCreateWithValues(t *testing.T) {
 	1h
 
 1976-01-02 (5h55m!)
+This is a
+new record!
 `, state.writtenFileContents)
 }

--- a/src/app/cli/main/cli.go
+++ b/src/app/cli/main/cli.go
@@ -46,6 +46,10 @@ func Run(homeDir string, meta app.Meta, isDebug bool, args []string) (int, error
 			t := klog.NewTagOrPanic("test", "")
 			return kong.TypeMapper(reflect.TypeOf(&t).Elem(), tagDecoder())
 		}(),
+		func() kong.Option {
+			s, _ := klog.NewRecordSummary("test")
+			return kong.TypeMapper(reflect.TypeOf(&s).Elem(), recordSummaryDecoder())
+		}(),
 		kong.ConfigureHelp(kong.HelpOptions{
 			Compact: true,
 		}),

--- a/src/app/cli/main/cli_test.go
+++ b/src/app/cli/main/cli_test.go
@@ -162,3 +162,21 @@ func TestDecodesTags(t *testing.T) {
 	assert.True(t, strings.Contains(out[3], "#bar=1"), out)
 	assert.True(t, strings.Contains(out[4], "#bar=1"), out)
 }
+
+func TestDecodesRecordSummary(t *testing.T) {
+	klog := &Env{
+		files: map[string]string{
+			"test.klg": "2020-01-01\nTest.",
+		},
+	}
+	out := klog.run(
+		[]string{"create", "--summary", "Foo", "test.klg"},
+		[]string{"create", "--summary", "Foo\nBar", "test.klg"},
+		[]string{"create", "--summary", "Foo\n\nBar", "test.klg"},
+		[]string{"create", "--summary", "Foo\n Bar", "test.klg"},
+	)
+	assert.True(t, strings.Contains(out[0], "Foo"), out)
+	assert.True(t, strings.Contains(out[1], "Foo\nBar"), out)
+	assert.True(t, strings.Contains(out[2], "A record summary cannot contain blank lines"), out)
+	assert.True(t, strings.Contains(out[3], "A record summary cannot contain blank lines"), out)
+}

--- a/src/app/cli/main/decoder.go
+++ b/src/app/cli/main/decoder.go
@@ -119,3 +119,21 @@ func tagDecoder() kong.MapperFunc {
 		return nil
 	}
 }
+
+func recordSummaryDecoder() kong.MapperFunc {
+	return func(ctx *kong.DecodeContext, target reflect.Value) error {
+		var value string
+		if err := ctx.Scan.PopValueInto("recordSummary", &value); err != nil {
+			return err
+		}
+		if value == "" {
+			return errors.New("Please provide a valid record summary")
+		}
+		summary, sErr := klog.NewRecordSummary(strings.Split(value, "\n")...)
+		if sErr != nil {
+			return errors.New("A record summary cannot contain blank lines, and none of its lines can start with whitespace characters")
+		}
+		target.Set(reflect.ValueOf(summary))
+		return nil
+	}
+}

--- a/src/app/cli/start.go
+++ b/src/app/cli/start.go
@@ -34,7 +34,7 @@ func (opt *Start) Run(ctx app.Context) error {
 				return reconciling.NewReconcilerAtRecord(parsedRecords, date)
 			},
 			func(parsedRecords []parser.ParsedRecord) *reconciling.Reconciler {
-				return reconciling.NewReconcilerForNewRecord(parsedRecords, date, nil)
+				return reconciling.NewReconcilerForNewRecord(parsedRecords, reconciling.RecordParams{Date: date})
 			},
 		},
 

--- a/src/app/cli/track.go
+++ b/src/app/cli/track.go
@@ -36,7 +36,7 @@ func (opt *Track) Run(ctx app.Context) error {
 				return reconciling.NewReconcilerAtRecord(parsedRecords, date)
 			},
 			func(parsedRecords []parser.ParsedRecord) *reconciling.Reconciler {
-				return reconciling.NewReconcilerForNewRecord(parsedRecords, date, nil)
+				return reconciling.NewReconcilerForNewRecord(parsedRecords, reconciling.RecordParams{Date: date})
 			},
 		},
 

--- a/src/parser/reconciling/creator_test.go
+++ b/src/parser/reconciling/creator_test.go
@@ -52,7 +52,7 @@ func TestReconcilerRespectsLineEndingStyle(t *testing.T) {
 
 func TestReconcileAddRecordIfOriginalIsEmpty(t *testing.T) {
 	rs, _ := parser.Parse("")
-	reconciler := NewReconcilerForNewRecord(rs, Ɀ_Date_(2000, 5, 5), nil)
+	reconciler := NewReconcilerForNewRecord(rs, RecordParams{Date: Ɀ_Date_(2000, 5, 5)})
 	result, err := reconciler.MakeResult()
 	require.Nil(t, err)
 	assert.Equal(t, "2000-05-05\n", result.AllSerialised)
@@ -61,7 +61,7 @@ func TestReconcileAddRecordIfOriginalIsEmpty(t *testing.T) {
 
 func TestReconcileAddRecordIfOriginalContainsOneRecord(t *testing.T) {
 	rs, _ := parser.Parse("1999-12-31")
-	reconciler := NewReconcilerForNewRecord(rs, Ɀ_Date_(2000, 2, 1), nil)
+	reconciler := NewReconcilerForNewRecord(rs, RecordParams{Date: Ɀ_Date_(2000, 2, 1)})
 	result, err := reconciler.MakeResult()
 	require.Nil(t, err)
 	assert.Equal(t, "1999-12-31\n\n2000-02-01\n", result.AllSerialised)
@@ -79,7 +79,7 @@ func TestReconcileNewRecordFromEmptyFile(t *testing.T) {
 		{"\n\n     \t\n \t     \n  "},
 	} {
 		rs, _ := parser.Parse(x.original)
-		reconciler := NewReconcilerForNewRecord(rs, Ɀ_Date_(1995, 3, 17), nil)
+		reconciler := NewReconcilerForNewRecord(rs, RecordParams{Date: Ɀ_Date_(1995, 3, 17)})
 		result, err := reconciler.MakeResult()
 		require.Nil(t, err)
 		assert.Equal(t, "1995-03-17\n", result.AllSerialised)
@@ -98,7 +98,7 @@ func TestReconcilePrependNewRecord(t *testing.T) {
 		{"\n\n2018-01-02\n", "2018-01-01\n\n\n\n2018-01-02\n"},
 	} {
 		rs, _ := parser.Parse(x.original)
-		reconciler := NewReconcilerForNewRecord(rs, Ɀ_Date_(2018, 1, 1), nil)
+		reconciler := NewReconcilerForNewRecord(rs, RecordParams{Date: Ɀ_Date_(2018, 1, 1)})
 		result, err := reconciler.MakeResult()
 		require.Nil(t, err)
 		assert.Equal(t, x.expected, result.AllSerialised)
@@ -115,7 +115,7 @@ func TestReconcileAppendNewRecord(t *testing.T) {
 		{"\n\n2018-01-01\n", "\n\n2018-01-01\n\n2019-01-01\n"},
 	} {
 		rs, _ := parser.Parse(x.original)
-		reconciler := NewReconcilerForNewRecord(rs, Ɀ_Date_(2019, 1, 1), nil)
+		reconciler := NewReconcilerForNewRecord(rs, RecordParams{Date: Ɀ_Date_(2019, 1, 1)})
 		result, err := reconciler.MakeResult()
 		require.Nil(t, err)
 		assert.Equal(t, x.expected, result.AllSerialised)
@@ -132,7 +132,7 @@ func TestReconcileAddBlockInBetween(t *testing.T) {
 		{"2018-01-02\n\t1h\n\n2018-01-03", "2018-01-02\n\t1h\n\n2018-01-02\n\n2018-01-03"},
 	} {
 		rs, _ := parser.Parse(x.original)
-		reconciler := NewReconcilerForNewRecord(rs, Ɀ_Date_(2018, 1, 2), nil)
+		reconciler := NewReconcilerForNewRecord(rs, RecordParams{Date: Ɀ_Date_(2018, 1, 2)})
 		result, err := reconciler.MakeResult()
 		require.Nil(t, err)
 		assert.Equal(t, x.expected, result.AllSerialised)
@@ -144,7 +144,7 @@ func TestReconcileAddRecordWithShouldTotal(t *testing.T) {
 2018-01-01
     1h`
 	rs, _ := parser.Parse(original)
-	reconciler := NewReconcilerForNewRecord(rs, Ɀ_Date_(2018, 1, 2), NewShouldTotal(5, 31))
+	reconciler := NewReconcilerForNewRecord(rs, RecordParams{Date: Ɀ_Date_(2018, 1, 2), ShouldTotal: NewShouldTotal(5, 31)})
 	result, err := reconciler.MakeResult()
 	require.Nil(t, err)
 	assert.Equal(t, `
@@ -165,7 +165,7 @@ func TestReconcileRespectsExistingStylePref(t *testing.T) {
 		{"3145/06/14\n\n3145/06/15\n\n3145-06-15\n", "3145/06/14\n\n3145/06/15\n\n3145-06-15\n\n3145/06/16\n"},
 	} {
 		rs, _ := parser.Parse(x.original)
-		reconciler := NewReconcilerForNewRecord(rs, Ɀ_Date_(3145, 6, 16), nil)
+		reconciler := NewReconcilerForNewRecord(rs, RecordParams{Date: Ɀ_Date_(3145, 6, 16)})
 		result, err := reconciler.MakeResult()
 		require.Nil(t, err)
 		assert.Equal(t, x.expected, result.AllSerialised)

--- a/src/parser/reconciling/creator_test.go
+++ b/src/parser/reconciling/creator_test.go
@@ -156,6 +156,26 @@ func TestReconcileAddRecordWithShouldTotal(t *testing.T) {
 	assert.Equal(t, NewShouldTotal(5, 31), result.Record.ShouldTotal())
 }
 
+func TestReconcileAddRecordWithSummary(t *testing.T) {
+	original := `
+2018-01-01
+    1h`
+	rs, _ := parser.Parse(original)
+	summary := Ɀ_RecordSummary_("This is a new record.", "It has a summary.")
+	reconciler := NewReconcilerForNewRecord(rs, RecordParams{Date: Ɀ_Date_(2018, 1, 2), Summary: summary})
+	result, err := reconciler.MakeResult()
+	require.Nil(t, err)
+	assert.Equal(t, `
+2018-01-01
+    1h
+
+2018-01-02
+This is a new record.
+It has a summary.
+`, result.AllSerialised)
+	assert.Equal(t, result.Record.Summary(), summary)
+}
+
 func TestReconcileRespectsExistingStylePref(t *testing.T) {
 	for _, x := range []struct {
 		original string


### PR DESCRIPTION
Fixes https://github.com/jotaen/klog/issues/195.

Examples:

- `klog create --summary 'Test record' file.klg`
- `klog create --summary 'Test record\nwith multiple\nsummary lines' file.klg`