### PR TITLE
Optionally display count in `klog tags`

### DIFF
--- a/klog/app/cli/lib/cli_serialiser.go
+++ b/klog/app/cli/lib/cli_serialiser.go
@@ -13,7 +13,7 @@ type CliSerialiser struct {
 	Decimal  bool // -> Decimal values rather than the canonical totals
 }
 
-func (cs CliSerialiser) format(s tf.Style, t string) string {
+func (cs CliSerialiser) Format(s parser.Styler, t string) string {
 	if cs.Unstyled {
 		return t
 	}
@@ -38,11 +38,11 @@ func (cs CliSerialiser) duration(d klog.Duration, withSign bool) string {
 }
 
 func (cs CliSerialiser) Date(d klog.Date) string {
-	return cs.format(tf.Style{Color: "015", IsUnderlined: true}, d.ToString())
+	return cs.Format(tf.Style{Color: "015", IsUnderlined: true}, d.ToString())
 }
 
 func (cs CliSerialiser) ShouldTotal(d klog.Duration) string {
-	return cs.format(tf.Style{Color: "213"}, cs.duration(d, false))
+	return cs.Format(tf.Style{Color: "213"}, cs.duration(d, false))
 }
 
 func (cs CliSerialiser) Summary(s parser.SummaryText) string {
@@ -52,15 +52,15 @@ func (cs CliSerialiser) Summary(s parser.SummaryText) string {
 	txt = klog.HashTagPattern.ReplaceAllStringFunc(txt, func(h string) string {
 		return cs.formatAndRestore(hashStyle, style, h)
 	})
-	return cs.format(style, txt)
+	return cs.Format(style, txt)
 }
 
 func (cs CliSerialiser) Range(r klog.Range) string {
-	return cs.format(tf.Style{Color: "117"}, r.ToString())
+	return cs.Format(tf.Style{Color: "117"}, r.ToString())
 }
 
 func (cs CliSerialiser) OpenRange(or klog.OpenRange) string {
-	return cs.format(tf.Style{Color: "027"}, or.ToString())
+	return cs.Format(tf.Style{Color: "027"}, or.ToString())
 }
 
 func (cs CliSerialiser) Duration(d klog.Duration) string {
@@ -68,7 +68,7 @@ func (cs CliSerialiser) Duration(d klog.Duration) string {
 	if d.InMinutes() < 0 {
 		f.Color = "167"
 	}
-	return cs.format(f, cs.duration(d, false))
+	return cs.Format(f, cs.duration(d, false))
 }
 
 func (cs CliSerialiser) SignedDuration(d klog.Duration) string {
@@ -76,9 +76,9 @@ func (cs CliSerialiser) SignedDuration(d klog.Duration) string {
 	if d.InMinutes() < 0 {
 		f.Color = "167"
 	}
-	return cs.format(f, cs.duration(d, true))
+	return cs.Format(f, cs.duration(d, true))
 }
 
 func (cs CliSerialiser) Time(t klog.Time) string {
-	return cs.format(tf.Style{Color: "027"}, t.ToString())
+	return cs.Format(tf.Style{Color: "027"}, t.ToString())
 }

--- a/klog/app/cli/tags_test.go
+++ b/klog/app/cli/tags_test.go
@@ -48,6 +48,38 @@ Was #sick, need to compensate later
 `, state.printBuffer)
 }
 
+func TestPrintTagsWithCount(t *testing.T) {
+	state, err := NewTestingContext()._SetRecords(`
+1995-03-17
+#sports
+	3h #badminton
+	1h #running
+	1h #running
+
+1995-03-28
+Was #sick, need to compensate later
+	-30m #running
+
+1995-04-02
+	9h something untagged
+	45m #badminton
+
+1995-04-19
+#sports #running (Don’t count that twice!)
+	14:00 - 17:00 #sports #running
+	
+`)._Run((&Tags{
+		Count: true,
+	}).Run)
+	require.Nil(t, err)
+	assert.Equal(t, `
+#badminton 3h45m  (2)
+#running   4h30m  (4)
+#sick      -30m   (1)
+#sports    8h     (4)
+`, state.printBuffer)
+}
+
 func TestPrintTagsOverviewWithValueGrouping(t *testing.T) {
 	state, err := NewTestingContext()._SetRecords(`
 1995-03-17
@@ -60,6 +92,24 @@ func TestPrintTagsOverviewWithValueGrouping(t *testing.T) {
 #ticket 4h   
  105       1h
  481       3h
+`, state.printBuffer)
+}
+
+func TestPrintTagsOverviewWithValueGroupingAndCount(t *testing.T) {
+	state, err := NewTestingContext()._SetRecords(`
+1995-03-17
+	3h #ticket=481
+	1h #ticket=105
+	1h
+`)._Run((&Tags{
+		Values: true,
+		Count:  true,
+	}).Run)
+	require.Nil(t, err)
+	assert.Equal(t, `
+#ticket 4h     (2)
+ 105       1h  (1)
+ 481       3h  (1)
 `, state.printBuffer)
 }
 

--- a/klog/parser/serialiser.go
+++ b/klog/parser/serialiser.go
@@ -5,6 +5,10 @@ import (
 	"strings"
 )
 
+type Styler interface {
+	Format(string) string
+}
+
 // Serialiser is used when the output should be modified, e.g. coloured.
 type Serialiser interface {
 	Date(klog.Date) string
@@ -15,6 +19,7 @@ type Serialiser interface {
 	Duration(klog.Duration) string
 	SignedDuration(klog.Duration) string
 	Time(klog.Time) string
+	Format(Styler, string) string
 }
 
 type Line struct {
@@ -94,3 +99,4 @@ func (ps PlainSerialiser) OpenRange(x klog.OpenRange) string     { return x.ToSt
 func (ps PlainSerialiser) Duration(x klog.Duration) string       { return x.ToString() }
 func (ps PlainSerialiser) SignedDuration(x klog.Duration) string { return x.ToString() }
 func (ps PlainSerialiser) Time(x klog.Time) string               { return x.ToString() }
+func (ps PlainSerialiser) Format(_ Styler, x string) string      { return x }

--- a/klog/service/tags_test.go
+++ b/klog/service/tags_test.go
@@ -7,6 +7,57 @@ import (
 	"testing"
 )
 
+func TestAggregateTotalTimesByTag(t *testing.T) {
+	r := klog.NewRecord(klog.Ɀ_Date_(2020, 1, 1))
+	r.SetSummary(klog.Ɀ_RecordSummary_("#foo"))
+	r.AddDuration(klog.NewDuration(1, 0), klog.Ɀ_EntrySummary_("#foo=1"))
+	r.AddDuration(klog.NewDuration(3, 0), klog.Ɀ_EntrySummary_("#foo"))
+	r.AddDuration(klog.NewDuration(0, 30), klog.Ɀ_EntrySummary_("#test"))
+
+	totals := AggregateTotalsByTags(r)
+	require.Len(t, totals, 3)
+
+	i := 0
+	assert.Equal(t, klog.NewTagOrPanic("foo", ""), totals[i].Tag)
+	assert.Equal(t, klog.NewDuration(4, 30), totals[i].Total)
+	assert.Equal(t, 3, totals[i].Count)
+
+	i++
+	assert.Equal(t, klog.NewTagOrPanic("foo", "1"), totals[i].Tag)
+	assert.Equal(t, klog.NewDuration(1, 0), totals[i].Total)
+	assert.Equal(t, 1, totals[i].Count)
+
+	i++
+	assert.Equal(t, klog.NewTagOrPanic("test", ""), totals[i].Tag)
+	assert.Equal(t, klog.NewDuration(0, 30), totals[i].Total)
+	assert.Equal(t, 1, totals[i].Count)
+}
+
+func TestAggregateTotalIgnoresRedundantTags(t *testing.T) {
+	r := klog.NewRecord(klog.Ɀ_Date_(2020, 1, 1))
+	r.SetSummary(klog.Ɀ_RecordSummary_("#foo #foo #foo=1"))
+	r.AddDuration(klog.NewDuration(1, 0), klog.Ɀ_EntrySummary_("#foo=1 #foo"))
+	r.AddDuration(klog.NewDuration(3, 0), klog.Ɀ_EntrySummary_("#foo=2 #foo=1 #foo"))
+
+	totals := AggregateTotalsByTags(r)
+	require.Len(t, totals, 3)
+
+	i := 0
+	assert.Equal(t, klog.NewTagOrPanic("foo", ""), totals[i].Tag)
+	assert.Equal(t, klog.NewDuration(4, 0), totals[i].Total)
+	assert.Equal(t, 2, totals[i].Count)
+
+	i++
+	assert.Equal(t, klog.NewTagOrPanic("foo", "1"), totals[i].Tag)
+	assert.Equal(t, klog.NewDuration(4, 0), totals[i].Total)
+	assert.Equal(t, 2, totals[i].Count)
+
+	i++
+	assert.Equal(t, klog.NewTagOrPanic("foo", "2"), totals[i].Tag)
+	assert.Equal(t, klog.NewDuration(3, 0), totals[i].Total)
+	assert.Equal(t, 1, totals[i].Count)
+}
+
 func TestAggregateTotalTimesByTagSortsAlphabetically(t *testing.T) {
 	r1 := klog.NewRecord(klog.Ɀ_Date_(2020, 1, 1))
 	r1.AddDuration(klog.NewDuration(1, 0), klog.Ɀ_EntrySummary_("#bbb"))
@@ -32,41 +83,4 @@ func TestAggregateTotalTimesByTagSortsAlphabetically(t *testing.T) {
 	assert.Equal(t, klog.NewTagOrPanic("ccc", "2"), totals[i].Tag)
 	i += 1
 	assert.Equal(t, klog.NewTagOrPanic("ddd", ""), totals[i].Tag)
-}
-
-func TestAggregateTotalTimesByTag(t *testing.T) {
-	r := klog.NewRecord(klog.Ɀ_Date_(2020, 1, 1))
-	r.SetSummary(klog.Ɀ_RecordSummary_("#foo"))
-	r.AddDuration(klog.NewDuration(1, 0), klog.Ɀ_EntrySummary_("#foo=1"))
-	r.AddDuration(klog.NewDuration(3, 0), klog.Ɀ_EntrySummary_("#foo"))
-
-	totals := AggregateTotalsByTags(r)
-	require.Len(t, totals, 2)
-	i := 0
-
-	assert.Equal(t, klog.NewTagOrPanic("foo", ""), totals[i].Tag)
-	assert.Equal(t, klog.NewDuration(4, 0), totals[i].Total)
-	i += 1
-	assert.Equal(t, klog.NewTagOrPanic("foo", "1"), totals[i].Tag)
-	assert.Equal(t, klog.NewDuration(1, 0), totals[i].Total)
-}
-
-func TestAggregateTotalIgnoresRedundantTags(t *testing.T) {
-	r := klog.NewRecord(klog.Ɀ_Date_(2020, 1, 1))
-	r.SetSummary(klog.Ɀ_RecordSummary_("#foo #foo #foo=1"))
-	r.AddDuration(klog.NewDuration(1, 0), klog.Ɀ_EntrySummary_("#foo=1 #foo"))
-	r.AddDuration(klog.NewDuration(3, 0), klog.Ɀ_EntrySummary_("#foo=2 #foo=1 #foo"))
-
-	totals := AggregateTotalsByTags(r)
-	require.Len(t, totals, 3)
-	i := 0
-
-	assert.Equal(t, klog.NewTagOrPanic("foo", ""), totals[i].Tag)
-	assert.Equal(t, klog.NewDuration(4, 0), totals[i].Total)
-	i += 1
-	assert.Equal(t, klog.NewTagOrPanic("foo", "1"), totals[i].Tag)
-	assert.Equal(t, klog.NewDuration(4, 0), totals[i].Total)
-	i += 1
-	assert.Equal(t, klog.NewTagOrPanic("foo", "2"), totals[i].Tag)
-	assert.Equal(t, klog.NewDuration(3, 0), totals[i].Total)
 }


### PR DESCRIPTION
Resolves https://github.com/jotaen/klog/issues/227.

Note, `--count` does not count how often a tag *appears* in the file, but how many entries *match* against it. I.e., the tag count for the following data is 4:

```
2000-01-01
#foo All 3 entries below match:
  1h
  2h
  3h

2000-01-02
  1h #foo #foo This entry is only counted once
```

It also works in conjunction with `--values`.