### PR TITLE
Fix command argument splitting to parse quoted arguments

### DIFF
--- a/src/app/context.go
+++ b/src/app/context.go
@@ -355,6 +355,8 @@ func tryCommands(commands []string, additionalArg string) bool {
 		err := cmd.Run()
 		if err == nil {
 			return true
+		} else {
+			fmt.Println(err)
 		}
 	}
 	return false

--- a/src/app/sys_darwin.go
+++ b/src/app/sys_darwin.go
@@ -2,9 +2,9 @@
 
 package app
 
-var POTENTIAL_EDITORS = []string{"vim", "vi", "nano", "pico", "open -a TextEdit"}
+var POTENTIAL_EDITORS = [][]string{{"vim"}, {"vi"}, {"nano"}, {"pico"}, {"open", "-a", "TextEdit"}}
 
-var POTENTIAL_FILE_EXLORERS = []string{"open"}
+var POTENTIAL_FILE_EXLORERS = [][]string{{"open"}}
 
 func flagAsHidden(path string) {
 	// Nothing to do on UNIX due to the dotfile convention

--- a/src/app/sys_linux.go
+++ b/src/app/sys_linux.go
@@ -2,9 +2,9 @@
 
 package app
 
-var POTENTIAL_EDITORS = []string{"vim", "vi", "nano", "pico"}
+var POTENTIAL_EDITORS = [][]string{{"vim"}, {"vi"}, {"nano"}, {"pico"}}
 
-var POTENTIAL_FILE_EXLORERS = []string{"xdg-open"}
+var POTENTIAL_FILE_EXLORERS = [][]string{{"xdg-open"}}
 
 func flagAsHidden(path string) {
 	// Nothing to do on UNIX due to the dotfile convention

--- a/src/app/sys_windows.go
+++ b/src/app/sys_windows.go
@@ -8,9 +8,9 @@ import (
 	"unsafe"
 )
 
-var POTENTIAL_EDITORS = []string{"notepad"}
+var POTENTIAL_EDITORS = [][]string{{"notepad"}}
 
-var POTENTIAL_FILE_EXLORERS = []string{"cmd.exe /C start"}
+var POTENTIAL_FILE_EXLORERS = [][]string{{"cmd.exe", "/C", "start"}}
 
 func flagAsHidden(path string) {
 	winFileName, err := syscall.UTF16PtrFromString(path)


### PR DESCRIPTION
I wrote a simple parse function to split arguments. The parser allows multiple spaces between arguments and can parse quoted arguments. The function also removed the quotes from the first argument as it is expected to be the executable.

I also made it so `tryCommands` logs all errors from failed commands.

Tell me if there anything I can fix or improve in this pull request. Otherwise, the pull request is ready to be merged (if the changes are wanted).

Fixes #206