### PR TITLE
Fix panic edge-case in report command

### DIFF
--- a/klog/app/cli/report.go
+++ b/klog/app/cli/report.go
@@ -30,11 +30,11 @@ func (opt *Report) Run(ctx app.Context) error {
 	if err != nil {
 		return err
 	}
+	now := ctx.Now()
+	records = opt.ApplyFilter(now, records)
 	if len(records) == 0 {
 		return nil
 	}
-	now := ctx.Now()
-	records = opt.ApplyFilter(now, records)
 	records, nErr := opt.ApplyNow(now, records...)
 	if nErr != nil {
 		return nErr

--- a/klog/app/cli/report_test.go
+++ b/klog/app/cli/report_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"github.com/jotaen/klog/klog"
 	"github.com/jotaen/klog/klog/app/cli/lib"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -9,6 +10,18 @@ import (
 
 func TestReportOfEmptyInput(t *testing.T) {
 	state, err := NewTestingContext()._SetRecords(``)._Run((&Report{}).Run)
+	require.Nil(t, err)
+	assert.Equal(t, "", state.printBuffer)
+}
+
+func TestReportOfEmptyFilteredData(t *testing.T) {
+	state, err := NewTestingContext()._SetRecords(`
+2022-10-30
+	8h
+`)._Run((&Report{
+		FilterArgs: lib.FilterArgs{Date: klog.Ɀ_Date_(2022, 10, 31)},
+		Fill:       true,
+	}).Run)
 	require.Nil(t, err)
 	assert.Equal(t, "", state.printBuffer)
 }


### PR DESCRIPTION
Resolves https://github.com/jotaen/klog/issues/221.


That was an odd edge-case in the `klog report` command, where it failed with an index-out-of-bounds panic, in case you use the `--fill`/`-f` option **and** when the filtered data set is empty. (See [`report.go:45-47`](https://github.com/jotaen/klog/blob/039da4da3ceb9be67dcdd63819810b2f6160339d/klog/app/cli/report.go#L45-L47).)