### PR TITLE
Optimise parsing performance

### DIFF
--- a/.github/benchmark.sh
+++ b/.github/benchmark.sh
@@ -2,7 +2,12 @@
 
 set -e
 
+# Generate test data.
 FILE="$(mktemp)"
 go run benchmark.go 10000 > "${FILE}"
 
+# Ensure binary is all set.
+klog > /dev/null
+
+# Run benchmark.
 time klog total --no-warn "${FILE}"

--- a/klog/app/cli/main/cli.go
+++ b/klog/app/cli/main/cli.go
@@ -10,8 +10,6 @@ import (
 	"github.com/jotaen/klog/klog/app/cli"
 	"github.com/jotaen/klog/klog/app/cli/lib"
 	"github.com/jotaen/klog/klog/parser"
-	"github.com/jotaen/klog/klog/parser/engine"
-	"github.com/jotaen/klog/klog/parser/txt"
 	"github.com/jotaen/klog/klog/service"
 	"github.com/jotaen/klog/klog/service/period"
 	kongcompletion "github.com/jotaen/kong-completion"
@@ -69,7 +67,7 @@ func Run(homeDir string, meta app.Meta, isDebug bool, args []string) (int, error
 	ctx := app.NewContext(
 		homeDir,
 		meta,
-		engine.ParallelBatchParser[txt.Block, parser.ParsedRecord, txt.Error]{NumberOfWorkers: runtime.NumCPU()},
+		parser.NewParallelParser(runtime.NumCPU()),
 		lib.CliSerialiser{},
 		isDebug,
 	)

--- a/klog/app/cli/main/cli.go
+++ b/klog/app/cli/main/cli.go
@@ -9,10 +9,14 @@ import (
 	"github.com/jotaen/klog/klog/app"
 	"github.com/jotaen/klog/klog/app/cli"
 	"github.com/jotaen/klog/klog/app/cli/lib"
+	"github.com/jotaen/klog/klog/parser"
+	"github.com/jotaen/klog/klog/parser/engine"
+	"github.com/jotaen/klog/klog/parser/txt"
 	"github.com/jotaen/klog/klog/service"
 	"github.com/jotaen/klog/klog/service/period"
 	kongcompletion "github.com/jotaen/kong-completion"
 	"reflect"
+	"runtime"
 )
 
 func Run(homeDir string, meta app.Meta, isDebug bool, args []string) (int, error) {
@@ -62,7 +66,13 @@ func Run(homeDir string, meta app.Meta, isDebug bool, args []string) (int, error
 		return -1, nErr
 	}
 
-	ctx := app.NewContext(homeDir, meta, lib.CliSerialiser{}, isDebug)
+	ctx := app.NewContext(
+		homeDir,
+		meta,
+		engine.ParallelBatchParser[txt.Block, parser.ParsedRecord, txt.Error]{NumberOfWorkers: runtime.NumCPU()},
+		lib.CliSerialiser{},
+		isDebug,
+	)
 
 	// When klog is invoked by shell completion (specifically, when the
 	// bash-specific COMP_LINE environment variable is set), the

--- a/klog/app/cli/testutil_test.go
+++ b/klog/app/cli/testutil_test.go
@@ -25,7 +25,7 @@ func NewTestingContext() TestingContext {
 }
 
 func (ctx TestingContext) _SetRecords(recordsText string) TestingContext {
-	records, err := parser.Parse(recordsText)
+	records, err := parser.NewSerialParser().Parse(recordsText)
 	if err != nil {
 		panic("Invalid records")
 	}

--- a/klog/app/context.go
+++ b/klog/app/context.go
@@ -92,7 +92,7 @@ type Meta struct {
 }
 
 // NewContext creates a new Context object.
-func NewContext(homeDir string, meta Meta, parserEngine parser.Engine, serialiser parser.Serialiser, isDebug bool) Context {
+func NewContext(homeDir string, meta Meta, parser parser.Parser, serialiser parser.Serialiser, isDebug bool) Context {
 	if meta.Version == "" {
 		meta.Version = "v?.?"
 	}
@@ -101,7 +101,7 @@ func NewContext(homeDir string, meta Meta, parserEngine parser.Engine, serialise
 	}
 	return &context{
 		homeDir,
-		parserEngine,
+		parser,
 		serialiser,
 		meta,
 		isDebug,
@@ -109,11 +109,11 @@ func NewContext(homeDir string, meta Meta, parserEngine parser.Engine, serialise
 }
 
 type context struct {
-	homeDir      string
-	parserEngine parser.Engine
-	serialiser   parser.Serialiser
-	meta         Meta
-	isDebug      bool
+	homeDir    string
+	parser     parser.Parser
+	serialiser parser.Serialiser
+	meta       Meta
+	isDebug    bool
 }
 
 func (ctx *context) Print(text string) {
@@ -171,7 +171,7 @@ func (ctx *context) ReadInputs(fileArgs ...FileOrBookmarkName) ([]klog.Record, E
 	}
 	var allRecords []klog.Record
 	for _, f := range files {
-		parsedRecords, parserErrors := parser.ParseWithEngine(ctx.parserEngine, f.Contents())
+		parsedRecords, parserErrors := ctx.parser.Parse(f.Contents())
 		if parserErrors != nil {
 			return nil, NewParserErrors(parserErrors)
 		}
@@ -207,7 +207,7 @@ func (ctx *context) ReconcileFile(doWrite bool, fileArg FileOrBookmarkName, crea
 	if err != nil {
 		return nil, err
 	}
-	parsedRecords, parserErrors := parser.ParseWithEngine(ctx.parserEngine, target.Contents())
+	parsedRecords, parserErrors := ctx.parser.Parse(target.Contents())
 	if parserErrors != nil {
 		return nil, NewParserErrors(parserErrors)
 	}

--- a/klog/app/context.go
+++ b/klog/app/context.go
@@ -92,7 +92,7 @@ type Meta struct {
 }
 
 // NewContext creates a new Context object.
-func NewContext(homeDir string, meta Meta, serialiser parser.Serialiser, isDebug bool) Context {
+func NewContext(homeDir string, meta Meta, parserEngine parser.Engine, serialiser parser.Serialiser, isDebug bool) Context {
 	if meta.Version == "" {
 		meta.Version = "v?.?"
 	}
@@ -101,6 +101,7 @@ func NewContext(homeDir string, meta Meta, serialiser parser.Serialiser, isDebug
 	}
 	return &context{
 		homeDir,
+		parserEngine,
 		serialiser,
 		meta,
 		isDebug,
@@ -108,10 +109,11 @@ func NewContext(homeDir string, meta Meta, serialiser parser.Serialiser, isDebug
 }
 
 type context struct {
-	homeDir    string
-	serialiser parser.Serialiser
-	meta       Meta
-	isDebug    bool
+	homeDir      string
+	parserEngine parser.Engine
+	serialiser   parser.Serialiser
+	meta         Meta
+	isDebug      bool
 }
 
 func (ctx *context) Print(text string) {
@@ -169,7 +171,7 @@ func (ctx *context) ReadInputs(fileArgs ...FileOrBookmarkName) ([]klog.Record, E
 	}
 	var allRecords []klog.Record
 	for _, f := range files {
-		parsedRecords, parserErrors := parser.Parse(f.Contents())
+		parsedRecords, parserErrors := parser.ParseWithEngine(ctx.parserEngine, f.Contents())
 		if parserErrors != nil {
 			return nil, NewParserErrors(parserErrors)
 		}
@@ -205,7 +207,7 @@ func (ctx *context) ReconcileFile(doWrite bool, fileArg FileOrBookmarkName, crea
 	if err != nil {
 		return nil, err
 	}
-	parsedRecords, parserErrors := parser.Parse(target.Contents())
+	parsedRecords, parserErrors := parser.ParseWithEngine(ctx.parserEngine, target.Contents())
 	if parserErrors != nil {
 		return nil, NewParserErrors(parserErrors)
 	}

--- a/klog/parser/engine.go
+++ b/klog/parser/engine.go
@@ -1,0 +1,22 @@
+package parser
+
+import (
+	"github.com/jotaen/klog/klog/parser/engine"
+	"github.com/jotaen/klog/klog/parser/txt"
+)
+
+func NewSerialParser() Parser {
+	return serialParser
+}
+
+func NewParallelParser(numberOfWorkers int) Parser {
+	return engine.ParallelParser[string, txt.Block, ParsedRecord, txt.Error]{
+		Serialparser:    serialParser,
+		NumberOfWorkers: numberOfWorkers,
+	}
+}
+
+var serialParser = engine.SerialParser[string, txt.Block, ParsedRecord, txt.Error]{
+	PreProcess: preProcess,
+	ParseOne:   parse,
+}

--- a/klog/parser/engine.go
+++ b/klog/parser/engine.go
@@ -10,8 +10,8 @@ func NewSerialParser() Parser {
 }
 
 func NewParallelParser(numberOfWorkers int) Parser {
-	return engine.ParallelParser[string, txt.Block, ParsedRecord, txt.Error]{
-		Serialparser:    serialParser,
+	return engine.ParallelBatchParser[string, txt.Block, ParsedRecord, txt.Error]{
+		SerialParser:    serialParser,
 		NumberOfWorkers: numberOfWorkers,
 	}
 }

--- a/klog/parser/engine/block.go
+++ b/klog/parser/engine/block.go
@@ -16,39 +16,56 @@ func (b Block) SignificantLines() []Line {
 	return linesWithContent
 }
 
-// GroupIntoBlocks splits up lines into Block’s.
-func GroupIntoBlocks(lines []Line) []Block {
+// GroupIntoBlocks splits up a text into Block’s of Line’s.
+func GroupIntoBlocks(text string) []Block {
 	const (
 		MODE_PRECEDING_BLANK_LINES = iota
 		MODE_SIGNIFICANT_LINES
 		MODE_TRAILING_BLANK_LINES
 	)
+
 	var blocks []Block
 	var currentBlock Block
+	var currentLine string
+	currentLineNumber := 1
 	currentMode := MODE_PRECEDING_BLANK_LINES
-	for _, l := range lines {
+
+	// Parse text.
+	for i, char := range text {
+		currentLine += string(char)
+		if char != '\n' && i+1 != len(text) {
+			continue
+		}
+
+		// Commit line.
+		line := NewLineFromString(currentLine, currentLineNumber)
+		currentLine = ""
+		currentLineNumber++
+
 		switch currentMode {
 		case MODE_PRECEDING_BLANK_LINES:
-			if !isBlank(l) {
+			if !isBlank(line) {
 				currentMode = MODE_SIGNIFICANT_LINES
 			}
 		case MODE_SIGNIFICANT_LINES:
-			if isBlank(l) {
+			if isBlank(line) {
 				currentMode = MODE_TRAILING_BLANK_LINES
 			}
 		case MODE_TRAILING_BLANK_LINES:
-			if !isBlank(l) {
+			if !isBlank(line) {
 				blocks = append(blocks, currentBlock)
 				currentBlock = nil
 				currentMode = MODE_SIGNIFICANT_LINES
 			}
 		}
-		currentBlock = append(currentBlock, l)
+		currentBlock = append(currentBlock, line)
 	}
+
 	if len(blocks) == 0 && currentMode == MODE_PRECEDING_BLANK_LINES {
 		// If the file only contained blank lines, act as if the file was empty altogether.
 		return nil
 	}
+
 	// Commit the latest ongoing currentBlock.
 	return append(blocks, currentBlock)
 }

--- a/klog/parser/engine/block_test.go
+++ b/klog/parser/engine/block_test.go
@@ -7,10 +7,9 @@ import (
 )
 
 func TestGroupEmptyInput(t *testing.T) {
-	for _, ls := range [][]Line{
-		{},
-		{{Text: ""}},
-		{{Text: ""}, {Text: "  "}, {Text: "\t\t"}},
+	for _, ls := range []string{
+		``,
+		"\n \n\t\t\n  ",
 	} {
 		blocks := GroupIntoBlocks(ls)
 		require.Nil(t, blocks)
@@ -18,35 +17,45 @@ func TestGroupEmptyInput(t *testing.T) {
 }
 
 func TestGroupLinesOfSingleBlock(t *testing.T) {
-	for _, ls := range [][]Line{
-		{{Text: "a1"}},
-		{{Text: ""}, {Text: "a1"}},
-		{{Text: "   "}, {Text: "a1"}},
-		{{Text: ""}, {Text: "a1"}, {Text: ""}},
-		{{Text: "\t"}, {Text: "a1"}, {Text: "\t \t "}},
-		{{Text: ""}, {Text: ""}, {Text: "a1"}, {Text: ""}, {Text: ""}},
+	for _, x := range []struct {
+		text string
+		ls   int
+	}{
+		{"a1", 1},
+		{"\na1", 2},
+		{"\na1\n", 2},
+		{"   \na1", 2},
+		{"   \na1\n", 2},
+		{"\t\na1\n\t \t ", 3},
+		{"\n\na1\n\n", 4},
 	} {
-		blocks := GroupIntoBlocks(ls)
+		blocks := GroupIntoBlocks(x.text)
 		require.Len(t, blocks, 1)
 
-		require.Len(t, blocks[0], len(ls))
+		require.Len(t, blocks[0], x.ls)
 		require.Len(t, blocks[0].SignificantLines(), 1)
 		assert.Equal(t, blocks[0].SignificantLines()[0].Text, "a1")
 	}
 }
 
 func TestGroupLinesOfSingleBlockWithMultipleLines(t *testing.T) {
-	for _, ls := range [][]Line{
-		{{Text: "a1"}, {Text: "a2"}},
-		{{Text: ""}, {Text: "a1"}, {Text: "a2"}},
-		{{Text: "    \t"}, {Text: "a1"}, {Text: "a2"}},
-		{{Text: " \t \t"}, {Text: "a1"}, {Text: "a2"}, {Text: "\t"}},
-		{{Text: " "}, {Text: "\t"}, {Text: "a1"}, {Text: "a2"}, {Text: ""}, {Text: ""}},
+	for _, x := range []struct {
+		text string
+		ls   int
+	}{
+		{"a1\na2", 2},
+		{"\na1\na2", 3},
+		{"\na1\na2\n", 3},
+		{"\n    \t\na1\na2", 4},
+		{"\n    \t\na1\na2\n", 4},
+		{"\n    \t\na1\na2\n\n", 5},
+		{" \t \t\na1\na2\n\t", 4},
+		{" \n\t\na1\na2\n\n", 5},
 	} {
-		blocks := GroupIntoBlocks(ls)
+		blocks := GroupIntoBlocks(x.text)
 		require.Len(t, blocks, 1)
 
-		require.Len(t, blocks[0], len(ls))
+		require.Len(t, blocks[0], x.ls)
 		require.Len(t, blocks[0].SignificantLines(), 2)
 		assert.Equal(t, blocks[0].SignificantLines()[0].Text, "a1")
 		assert.Equal(t, blocks[0].SignificantLines()[1].Text, "a2")
@@ -54,18 +63,17 @@ func TestGroupLinesOfSingleBlockWithMultipleLines(t *testing.T) {
 }
 
 func TestGroupLinesOfMultipleBlocks(t *testing.T) {
-	blocks := GroupIntoBlocks([]Line{
-		{Text: ""},
-		{Text: "  "},
-		{Text: "a1"},
-		{Text: "a2"},
-		{Text: ""},
-		{Text: "b1"},
-		{Text: "    "},
-		{Text: "\t"},
-		{Text: "c1"},
-		{Text: ""},
-	})
+	blocks := GroupIntoBlocks(`
+  
+a1
+a2
+
+b1
+        
+	
+c1
+
+`)
 	require.Len(t, blocks, 3)
 
 	require.Len(t, blocks[0], 5)
@@ -83,11 +91,12 @@ func TestGroupLinesOfMultipleBlocks(t *testing.T) {
 }
 
 func TestDisregardLinesAllEmpty(t *testing.T) {
-	blocks := GroupIntoBlocks([]Line{
-		{Text: ""},
-		{Text: "  "},
-		{Text: "\t"},
-		{Text: ""},
-	})
+	blocks := GroupIntoBlocks(`
+
+ 
+	
+ 
+
+`)
 	require.Nil(t, blocks)
 }

--- a/klog/parser/engine/line.go
+++ b/klog/parser/engine/line.go
@@ -1,7 +1,6 @@
 package engine
 
 import (
-	"regexp"
 	"strings"
 )
 
@@ -17,8 +16,6 @@ type Line struct {
 	// Note that for the last line in a file, there might be no line ending.
 	LineEnding string
 }
-
-var lineDelimiterPattern = regexp.MustCompile(`^.*\n?`)
 
 // NewLineFromString turns data into a Line object.
 func NewLineFromString(rawLineText string, lineNumber int) Line {
@@ -39,13 +36,15 @@ func (l *Line) Original() string {
 // line delimiters.
 func Split(text string) []Line {
 	var result []Line
-	remainder := text
-	lineNumber := 0
-	for len(remainder) > 0 {
-		lineNumber += 1
-		original := lineDelimiterPattern.FindString(remainder)
-		result = append(result, NewLineFromString(original, lineNumber))
-		remainder = remainder[len(original):]
+	var currentLine string
+	lineNumber := 1
+	for i, char := range text {
+		currentLine += string(char)
+		if char == '\n' || i+1 == len(text) {
+			result = append(result, NewLineFromString(currentLine, lineNumber))
+			currentLine = ""
+			lineNumber++
+		}
 	}
 	return result
 }

--- a/klog/parser/engine/line.go
+++ b/klog/parser/engine/line.go
@@ -32,23 +32,6 @@ func (l *Line) Original() string {
 	return l.Text + l.LineEnding
 }
 
-// Split breaks up text into a list of Line’s. The text must use `\n` as
-// line delimiters.
-func Split(text string) []Line {
-	var result []Line
-	var currentLine string
-	lineNumber := 1
-	for i, char := range text {
-		currentLine += string(char)
-		if char == '\n' || i+1 == len(text) {
-			result = append(result, NewLineFromString(currentLine, lineNumber))
-			currentLine = ""
-			lineNumber++
-		}
-	}
-	return result
-}
-
 var lineEndingPatterns = []string{"\r\n", "\n"}
 
 func splitOffLineEnding(text string) (string, string) {

--- a/klog/parser/engine/line_test.go
+++ b/klog/parser/engine/line_test.go
@@ -2,48 +2,19 @@ package engine
 
 import (
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
 )
 
-func TestSplitTextIntoLines(t *testing.T) {
-	text := "foo\nbar\r\n\n  \nbaz"
-	ls := Split(text)
-	require.Len(t, ls, 5)
-
-	assert.Equal(t, ls[0].Original(), "foo\n")
-	assert.Equal(t, ls[0].LineNumber, 1)
-
-	assert.Equal(t, ls[1].Original(), "bar\r\n")
-	assert.Equal(t, ls[1].LineNumber, 2)
-
-	assert.Equal(t, ls[2].Original(), "\n")
-	assert.Equal(t, ls[2].LineNumber, 3)
-
-	assert.Equal(t, ls[3].Original(), "  \n")
-	assert.Equal(t, ls[3].LineNumber, 4)
-
-	assert.Equal(t, ls[4].Original(), "baz")
-	assert.Equal(t, ls[4].LineNumber, 5)
-}
-
 func TestDeterminesLineEndings(t *testing.T) {
-	text := "foo\nbar\r\nbaz"
-	ls := Split(text)
-	require.Len(t, ls, 3)
+	ls := []Line{NewLineFromString(
+		"foo\n", 1),
+		NewLineFromString("bar\r\n", 2),
+		NewLineFromString("baz", 3),
+	}
 	assert.Equal(t, "foo", ls[0].Text)
 	assert.Equal(t, "\n", ls[0].LineEnding)
 	assert.Equal(t, "bar", ls[1].Text)
 	assert.Equal(t, "\r\n", ls[1].LineEnding)
 	assert.Equal(t, "baz", ls[2].Text)
 	assert.Equal(t, "", ls[2].LineEnding)
-}
-
-func TestToStringRestoresOriginal(t *testing.T) {
-	text := "  Hello World\n\tTest 123\r\n      Foo Bar BAZ"
-	ls := Split(text)
-	require.Len(t, ls, 3)
-	assert.Equal(t, "  Hello World\n", ls[0].Original())
-	assert.Equal(t, "\tTest 123\r\n", ls[1].Original())
-	assert.Equal(t, "      Foo Bar BAZ", ls[2].Original())
 }

--- a/klog/parser/engine/parallel.go
+++ b/klog/parser/engine/parallel.go
@@ -4,8 +4,8 @@ import (
 	"sync"
 )
 
-type ParallelParser[Txt any, Int any, Out any, Err any] struct {
-	Serialparser    SerialParser[Txt, Int, Out, Err]
+type ParallelBatchParser[Txt any, Int any, Out any, Err any] struct {
+	SerialParser    SerialParser[Txt, Int, Out, Err]
 	NumberOfWorkers int
 }
 
@@ -14,17 +14,17 @@ type batchResult[Out any, Err any] struct {
 	errs []Err
 }
 
-func (p ParallelParser[Txt, Int, Out, Err]) Parse(txt Txt) ([]Out, []Err) {
-	ints := p.Serialparser.PreProcess(txt)
+func (p ParallelBatchParser[Txt, Int, Out, Err]) Parse(txt Txt) ([]Out, []Err) {
+	allInts := p.SerialParser.PreProcess(txt)
 	// Batch up and dispatch to workers.
 	wg := &sync.WaitGroup{}
-	batches := batch(ints, p.NumberOfWorkers)
+	batches := splitUp(allInts, p.NumberOfWorkers)
 	wg.Add(len(batches))
 	resultChannel := make(chan batchResult[Out, Err])
 	for _, b := range batches {
 		go func(ints []Int) {
 			defer wg.Done()
-			outs, errs := p.Serialparser.parseAll(ints)
+			outs, errs := p.SerialParser.parseAll(ints)
 			resultChannel <- batchResult[Out, Err]{outs, errs}
 		}(b)
 	}
@@ -37,7 +37,7 @@ func (p ParallelParser[Txt, Int, Out, Err]) Parse(txt Txt) ([]Out, []Err) {
 
 	// Collect results.
 	i := 0
-	outs := make([]Out, len(ints))
+	outs := make([]Out, len(allInts))
 	var allErrs []Err
 	for result := range resultChannel {
 		if len(result.errs) > 0 {
@@ -55,7 +55,7 @@ func (p ParallelParser[Txt, Int, Out, Err]) Parse(txt Txt) ([]Out, []Err) {
 	return outs, nil
 }
 
-func batch[T any](slice []T, batchSize int) [][]T {
+func splitUp[T any](slice []T, batchSize int) [][]T {
 	batches := make([][]T, 0, (len(slice)+batchSize-1)/batchSize)
 	for batchSize < len(slice) {
 		slice, batches = slice[batchSize:], append(batches, slice[0:batchSize:batchSize])

--- a/klog/parser/engine/parallel.go
+++ b/klog/parser/engine/parallel.go
@@ -1,4 +1,4 @@
-package engine2
+package engine
 
 import (
 	"sync"

--- a/klog/parser/engine/serial.go
+++ b/klog/parser/engine/serial.go
@@ -1,12 +1,19 @@
 package engine
 
-type SerialParser[In any, Out any, Err error] struct{}
+type SerialParser[Txt any, Int any, Out any, Err any] struct {
+	PreProcess func(Txt) []Int
+	ParseOne   func(Int) (Out, []Err)
+}
 
-func (p SerialParser[In, Out, Err]) ParseAll(ins []In, parseOne func(In) (Out, []Err)) ([]Out, []Err) {
-	outs := make([]Out, len(ins))
+func (p SerialParser[Txt, Int, Out, Err]) Parse(text Txt) ([]Out, []Err) {
+	return p.parseAll(p.PreProcess(text))
+}
+
+func (p SerialParser[Txt, Int, Out, Err]) parseAll(ints []Int) ([]Out, []Err) {
+	outs := make([]Out, len(ints))
 	var errs []Err
-	for i, in := range ins {
-		out, err := parseOne(in)
+	for i, in := range ints {
+		out, err := p.ParseOne(in)
 		if err != nil {
 			errs = append(errs, err...)
 			continue

--- a/klog/parser/engine/serial.go
+++ b/klog/parser/engine/serial.go
@@ -1,4 +1,4 @@
-package engine2
+package engine
 
 type SerialParser[In any, Out any, Err error] struct{}
 

--- a/klog/parser/engine2/parallel.go
+++ b/klog/parser/engine2/parallel.go
@@ -1,0 +1,74 @@
+package engine2
+
+import (
+	"sync"
+)
+
+type dataIn[In any] struct {
+	data In
+	i    int
+}
+
+type dataOut[Out any, Err error] struct {
+	data Out
+	errs []Err
+	i    int
+}
+
+type ParallelParser[In any, Out any, Err error] struct {
+	NumberOfWorkers int
+}
+
+func (pp ParallelParser[In, Out, Err]) ParseAll(ins []In, parseOne func(In) (Out, []Err)) ([]Out, []Err) {
+	outs := make([]Out, len(ins))
+	var allErrs []Err
+
+	// Set up channels.
+	inChannel := make(chan dataIn[In])
+	outChannel := make(chan dataOut[Out, Err])
+
+	// Dispatch work.
+	wg := &sync.WaitGroup{}
+	wg.Add(len(ins))
+	go func() {
+		for i, in := range ins {
+			inChannel <- dataIn[In]{in, i}
+		}
+		close(inChannel)
+	}()
+
+	// Spawn workers.
+	for i := 0; i < pp.NumberOfWorkers; i++ {
+		go func() {
+			for in := range inChannel {
+				data, errs := parseOne(in.data)
+				out := dataOut[Out, Err]{i: in.i}
+				if len(errs) > 0 {
+					out.errs = errs
+				} else {
+					out.data = data
+				}
+				outChannel <- out
+				wg.Done()
+			}
+		}()
+	}
+
+	go func() {
+		wg.Wait()
+		close(outChannel)
+	}()
+
+	for out := range outChannel {
+		if out.errs == nil {
+			outs[out.i] = out.data
+		} else {
+			allErrs = append(allErrs, out.errs...)
+		}
+	}
+
+	if len(allErrs) > 0 {
+		return nil, allErrs
+	}
+	return outs, nil
+}

--- a/klog/parser/engine2/serial.go
+++ b/klog/parser/engine2/serial.go
@@ -1,0 +1,20 @@
+package engine2
+
+type SerialParser[In any, Out any, Err error] struct{}
+
+func (p SerialParser[In, Out, Err]) ParseAll(ins []In, parseOne func(In) (Out, []Err)) ([]Out, []Err) {
+	outs := make([]Out, len(ins))
+	var errs []Err
+	for i, in := range ins {
+		out, err := parseOne(in)
+		if err != nil {
+			errs = append(errs, err...)
+			continue
+		}
+		outs[i] = out
+	}
+	if errs != nil {
+		return nil, errs
+	}
+	return outs, errs
+}

--- a/klog/parser/integration_test.go
+++ b/klog/parser/integration_test.go
@@ -21,7 +21,7 @@ lines and contains a #tag as well.
     1:00am - 3:12pm
     7:00 - ?
 `
-	rs, _ := Parse(text)
+	rs, _ := NewSerialParser().Parse(text)
 	s := SerialiseRecords(PlainSerialiser{}, rs[0]).ToString()
 	assert.Equal(t, text, s)
 }

--- a/klog/parser/parser.go
+++ b/klog/parser/parser.go
@@ -39,7 +39,7 @@ type Out struct {
 // Parse parses a text into a list of Record datastructures. On success, it returns
 // the parsed records. Otherwise, it returns all encountered parser errors.
 func Parse(recordsAsText string) ([]ParsedRecord, []engine.Error) {
-	blocks := engine.GroupIntoBlocks(engine.Split(recordsAsText))
+	blocks := engine.GroupIntoBlocks(recordsAsText)
 	records := make([]ParsedRecord, len(blocks))
 	var allErrs []engine.Error
 

--- a/klog/parser/parser.go
+++ b/klog/parser/parser.go
@@ -5,7 +5,7 @@ package parser
 
 import (
 	"github.com/jotaen/klog/klog"
-	"github.com/jotaen/klog/klog/parser/engine2"
+	"github.com/jotaen/klog/klog/parser/engine"
 	"github.com/jotaen/klog/klog/parser/txt"
 	"strings"
 )
@@ -30,7 +30,7 @@ type Engine interface {
 // the parsed records. Otherwise, it returns all encountered parser errors.
 func Parse(recordsAsText string) ([]ParsedRecord, []txt.Error) {
 	blocks := txt.GroupIntoBlocks(recordsAsText)
-	return engine2.SerialParser[txt.Block, ParsedRecord, txt.Error]{}.ParseAll(blocks, func(block txt.Block) (ParsedRecord, []txt.Error) {
+	return engine.SerialParser[txt.Block, ParsedRecord, txt.Error]{}.ParseAll(blocks, func(block txt.Block) (ParsedRecord, []txt.Error) {
 		record, style, errs := parseRecord(block.SignificantLines())
 		if errs != nil {
 			return ParsedRecord{}, errs

--- a/klog/parser/parser.go
+++ b/klog/parser/parser.go
@@ -24,10 +24,10 @@ type ParsedRecord struct {
 // Parse parses a text into a list of Record datastructures. On success, it returns
 // the parsed records. Otherwise, it returns all encountered parser errors.
 func Parse(recordsAsText string) ([]ParsedRecord, []engine.Error) {
-	var results []ParsedRecord
-	var allErrs []engine.Error
 	blocks := engine.GroupIntoBlocks(engine.Split(recordsAsText))
-	for _, block := range blocks {
+	records := make([]ParsedRecord, len(blocks))
+	var allErrs []engine.Error
+	for i, block := range blocks {
 		record, style, errs := parseRecord(block.SignificantLines())
 		if len(errs) > 0 {
 			allErrs = append(allErrs, errs...)
@@ -36,16 +36,16 @@ func Parse(recordsAsText string) ([]ParsedRecord, []engine.Error) {
 		if block[0].LineEnding != "" {
 			style.LineEnding.Set(block[0].LineEnding)
 		}
-		results = append(results, ParsedRecord{
+		records[i] = ParsedRecord{
 			Record: record,
 			Block:  block,
 			Style:  style,
-		})
+		}
 	}
 	if len(allErrs) > 0 {
 		return nil, allErrs
 	}
-	return results, nil
+	return records, nil
 }
 
 var allowedIndentationStyles = []string{"    ", "   ", "  ", "\t"}

--- a/klog/parser/parser.go
+++ b/klog/parser/parser.go
@@ -23,14 +23,18 @@ type ParsedRecord struct {
 }
 
 type Engine interface {
-	ParseAll([]txt.Block, func(block txt.Block) (ParsedRecord, []txt.Error)) ([]ParsedRecord, []txt.Error)
+	ParseAll(blocks []txt.Block, parseOne func(txt.Block) (ParsedRecord, []txt.Error)) ([]ParsedRecord, []txt.Error)
 }
 
 // Parse parses a text into a list of Record datastructures. On success, it returns
 // the parsed records. Otherwise, it returns all encountered parser errors.
 func Parse(recordsAsText string) ([]ParsedRecord, []txt.Error) {
+	return ParseWithEngine(engine.SerialParser[txt.Block, ParsedRecord, txt.Error]{}, recordsAsText)
+}
+
+func ParseWithEngine(e Engine, recordsAsText string) ([]ParsedRecord, []txt.Error) {
 	blocks := txt.GroupIntoBlocks(recordsAsText)
-	return engine.SerialParser[txt.Block, ParsedRecord, txt.Error]{}.ParseAll(blocks, func(block txt.Block) (ParsedRecord, []txt.Error) {
+	return e.ParseAll(blocks, func(block txt.Block) (ParsedRecord, []txt.Error) {
 		record, style, errs := parseRecord(block.SignificantLines())
 		if errs != nil {
 			return ParsedRecord{}, errs

--- a/klog/parser/reconciling/append_entry_test.go
+++ b/klog/parser/reconciling/append_entry_test.go
@@ -23,7 +23,7 @@ Hello World
 2018-01-03
     5h
 `
-	rs, _ := parser.Parse(original)
+	rs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(rs, klog.Ɀ_Date_(2018, 1, 2))
 	require.NotNil(t, reconciler)
 	result, err := reconciler.AppendEntry(klog.Ɀ_EntrySummary_("2h30m"))
@@ -49,7 +49,7 @@ Hello World
 
 func TestReconcilerAddsNewlyCreatedEntryAtEndOfFile(t *testing.T) {
 	original := "\n2018-01-01\n    1h"
-	rs, _ := parser.Parse(original)
+	rs, _ := parser.NewSerialParser().Parse(original)
 
 	reconciler := NewReconcilerAtRecord(rs, klog.Ɀ_Date_(2018, 1, 1))
 	require.NotNil(t, reconciler)
@@ -64,7 +64,7 @@ func TestReconcilerAddsNewlyCreatedEntryAtEndOfFile(t *testing.T) {
 
 func TestReconcilerSplitsUpSummaryText(t *testing.T) {
 	original := "\n2018-01-01\n    1h"
-	rs, _ := parser.Parse(original)
+	rs, _ := parser.NewSerialParser().Parse(original)
 
 	reconciler := NewReconcilerAtRecord(rs, klog.Ɀ_Date_(2018, 1, 1))
 	require.NotNil(t, reconciler)
@@ -80,7 +80,7 @@ func TestReconcilerSplitsUpSummaryText(t *testing.T) {
 
 func TestReconcilerStartsSummaryTextOnNextLine(t *testing.T) {
 	original := "\n2018-01-01\n    1h"
-	rs, _ := parser.Parse(original)
+	rs, _ := parser.NewSerialParser().Parse(original)
 
 	reconciler := NewReconcilerAtRecord(rs, klog.Ɀ_Date_(2018, 1, 1))
 	require.NotNil(t, reconciler)
@@ -96,7 +96,7 @@ func TestReconcilerStartsSummaryTextOnNextLine(t *testing.T) {
 
 func TestReconcilerRejectsInvalidEntry(t *testing.T) {
 	original := "2018-01-01\n"
-	rs, _ := parser.Parse(original)
+	rs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(rs, klog.Ɀ_Date_(2018, 1, 1))
 	require.NotNil(t, reconciler)
 	result, err := reconciler.AppendEntry(klog.Ɀ_EntrySummary_("this is not valid entry text"))

--- a/klog/parser/reconciling/close_open_range_test.go
+++ b/klog/parser/reconciling/close_open_range_test.go
@@ -13,7 +13,7 @@ func TestReconcilerClosesOpenRangeWithStyle(t *testing.T) {
 2010-04-27
     3:00pm - ??
 `
-	rs, _ := parser.Parse(original)
+	rs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(rs, klog.Ɀ_Date_(2010, 4, 27))
 	require.NotNil(t, reconciler)
 	result, err := reconciler.CloseOpenRange(klog.Ɀ_Time_(15, 30), nil)
@@ -29,7 +29,7 @@ func TestReconcilerClosesOpenRangeWithNewSummary(t *testing.T) {
 2018-01-01
     15:00 - ?
 `
-	rs, _ := parser.Parse(original)
+	rs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(rs, klog.Ɀ_Date_(2018, 1, 1))
 	require.NotNil(t, reconciler)
 	result, err := reconciler.CloseOpenRange(klog.Ɀ_Time_(15, 22), klog.Ɀ_EntrySummary_("Finished."))
@@ -45,7 +45,7 @@ func TestReconcilerClosesOpenRangeWithNewMultilineSummary(t *testing.T) {
 2018-01-01
     15:00 - ?
 `
-	rs, _ := parser.Parse(original)
+	rs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(rs, klog.Ɀ_Date_(2018, 1, 1))
 	require.NotNil(t, reconciler)
 	result, err := reconciler.CloseOpenRange(klog.Ɀ_Time_(15, 22), klog.Ɀ_EntrySummary_("", "Finished."))
@@ -66,7 +66,7 @@ func TestReconcilerClosesOpenRangeWithExtendingSummary(t *testing.T) {
         I hope so.
     2m
 `
-	rs, _ := parser.Parse(original)
+	rs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(rs, klog.Ɀ_Date_(2018, 1, 1))
 	require.NotNil(t, reconciler)
 	result, err := reconciler.CloseOpenRange(klog.Ɀ_Time_(16, 42), klog.Ɀ_EntrySummary_("Yes!"))
@@ -87,7 +87,7 @@ func TestReconcilerClosesOpenRangeWithExtendingSummaryOnNextLine(t *testing.T) {
     16:00-? Started...
     -45m break
 `
-	rs, _ := parser.Parse(original)
+	rs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(rs, klog.Ɀ_Date_(2018, 1, 1))
 	require.NotNil(t, reconciler)
 	result, err := reconciler.CloseOpenRange(klog.Ɀ_Time_(18, 01), klog.Ɀ_EntrySummary_("", "Stopped."))

--- a/klog/parser/reconciling/creator_test.go
+++ b/klog/parser/reconciling/creator_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestReconcilerSkipsIfNoRecordMatches(t *testing.T) {
 	original := "2018-01-01\n"
-	rs, _ := parser.Parse(original)
+	rs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(rs, klog.Ɀ_Date_(9999, 12, 31))
 	require.Nil(t, reconciler)
 }
@@ -26,7 +26,7 @@ func TestReconcilerRespectsIndentationStyle(t *testing.T) {
 		{"1444-10-09\n    1h", "1444-10-09\n    1h\n    30m\n"},
 		{"1444-10-08\n  3h\n\n1444-10-09\n\t1h", "1444-10-08\n  3h\n\n1444-10-09\n\t1h\n\t30m\n"},
 	} {
-		rs, _ := parser.Parse(x.original)
+		rs, _ := parser.NewSerialParser().Parse(x.original)
 		reconciler := NewReconcilerAtRecord(rs, klog.Ɀ_Date_(1444, 10, 9))
 		result, err := reconciler.AppendEntry(klog.Ɀ_EntrySummary_("30m"))
 		require.Nil(t, err)
@@ -42,7 +42,7 @@ func TestReconcilerRespectsLineEndingStyle(t *testing.T) {
 		{"1444-10-09\r\n\t1h", "1444-10-09\r\n\t1h\r\n\t30m\r\n"},
 		{"1444-10-09\r\n\t1h\n\t2h", "1444-10-09\r\n\t1h\n\t2h\r\n\t30m\r\n"},
 	} {
-		rs, _ := parser.Parse(x.original)
+		rs, _ := parser.NewSerialParser().Parse(x.original)
 		reconciler := NewReconcilerAtRecord(rs, klog.Ɀ_Date_(1444, 10, 9))
 		result, err := reconciler.AppendEntry(klog.Ɀ_EntrySummary_("30m"))
 		require.Nil(t, err)
@@ -51,7 +51,7 @@ func TestReconcilerRespectsLineEndingStyle(t *testing.T) {
 }
 
 func TestReconcileAddRecordIfOriginalIsEmpty(t *testing.T) {
-	rs, _ := parser.Parse("")
+	rs, _ := parser.NewSerialParser().Parse("")
 	reconciler := NewReconcilerForNewRecord(rs, RecordParams{Date: klog.Ɀ_Date_(2000, 5, 5)})
 	result, err := reconciler.MakeResult()
 	require.Nil(t, err)
@@ -60,7 +60,7 @@ func TestReconcileAddRecordIfOriginalIsEmpty(t *testing.T) {
 }
 
 func TestReconcileAddRecordIfOriginalContainsOneRecord(t *testing.T) {
-	rs, _ := parser.Parse("1999-12-31")
+	rs, _ := parser.NewSerialParser().Parse("1999-12-31")
 	reconciler := NewReconcilerForNewRecord(rs, RecordParams{Date: klog.Ɀ_Date_(2000, 2, 1)})
 	result, err := reconciler.MakeResult()
 	require.Nil(t, err)
@@ -78,7 +78,7 @@ func TestReconcileNewRecordFromEmptyFile(t *testing.T) {
 		{"\n\n\t\n"},
 		{"\n\n     \t\n \t     \n  "},
 	} {
-		rs, _ := parser.Parse(x.original)
+		rs, _ := parser.NewSerialParser().Parse(x.original)
 		reconciler := NewReconcilerForNewRecord(rs, RecordParams{Date: klog.Ɀ_Date_(1995, 3, 17)})
 		result, err := reconciler.MakeResult()
 		require.Nil(t, err)
@@ -97,7 +97,7 @@ func TestReconcilePrependNewRecord(t *testing.T) {
 		{"2018-01-02\n\n", "2018-01-01\n\n2018-01-02\n\n"},
 		{"\n\n2018-01-02\n", "2018-01-01\n\n\n\n2018-01-02\n"},
 	} {
-		rs, _ := parser.Parse(x.original)
+		rs, _ := parser.NewSerialParser().Parse(x.original)
 		reconciler := NewReconcilerForNewRecord(rs, RecordParams{Date: klog.Ɀ_Date_(2018, 1, 1)})
 		result, err := reconciler.MakeResult()
 		require.Nil(t, err)
@@ -114,7 +114,7 @@ func TestReconcileAppendNewRecord(t *testing.T) {
 		{"2018-01-01\n\n", "2018-01-01\n\n2019-01-01\n\n"},
 		{"\n\n2018-01-01\n", "\n\n2018-01-01\n\n2019-01-01\n"},
 	} {
-		rs, _ := parser.Parse(x.original)
+		rs, _ := parser.NewSerialParser().Parse(x.original)
 		reconciler := NewReconcilerForNewRecord(rs, RecordParams{Date: klog.Ɀ_Date_(2019, 1, 1)})
 		result, err := reconciler.MakeResult()
 		require.Nil(t, err)
@@ -131,7 +131,7 @@ func TestReconcileAddBlockInBetween(t *testing.T) {
 		{"2018-01-01\n\n\n2018-01-03", "2018-01-01\n\n2018-01-02\n\n\n2018-01-03"},
 		{"2018-01-02\n\t1h\n\n2018-01-03", "2018-01-02\n\t1h\n\n2018-01-02\n\n2018-01-03"},
 	} {
-		rs, _ := parser.Parse(x.original)
+		rs, _ := parser.NewSerialParser().Parse(x.original)
 		reconciler := NewReconcilerForNewRecord(rs, RecordParams{Date: klog.Ɀ_Date_(2018, 1, 2)})
 		result, err := reconciler.MakeResult()
 		require.Nil(t, err)
@@ -143,7 +143,7 @@ func TestReconcileAddRecordWithShouldTotal(t *testing.T) {
 	original := `
 2018-01-01
     1h`
-	rs, _ := parser.Parse(original)
+	rs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerForNewRecord(rs, RecordParams{Date: klog.Ɀ_Date_(2018, 1, 2), ShouldTotal: klog.NewShouldTotal(5, 31)})
 	result, err := reconciler.MakeResult()
 	require.Nil(t, err)
@@ -160,7 +160,7 @@ func TestReconcileAddRecordWithSummary(t *testing.T) {
 	original := `
 2018-01-01
     1h`
-	rs, _ := parser.Parse(original)
+	rs, _ := parser.NewSerialParser().Parse(original)
 	summary := klog.Ɀ_RecordSummary_("This is a new record.", "It has a summary.")
 	reconciler := NewReconcilerForNewRecord(rs, RecordParams{Date: klog.Ɀ_Date_(2018, 1, 2), Summary: summary})
 	result, err := reconciler.MakeResult()
@@ -184,7 +184,7 @@ func TestReconcileRespectsExistingStylePref(t *testing.T) {
 		{"3145/06/15\n", "3145/06/15\n\n3145/06/16\n"},
 		{"3145/06/14\n\n3145/06/15\n\n3145-06-15\n", "3145/06/14\n\n3145/06/15\n\n3145-06-15\n\n3145/06/16\n"},
 	} {
-		rs, _ := parser.Parse(x.original)
+		rs, _ := parser.NewSerialParser().Parse(x.original)
 		reconciler := NewReconcilerForNewRecord(rs, RecordParams{Date: klog.Ɀ_Date_(3145, 6, 16)})
 		result, err := reconciler.MakeResult()
 		require.Nil(t, err)

--- a/klog/parser/reconciling/pause_open_range_test.go
+++ b/klog/parser/reconciling/pause_open_range_test.go
@@ -13,7 +13,7 @@ func TestReconcilerAddsNewPauseEntry(t *testing.T) {
 2010-04-27
     3:00pm - ?
 `
-	rs, _ := parser.Parse(original)
+	rs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(rs, klog.Ɀ_Date_(2010, 4, 27))
 	require.NotNil(t, reconciler)
 	result, err := reconciler.PauseOpenRange(klog.NewDuration(0, -12), nil)
@@ -30,7 +30,7 @@ func TestReconcilerFailsIfPauseIsPositiveValue(t *testing.T) {
 2010-04-27
     3:00 - 4:00
 `
-	rs, _ := parser.Parse(original)
+	rs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(rs, klog.Ɀ_Date_(2010, 4, 27))
 	require.NotNil(t, reconciler)
 	result, err := reconciler.PauseOpenRange(klog.NewDuration(0, 12), nil)
@@ -43,7 +43,7 @@ func TestReconcilerFailsIfThereIsNoOpenRange(t *testing.T) {
 2010-04-27
     3:00 - 4:00
 `
-	rs, _ := parser.Parse(original)
+	rs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(rs, klog.Ɀ_Date_(2010, 4, 27))
 	require.NotNil(t, reconciler)
 	result, err := reconciler.PauseOpenRange(klog.NewDuration(0, -12), nil)
@@ -59,7 +59,7 @@ Foo
         a break!
     -30m
 `
-	rs, _ := parser.Parse(original)
+	rs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(rs, klog.Ɀ_Date_(2010, 4, 27))
 	require.NotNil(t, reconciler)
 	result, err := reconciler.PauseOpenRange(klog.NewDuration(0, -3), nil)
@@ -81,7 +81,7 @@ Foo
     -30m This is a totally unrelated entry,
         that should not be modified!
 `
-	rs, _ := parser.Parse(original)
+	rs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(rs, klog.Ɀ_Date_(2010, 4, 27))
 	require.NotNil(t, reconciler)
 	result, err := reconciler.PauseOpenRange(klog.NewDuration(-1, -30), klog.Ɀ_EntrySummary_("Lunch break"))
@@ -102,7 +102,7 @@ func TestReconcilerDoesNotExtendNonNegativeDurations(t *testing.T) {
     3:00 - ?
     30m
 `
-	rs, _ := parser.Parse(original)
+	rs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(rs, klog.Ɀ_Date_(2010, 4, 27))
 	require.NotNil(t, reconciler)
 	result, err := reconciler.PauseOpenRange(klog.NewDuration(0, -10), nil)

--- a/klog/parser/reconciling/reconciler.go
+++ b/klog/parser/reconciling/reconciler.go
@@ -51,7 +51,7 @@ func (r *Reconciler) MakeResult() (*Result, error) {
 	}
 
 	// As a safeguard, make sure the result is parseable.
-	newRecords, errs := parser.Parse(text)
+	newRecords, errs := parser.NewSerialParser().Parse(text)
 	if errs != nil {
 		return nil, errors.New("This operation wouldn’t result in a valid record")
 	}

--- a/klog/parser/reconciling/start_open_range_test.go
+++ b/klog/parser/reconciling/start_open_range_test.go
@@ -13,7 +13,7 @@ func TestReconcilerStartsOpenRange(t *testing.T) {
 2018-01-01
 	5h22m
 `
-	rs, _ := parser.Parse(original)
+	rs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(rs, klog.Ɀ_Date_(2018, 1, 1))
 	require.NotNil(t, reconciler)
 	result, err := reconciler.StartOpenRange(klog.Ɀ_Time_(8, 3), nil)
@@ -31,7 +31,7 @@ func TestReconcilerStartsOpenRangeWithSummary(t *testing.T) {
 	5h22m
 		Existing entry
 `
-	rs, _ := parser.Parse(original)
+	rs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(rs, klog.Ɀ_Date_(2018, 1, 1))
 	require.NotNil(t, reconciler)
 	result, err := reconciler.StartOpenRange(klog.Ɀ_Time_(8, 3), klog.Ɀ_EntrySummary_("Test"))
@@ -49,7 +49,7 @@ func TestReconcilerStartsOpenRangeWithNewMultilineSummary(t *testing.T) {
 2018-01-01
 	5h22m
 `
-	rs, _ := parser.Parse(original)
+	rs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(rs, klog.Ɀ_Date_(2018, 1, 1))
 	require.NotNil(t, reconciler)
 	result, err := reconciler.StartOpenRange(klog.Ɀ_Time_(8, 3), klog.Ɀ_EntrySummary_("", "Started...", "something!"))
@@ -68,7 +68,7 @@ func TestReconcilerStartsOpenRangeWithStyle(t *testing.T) {
 2018-01-01
 	2:00am-3:00am
 `
-	rs, _ := parser.Parse(original)
+	rs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(rs, klog.Ɀ_Date_(2018, 1, 1))
 	require.NotNil(t, reconciler)
 	result, err := reconciler.StartOpenRange(klog.Ɀ_Time_(8, 3), nil)
@@ -88,7 +88,7 @@ func TestReconcilerStartsOpenRangeWithStyleFromOtherRecord(t *testing.T) {
 
 2018-01-02
 `
-	rs, _ := parser.Parse(original)
+	rs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(rs, klog.Ɀ_Date_(2018, 1, 2))
 	require.NotNil(t, reconciler)
 	result, err := reconciler.StartOpenRange(klog.Ɀ_Time_(8, 3), nil)

--- a/klog/parser/style_test.go
+++ b/klog/parser/style_test.go
@@ -87,7 +87,7 @@ func TestElectStyleDoesNotOverrideSetPreferences(t *testing.T) {
 }
 
 func parseOrPanic(recordsAsText ...string) []ParsedRecord {
-	rs, err := Parse(strings.Join(recordsAsText, ""))
+	rs, err := NewSerialParser().Parse(strings.Join(recordsAsText, ""))
 	if err != nil {
 		panic("Invalid data")
 	}

--- a/klog/summary.go
+++ b/klog/summary.go
@@ -13,17 +13,21 @@ type RecordSummary []string
 // of an entry.
 type EntrySummary []string
 
+var recordSummaryLinePattern = regexp.MustCompile(`^[\p{Zs}\t]`)
+
 // NewRecordSummary creates a new RecordSummary from individual lines of text.
 // None of the lines can start with blank characters, and none of the lines
 // can be empty or blank.
 func NewRecordSummary(line ...string) (RecordSummary, error) {
 	for _, l := range line {
-		if len(l) == 0 || regexp.MustCompile(`^[\p{Zs}\t]`).MatchString(l) {
+		if len(l) == 0 || recordSummaryLinePattern.MatchString(l) {
 			return nil, errors.New("MALFORMED_SUMMARY")
 		}
 	}
 	return line, nil
 }
+
+var entrySummaryLinePattern = regexp.MustCompile("^[\\p{Zs}\t]*$")
 
 // NewEntrySummary creates an EntrySummary from individual lines of text.
 // Except for the first line, none of the lines can be empty or blank.
@@ -32,7 +36,7 @@ func NewEntrySummary(line ...string) (EntrySummary, error) {
 		if i == 0 {
 			continue
 		}
-		if len(l) == 0 || regexp.MustCompile(`^[\p{Zs}\t]*$`).MatchString(l) {
+		if len(l) == 0 || entrySummaryLinePattern.MatchString(l) {
 			return nil, errors.New("MALFORMED_SUMMARY")
 		}
 	}


### PR DESCRIPTION
This PR cuts the parsing time roughly in half:

- All regexes are cached now (~20% speed-up)
- The memory allocations are optimised, so it avoids dynamic allocations where possible (~5% speed-up)
- Records are parsed in parallel, so it utilises all cores of the machine (~20% speed-up)
- The preprocessing algorithm is simplified, and doesn’t rely on regexes anymore (~5% speed-up)

The improvements are only noticeable on larger data-sets, i.e. > 500 records. For smaller ones, it’s the same as before.

|Number of records|Before|After|
|-|-|-|
|10|15ms|15ms|
|100|20ms|20ms|
|1.000|60ms|35ms|
|10.000|480ms|210ms|
|100.000|4.500ms|2.000ms|

(The numbers depend on machine and test data-set, but the overall trend should be representative.)