### PR TITLE
Set up benchmark on CI

### DIFF
--- a/.github/benchmark.go
+++ b/.github/benchmark.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"fmt"
+	"github.com/jotaen/klog/klog"
+	"github.com/jotaen/klog/klog/parser"
+	"math/rand"
+	"os"
+	"strconv"
+	"time"
+)
+
+func main() {
+	// Setup
+	iterations, err := strconv.Atoi(os.Args[1])
+	if err != nil {
+		panic(err)
+	}
+	rand.Seed(int64(time.Now().Nanosecond()))
+	now := klog.NewDateFromGo(time.Now())
+
+	// Generate records
+	for i := 0; i < iterations; i++ {
+		date := now.PlusDays((i + 1) * -1)
+		r := klog.NewRecord(date)
+
+		// Should total
+		if i%2 == ri(0, 2) {
+			r.SetShouldTotal(klog.NewDuration(ri(0, 23), ri(0, 59)))
+		}
+
+		// Summary
+		text := rt(0, 5)
+		if len(text) > 0 {
+			r.SetSummary(klog.Ɀ_RecordSummary_(text...))
+		}
+
+		// Entries
+		entriesCount := ri(1, 5)
+		for j := 0; j < entriesCount; j++ {
+			added := re()(&r)
+			if !added {
+				entriesCount++
+			}
+		}
+		fmt.Println(parser.SerialiseRecords(parser.PlainSerialiser{}, r).ToString())
+	}
+}
+
+// ri = random integer
+func ri(min int, max int) int {
+	return rand.Intn(max+1-min) + min
+}
+
+// rt = random texts
+func rt(rowsMin int, rowsMax int) []string {
+	alphabet := "abcdefghijklmnopqrstuvwxyz"
+
+	texts := make([]string, ri(rowsMin, rowsMax))
+	for j := 0; j < len(texts); j++ {
+		bs := make([]byte, ri(1, 50))
+		for i := range bs {
+			bs[i] = alphabet[ri(0, len(alphabet)-1)]
+		}
+		texts[j] = string(bs)
+	}
+	return texts
+}
+
+// re = random entry
+func re() func(r *klog.Record) bool {
+	text := rt(0, 2)
+	var entrySummary klog.EntrySummary
+	if len(text) > 0 {
+		entrySummary = klog.Ɀ_EntrySummary_(text...)
+	}
+	entryAdders := []func(r *klog.Record) bool{
+		func(r *klog.Record) bool {
+			(*r).AddDuration(klog.NewDuration(ri(0, 23), ri(0, 60)), entrySummary)
+			return true
+		},
+		func(r *klog.Record) bool {
+			(*r).AddRange(klog.Ɀ_Range_(
+				klog.Ɀ_Time_(ri(0, 11), ri(0, 59)),
+				klog.Ɀ_Time_(ri(12, 23), ri(0, 59)),
+			), entrySummary)
+			return true
+		},
+		func(r *klog.Record) bool {
+			err := (*r).StartOpenRange(klog.Ɀ_Time_(ri(0, 23), ri(0, 59)), entrySummary)
+			return err == nil
+		},
+	}
+	return entryAdders[ri(0, len(entryAdders)-1)]
+}

--- a/.github/benchmark.sh
+++ b/.github/benchmark.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+FILE="$(mktemp)"
+go run benchmark.go 10000 > "${FILE}"
+
+time klog total --no-warn "${FILE}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,20 @@ jobs:
         run: docker run --rm -v $(pwd):/wdir:ro -w /wdir "${IMAGE_NAME}" --not-match-f="${TEST_FILE_PATTERN}" "${TARGET}"
       - name: LOC of test files
         run: docker run --rm -v $(pwd):/wdir:ro -w /wdir "${IMAGE_NAME}" --match-f="${TEST_FILE_PATTERN}" "${TARGET}"
+  benchmark:
+    name: Benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Build
+        run: |
+          source ./run.sh && run_build
+          mv out/klog /usr/local/bin/klog
+      - name: Benchmark
+        run: cd .github/ && ./benchmark.sh
   format:
     name: Static analysis
     runs-on: ubuntu-latest

