### PR TITLE
Make benchmark more differentiated

### DIFF
--- a/.github/benchmark.sh
+++ b/.github/benchmark.sh
@@ -2,12 +2,23 @@
 
 set -e
 
-# Generate test data.
-FILE="$(mktemp)"
-go run benchmark.go 10000 > "${FILE}"
+declare -a samples=(1 10 100 1000 10000)
+ITERATIONS=3
 
 # Ensure binary is all set.
 klog > /dev/null
 
 # Run benchmark.
-time klog total --no-warn "${FILE}"
+TIMEFORMAT=%R
+for size in "${samples[@]}"; do
+  printf "%8d:  " $size
+  for _ in $(seq $ITERATIONS); do
+    # Generate new test data.
+    file="$(mktemp)"
+    go run benchmark.go "${size}" > "${file}"
+
+    runtime=$( { time klog total --no-warn "${file}" > /dev/null; } 2>&1 )
+    printf "%ss  " $runtime
+  done
+  echo
+done


### PR DESCRIPTION
Run multiple batch sizes, in 3 iterations each:

```
       1:  0.008s  0.008s  0.008s  
      10:  0.009s  0.008s  0.008s  
     100:  0.010s  0.011s  0.010s  
    1000:  0.039s  0.037s  0.040s  
   10000:  0.275s  0.279s  0.274s
```

(Before, it was just one iteration with a batch size of 10.000.)