### PR TITLE
Simplify logic of `klog pause`

### DIFF
--- a/klog/app/cli/lib/cli_serialiser.go
+++ b/klog/app/cli/lib/cli_serialiser.go
@@ -13,6 +13,15 @@ type CliSerialiser struct {
 	Decimal  bool // -> Decimal values rather than the canonical totals
 }
 
+var (
+	Green     = tf.Style{Color: "120"}
+	Red       = tf.Style{Color: "167"}
+	BlueDark  = tf.Style{Color: "117"}
+	BlueLight = tf.Style{Color: "027"}
+	Subdued   = tf.Style{Color: "249"}
+	Purple    = tf.Style{Color: "213"}
+)
+
 func (cs CliSerialiser) Format(s parser.Styler, t string) string {
 	if cs.Unstyled {
 		return t
@@ -42,12 +51,12 @@ func (cs CliSerialiser) Date(d klog.Date) string {
 }
 
 func (cs CliSerialiser) ShouldTotal(d klog.Duration) string {
-	return cs.Format(tf.Style{Color: "213"}, cs.duration(d, false))
+	return cs.Format(Purple, cs.duration(d, false))
 }
 
 func (cs CliSerialiser) Summary(s parser.SummaryText) string {
 	txt := s.ToString()
-	style := tf.Style{Color: "249"}
+	style := Subdued
 	hashStyle := style.ChangedBold(true).ChangedColor("251")
 	txt = klog.HashTagPattern.ReplaceAllStringFunc(txt, func(h string) string {
 		return cs.formatAndRestore(hashStyle, style, h)
@@ -56,29 +65,29 @@ func (cs CliSerialiser) Summary(s parser.SummaryText) string {
 }
 
 func (cs CliSerialiser) Range(r klog.Range) string {
-	return cs.Format(tf.Style{Color: "117"}, r.ToString())
+	return cs.Format(BlueDark, r.ToString())
 }
 
 func (cs CliSerialiser) OpenRange(or klog.OpenRange) string {
-	return cs.Format(tf.Style{Color: "027"}, or.ToString())
+	return cs.Format(BlueLight, or.ToString())
 }
 
 func (cs CliSerialiser) Duration(d klog.Duration) string {
-	f := tf.Style{Color: "120"}
+	f := Green
 	if d.InMinutes() < 0 {
-		f.Color = "167"
+		f = Red
 	}
 	return cs.Format(f, cs.duration(d, false))
 }
 
 func (cs CliSerialiser) SignedDuration(d klog.Duration) string {
-	f := tf.Style{Color: "120"}
+	f := Green
 	if d.InMinutes() < 0 {
-		f.Color = "167"
+		f = Red
 	}
 	return cs.Format(f, cs.duration(d, true))
 }
 
 func (cs CliSerialiser) Time(t klog.Time) string {
-	return cs.Format(tf.Style{Color: "027"}, t.ToString())
+	return cs.Format(BlueLight, t.ToString())
 }

--- a/klog/app/cli/lib/helper.go
+++ b/klog/app/cli/lib/helper.go
@@ -12,12 +12,7 @@ type ReconcileOpts struct {
 }
 
 func Reconcile(ctx app.Context, opts ReconcileOpts, creators []reconciling.Creator, reconcile reconciling.Reconcile) app.Error {
-	result, err := ctx.ReconcileFile(
-		true,
-		opts.OutputFileArgs.File,
-		creators,
-		reconcile,
-	)
+	result, err := ctx.ReconcileFile(opts.OutputFileArgs.File, creators, reconcile)
 	if err != nil {
 		return err
 	}

--- a/klog/app/cli/pause.go
+++ b/klog/app/cli/pause.go
@@ -11,61 +11,85 @@ import (
 
 type Pause struct {
 	Summary klog.EntrySummary `name:"summary" short:"s" placeholder:"TEXT" help:"Summary text for the pause entry"`
+	Extend  bool              `name:"extend" short:"e" help:"Extend latest pause, instead of adding a new pause entry"`
 	lib.OutputFileArgs
+	lib.NoStyleArgs
 	lib.WarnArgs
 }
 
 func (opt *Pause) Help() string {
-	return `This doesn’t actually stop the open-ended time range.
-Instead, it adds/extends an entry underneath the open-ended time range that contains the duration of the pause.
-The command is blocking, and it keeps updating the pause entry until the process is exited.
+	return `Creates a pause entry for a record with an open time range.
+The command is blocking – it keeps updating the pause entry until the process is exited.
 (The file will be written into once per minute.)
 `
 }
 
 func (opt *Pause) Run(ctx app.Context) app.Error {
-	// We don’t rely on the accumulated counter, because then it might
-	// also accumulate imprecisions over time. Therefore, we always base the
-	// increment off the initial start time.
-	//
-	// Upon initial invocation, it performs one dry-run. This is for detecting – and,
-	// more importantly: displaying – errors right away; like malicious syntax,
-	// or if there is no open-ended time range.
-	start := gotime.Now()
-	minsProcessed := 0
-	isDryRun := true
-	return lib.WithRepeat(ctx.Print, 500*gotime.Millisecond, func(counter int64) app.Error {
-		dots := strings.Repeat(".", int(counter%4))
-		diffMins := int(-1 * gotime.Time.Sub(start, gotime.Now()).Minutes())
-		ctx.Print("Pausing since " +
-			klog.NewTimeFromGo(start).ToString() +
-			" (" +
-			ctx.Serialiser().Duration(klog.NewDuration(0, diffMins)) +
-			")" + dots + "\n")
-		if counter < 14 {
-			// Display exit hint for a couple of seconds.
-			ctx.Print("\n")
-			ctx.Print("Press ^C to stop\n")
-		}
-		increment := diffMins - minsProcessed
-		if !isDryRun && increment <= 0 {
-			return nil
-		}
-		minsProcessed += increment
-		today := klog.NewDateFromGo(gotime.Now())
+	opt.NoStyleArgs.Apply(&ctx)
+	today := klog.NewDateFromGo(gotime.Now())
+	doReconcile := func(reconcile reconciling.Reconcile) app.Error {
 		_, err := ctx.ReconcileFile(
-			!isDryRun,
 			opt.OutputFileArgs.File,
 			[]reconciling.Creator{
 				reconciling.NewReconcilerAtRecord(today),
 				reconciling.NewReconcilerAtRecord(today.PlusDays(-1)),
 			},
-
-			func(reconciler *reconciling.Reconciler) (*reconciling.Result, error) {
-				return reconciler.PauseOpenRange(klog.NewDuration(0, -1*increment), opt.Summary)
-			},
+			reconcile,
 		)
-		isDryRun = false
 		return err
+	}
+
+	// Initial run:
+	// Ensure that an open range exists, and set up the pause entry:
+	// - Without `--extend`, append a new entry, including the summary
+	// - With `--extend`, find a pause and append the summary
+	err := doReconcile(func(reconciler *reconciling.Reconciler) (*reconciling.Result, error) {
+		if opt.Extend {
+			return reconciler.ExtendPause(klog.NewDuration(0, 0), opt.Summary)
+		}
+		return reconciler.AppendPause(opt.Summary)
+	})
+	if err != nil {
+		return err
+	}
+
+	// Subsequent runs:
+	// We don’t rely on the accumulated counter, because then it might also accumulate
+	// imprecisions over time. Therefore, we always base the increment off the initial
+	// start time.
+	start := gotime.Now()
+	minsCaptured := 0 // The amount of minutes that have already been written into the file.
+	return lib.WithRepeat(ctx.Print, 500*gotime.Millisecond, func(counter int64) app.Error {
+		dots := strings.Repeat(".", int(counter%4))
+		ctx.Print("" +
+			"Pausing for " +
+			// Always print number in red, but without sign
+			ctx.Serialiser().Format(lib.Red, klog.NewDuration(0, minsCaptured).ToString()) +
+			dots + "\n" +
+			"(since " +
+			klog.NewTimeFromGo(start).ToString() +
+			")\n")
+		if counter < 14 {
+			// Display exit hint for a couple of seconds.
+			ctx.Print("\n")
+			ctx.Print("Press ^C to stop\n")
+		}
+
+		diffMins := int(gotime.Time.Sub(gotime.Now(), start).Minutes())
+		increment := diffMins - minsCaptured
+		if increment > 0 {
+			minsCaptured += increment
+			err := doReconcile(func(reconciler *reconciling.Reconciler) (*reconciling.Result, error) {
+				// Don’t add the summary, as we already appended it in the initial run.
+				return reconciler.ExtendPause(klog.NewDuration(0, -1*increment), nil)
+			})
+			if err != nil {
+				return err
+			}
+			ctx.Debug(func() {
+				ctx.Print("File saved.\n")
+			})
+		}
+		return nil
 	})
 }

--- a/klog/app/cli/testcontext_test.go
+++ b/klog/app/cli/testcontext_test.go
@@ -120,14 +120,12 @@ func (ctx *TestingContext) ReadInputs(_ ...app.FileOrBookmarkName) ([]klog.Recor
 	return ctx.records, nil
 }
 
-func (ctx *TestingContext) ReconcileFile(doWrite bool, _ app.FileOrBookmarkName, creators []reconciling.Creator, reconcile reconciling.Reconcile) (*reconciling.Result, app.Error) {
+func (ctx *TestingContext) ReconcileFile(_ app.FileOrBookmarkName, creators []reconciling.Creator, reconcile reconciling.Reconcile) (*reconciling.Result, app.Error) {
 	result, err := app.ApplyReconciler(ctx.records, ctx.blocks, creators, reconcile)
 	if err != nil {
 		return nil, err
 	}
-	if doWrite {
-		ctx.writtenFileContents = result.AllSerialised
-	}
+	ctx.writtenFileContents = result.AllSerialised
 	return result, nil
 }
 

--- a/klog/app/context.go
+++ b/klog/app/context.go
@@ -49,9 +49,7 @@ type Context interface {
 	RetrieveTargetFile(fileArg FileOrBookmarkName) (FileWithContents, Error)
 
 	// ReconcileFile applies one or more reconcile handlers to a file and saves it.
-	// The boolean argument specifies whether the result shall be written into the file (true),
-	// or whether it should only perform a dry-run (false).
-	ReconcileFile(bool, FileOrBookmarkName, []reconciling.Creator, reconciling.Reconcile) (*reconciling.Result, Error)
+	ReconcileFile(FileOrBookmarkName, []reconciling.Creator, reconciling.Reconcile) (*reconciling.Result, Error)
 
 	// Now returns the current timestamp.
 	Now() gotime.Time
@@ -235,7 +233,7 @@ func (ctx *context) RetrieveTargetFile(fileArg FileOrBookmarkName) (FileWithCont
 	return inputs[0], nil
 }
 
-func (ctx *context) ReconcileFile(doWrite bool, fileArg FileOrBookmarkName, creators []reconciling.Creator, reconcile reconciling.Reconcile) (*reconciling.Result, Error) {
+func (ctx *context) ReconcileFile(fileArg FileOrBookmarkName, creators []reconciling.Creator, reconcile reconciling.Reconcile) (*reconciling.Result, Error) {
 	target, err := ctx.RetrieveTargetFile(fileArg)
 	if err != nil {
 		return nil, err
@@ -248,11 +246,9 @@ func (ctx *context) ReconcileFile(doWrite bool, fileArg FileOrBookmarkName, crea
 	if aErr != nil {
 		return nil, aErr
 	}
-	if doWrite {
-		wErr := WriteToFile(target, result.AllSerialised)
-		if wErr != nil {
-			return nil, wErr
-		}
+	wErr := WriteToFile(target, result.AllSerialised)
+	if wErr != nil {
+		return nil, wErr
 	}
 	return result, nil
 }

--- a/klog/parser/reconciling/close_open_range.go
+++ b/klog/parser/reconciling/close_open_range.go
@@ -29,26 +29,6 @@ func (r *Reconciler) CloseOpenRange(endTime Styled[klog.Time], additionalSummary
 			"${1}"+endTime.Value.ToStringWithFormat(timeFormat)+"${2}",
 		)
 
-	// Append additional summary text. Due to multiline entry summaries, that might
-	// not be the same line as the time value.
-	openRangeLastSummaryLineIndex := openRangeValueLineIndex + countLines([]klog.Entry{r.Record.Entries()[openRangeEntryIndex]}) - 1
-	if len(additionalSummary) > 0 {
-		if len(additionalSummary[0]) > 0 {
-			// If there is additional summary text, always prepend a space to delimit
-			// the additional summary from either the time value or from an already
-			// existing summary text.
-			r.lines[openRangeLastSummaryLineIndex].Text += " "
-		}
-		r.lines[openRangeLastSummaryLineIndex].Text += additionalSummary[0]
-	}
-
-	if len(additionalSummary) > 1 {
-		var subsequentSummaryLines []insertableText
-		for _, nextLine := range additionalSummary[1:] {
-			subsequentSummaryLines = append(subsequentSummaryLines, insertableText{nextLine, 2})
-		}
-		r.insert(openRangeLastSummaryLineIndex+1, subsequentSummaryLines)
-	}
-
+	r.concatenateSummary(openRangeEntryIndex, openRangeValueLineIndex, additionalSummary)
 	return r.MakeResult()
 }


### PR DESCRIPTION
Resolves https://github.com/jotaen/klog/issues/228.

This PR simplifies the logic of `klog pause`:

- `klog pause` appends a new pause entry to the record
  - The pause entry will be added as last entry
  - It adds the new entry directly, without waiting out the first minute. During the first minute, the entry value is `-0m`.
  - There is no auto-magic auto-extending of existing pause entries
- If `--extend` is specified, it keeps adding to the last pause entry
  - If `--summary` is specified, the summary text will be appended to the existing pause entry
  - If there is no pause entry, the command fails