--- a/klog/parser/integration_test.go
+++ b/klog/parser/integration_test.go
@@ -22,6 +22,6 @@ lines and contains a #tag as well.
     7:00 - ?
 `
 	rs, _ := Parse(text)
-	s := SerialiseRecords(plainSerialiser{}, rs[0]).ToString()
+	s := SerialiseRecords(PlainSerialiser{}, rs[0]).ToString()
 	assert.Equal(t, text, s)
 }

--- a/klog/parser/serialiser.go
+++ b/klog/parser/serialiser.go
@@ -82,3 +82,14 @@ func (s SummaryText) ToString() string {
 }
 
 var canonicalStyle = DefaultStyle()
+
+type PlainSerialiser struct{}
+
+func (ps PlainSerialiser) Date(x klog.Date) string               { return x.ToString() }
+func (ps PlainSerialiser) ShouldTotal(x klog.Duration) string    { return x.ToString() }
+func (ps PlainSerialiser) Summary(x SummaryText) string          { return x.ToString() }
+func (ps PlainSerialiser) Range(x klog.Range) string             { return x.ToString() }
+func (ps PlainSerialiser) OpenRange(x klog.OpenRange) string     { return x.ToString() }
+func (ps PlainSerialiser) Duration(x klog.Duration) string       { return x.ToString() }
+func (ps PlainSerialiser) SignedDuration(x klog.Duration) string { return x.ToString() }
+func (ps PlainSerialiser) Time(x klog.Time) string               { return x.ToString() }

--- a/klog/parser/serialiser_test.go
+++ b/klog/parser/serialiser_test.go
@@ -6,30 +6,19 @@ import (
 	"testing"
 )
 
-type plainSerialiser struct{}
-
-func (ps plainSerialiser) Date(x klog.Date) string               { return x.ToString() }
-func (ps plainSerialiser) ShouldTotal(x klog.Duration) string    { return x.ToString() }
-func (ps plainSerialiser) Summary(x SummaryText) string          { return x.ToString() }
-func (ps plainSerialiser) Range(x klog.Range) string             { return x.ToString() }
-func (ps plainSerialiser) OpenRange(x klog.OpenRange) string     { return x.ToString() }
-func (ps plainSerialiser) Duration(x klog.Duration) string       { return x.ToString() }
-func (ps plainSerialiser) SignedDuration(x klog.Duration) string { return x.ToString() }
-func (ps plainSerialiser) Time(x klog.Time) string               { return x.ToString() }
-
 func TestSerialiseNoRecordsToEmptyString(t *testing.T) {
-	text := SerialiseRecords(plainSerialiser{}, []klog.Record{}...).ToString()
+	text := SerialiseRecords(PlainSerialiser{}, []klog.Record{}...).ToString()
 	assert.Equal(t, "", text)
 }
 
 func TestSerialiseEndsWithNewlineIfContainsContent(t *testing.T) {
-	text := SerialiseRecords(plainSerialiser{}, klog.NewRecord(klog.Ɀ_Date_(2020, 01, 15))).ToString()
+	text := SerialiseRecords(PlainSerialiser{}, klog.NewRecord(klog.Ɀ_Date_(2020, 01, 15))).ToString()
 	lastChar := []rune(text)[len(text)-1]
 	assert.Equal(t, '\n', lastChar)
 }
 
 func TestSerialiseRecordWithMinimalRecord(t *testing.T) {
-	text := SerialiseRecords(plainSerialiser{}, klog.NewRecord(klog.Ɀ_Date_(2020, 01, 15))).ToString()
+	text := SerialiseRecords(PlainSerialiser{}, klog.NewRecord(klog.Ɀ_Date_(2020, 01, 15))).ToString()
 	assert.Equal(t, `2020-01-15
 `, text)
 }
@@ -45,7 +34,7 @@ func TestSerialiseRecordWithCompleteRecord(t *testing.T) {
 	r.AddDuration(klog.NewDuration(-1, -51), nil)
 	r.AddRange(klog.Ɀ_Range_(klog.Ɀ_TimeYesterday_(23, 23), klog.Ɀ_Time_(4, 3)), nil)
 	r.AddRange(klog.Ɀ_Range_(klog.Ɀ_Time_(22, 0), klog.Ɀ_TimeTomorrow_(0, 1)), nil)
-	text := SerialiseRecords(plainSerialiser{}, r).ToString()
+	text := SerialiseRecords(PlainSerialiser{}, r).ToString()
 	assert.Equal(t, `2020-01-15 (7h30m!)
 This is a
 multiline summary
@@ -64,7 +53,7 @@ multiline summary
 }
 
 func TestSerialiseMultipleRecords(t *testing.T) {
-	text := SerialiseRecords(plainSerialiser{}, []klog.Record{
+	text := SerialiseRecords(PlainSerialiser{}, []klog.Record{
 		klog.NewRecord(klog.Ɀ_Date_(2020, 01, 15)),
 		klog.NewRecord(klog.Ɀ_Date_(2020, 01, 20)),
 	}...).ToString()


### PR DESCRIPTION
This PR adds a benchmark that’s automatically executed during the build on the CI. The benchmark creates a temporary `.klg` file, which is seeded with 10.000 randomly generated records. It then measures the time it takes for `klog total` to evaluate all that data.

On the Github Action runners (which have slightly-below-average computing power, compared to up-to-date commodity hardware), the benchmark runtime seems to be somewhere in the range of 600ms–800ms.

For comparison, 1 year worth of data (i.e., 365 records) would take ~30ms to evaluate, which I think is sufficiently fast.

Should I ever get around to it, the implementation of `klog` would probably allow for some relatively straightforward performance wins, e.g. by parallelising the record parsing, or by making smarter assumptions about memory allocation.

fyi, the seed data looks like this: (3 sample records)

```
2022-11-02 (7h4m!)
vcktkrrpurh
ytmhgzapcchhdhalajjskcm
szjyyqwcdnjrmshuhgukrrpcnwrvnjzhmj
    3:37 - 14:28 podxgqnvfccqktyqhyodlgzebfchwlygohftuakppfcgnoh

2022-11-01
ksmmpr
ovfnhrzlscnhtdkdxlorvvlzxbxbkwbqktdaibucplaodhvoqm
wbwkghevcefjoukagfpuumggjozigxbjsmlot
    1h38m rcmfasbuhaplhucoebng
    3h7m yqsklmtsxaj
        txtdoaali
    22:53 - ? qrdcoqcl
        kxrjbhvjexjbdrjfcidumqnsgsvna
    0:45 - 23:27
    9:27 - 14:26

2022-10-31
ovecavzycuyqicalsxbtvfmcesedcrlvedwplvikjqcc
kdjtffcexuyendicyfkljyszg
fctfoyjgumgqbneullthnsnrlvejzo
qxtz
n
    7:30 - 14:13 qgqufwaukttukrlqvxsqgmubhdypbc
    5:56 - 15:21 tqjncvhqklanxsonfwscglzrbvajjjetrckqer
        szrtvewslofgypnzqaxmlfusjylmqjalyljsyra
    2h16m
```