### PR TITLE
Support `$EDITOR` containing flags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go v0.104.0
 	github.com/alecthomas/kong v0.6.1
 	github.com/jotaen/kong-completion v0.0.4
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/posener/complete v1.2.3
 	github.com/stretchr/testify v1.7.2
 )

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/jotaen/kong-completion v0.0.4 h1:WOn4iXzJqEgKhMah8gc/hHuWazlrb3GNvwCTnjIJJ40=
 github.com/jotaen/kong-completion v0.0.4/go.mod h1:FShMtyKD5+PFrlTJWutqdFcxR5WTPDXd+kN38w7OCfs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/klog.go
+++ b/klog.go
@@ -36,7 +36,10 @@ func main() {
 	if os.Getenv("KLOG_BETA_PARALLEL") != "" {
 		prefs.CpuKernels = runtime.NumCPU()
 	}
-	prefs.Editor = os.Getenv("EDITOR")
+	prefs.Editor = os.Getenv("KLOG_EDITOR")
+	if prefs.Editor == "" {
+		prefs.Editor = os.Getenv("EDITOR")
+	}
 	homeDir, err := user.Current()
 	if err != nil {
 		fmt.Println("Failed to initialise application. Error:")

--- a/klog/app/cli/goto_test.go
+++ b/klog/app/cli/goto_test.go
@@ -18,7 +18,8 @@ func TestGotoLocation(t *testing.T) {
 	}).Run)
 	require.Nil(t, err)
 	assert.Equal(t, 1, spy.Count)
-	assert.Equal(t, "goto --file /tmp", spy.LastCmd.ToString())
+	assert.Equal(t, "goto", spy.LastCmd.Bin)
+	assert.Equal(t, []string{"--file", "/tmp"}, spy.LastCmd.Args)
 }
 
 func TestGotoLocationFirstSucceeds(t *testing.T) {
@@ -37,7 +38,8 @@ func TestGotoLocationFirstSucceeds(t *testing.T) {
 	}).Run)
 	require.Nil(t, err)
 	assert.Equal(t, 2, spy.Count)
-	assert.Equal(t, "goto2 /tmp", spy.LastCmd.ToString())
+	assert.Equal(t, "goto2", spy.LastCmd.Bin)
+	assert.Equal(t, []string{"/tmp"}, spy.LastCmd.Args)
 }
 
 func TestGotoFails(t *testing.T) {

--- a/klog/app/cli/lib/command/command.go
+++ b/klog/app/cli/lib/command/command.go
@@ -1,16 +1,26 @@
 package command
 
-import "strings"
+import (
+	"errors"
+	"github.com/kballard/go-shellquote"
+)
 
 type Command struct {
 	Bin  string
 	Args []string
 }
 
-func New(bin string, args []string) Command {
-	return Command{Bin: bin, Args: args}
+func NewFromString(command string) (Command, error) {
+	words, err := shellquote.Split(command)
+	if err != nil {
+		return Command{}, err
+	}
+	if len(words) == 0 {
+		return Command{}, errors.New("Empty command")
+	}
+	return New(words[0], words[1:]), nil
 }
 
-func (c Command) ToString() string {
-	return c.Bin + " " + strings.Join(c.Args, " ")
+func New(bin string, args []string) Command {
+	return Command{Bin: bin, Args: args}
 }


### PR DESCRIPTION
Resolves https://github.com/jotaen/klog/issues/230.

- `$EDITOR` can now contain flags, such as `subl --wait` or `vi -R`
- In case the binary path itself contains spaces, it must be quoted, so that klog is able to distinguish the full path from any additional flags. E.g.
  `EDITOR='"C:\Program Files\Sublime Text" --wait'`
- Instead of `$EDITOR`, you can alternatively specify `$KLOG_EDITOR`. This is for the case where quoting would create problems for other programs that can’t handle quotes in `$EDITOR`. That way, you can configure a klog-specific override, which takes precedence over `$EDITOR`.