### PR TITLE
Improve UI around `--now` flag

### DIFF
--- a/klog/app/cli/json.go
+++ b/klog/app/cli/json.go
@@ -36,7 +36,7 @@ func (opt *Json) Run(ctx app.Context) app.Error {
 		return err
 	}
 	now := ctx.Now()
-	records, nErr := opt.ApplyNow(now, records...)
+	nErr := opt.ApplyNow(now, records...)
 	if nErr != nil {
 		return nErr
 	}

--- a/klog/app/cli/lib/helper.go
+++ b/klog/app/cli/lib/helper.go
@@ -17,6 +17,6 @@ func Reconcile(ctx app.Context, opts ReconcileOpts, creators []reconciling.Creat
 		return err
 	}
 	ctx.Print("\n" + parser.SerialiseRecords(ctx.Serialiser(), result.Record).ToString() + "\n")
-	opts.WarnArgs.PrintWarnings(ctx, result.AllRecords)
+	opts.WarnArgs.PrintWarnings(ctx, result.AllRecords, nil)
 	return nil
 }

--- a/klog/app/cli/lib/prettifier.go
+++ b/klog/app/cli/lib/prettifier.go
@@ -49,12 +49,17 @@ func PrettifyError(err error, isDebug bool) error {
 	return errors.New("Error: " + err.Error())
 }
 
-// PrettifyWarning turns an error into a coloured and well-structured form.
+// PrettifyWarning formats a warning about a record.
 func PrettifyWarning(w service.Warning) string {
+	return PrettifyGeneralWarning(w.Date().ToString() + ": " + w.Warning())
+}
+
+// PrettifyGeneralWarning formats a general warning message.
+func PrettifyGeneralWarning(message string) string {
 	result := ""
 	result += terminalformat.Style{Background: "227", Color: "000"}.Format(" WARNING ")
 	result += " "
-	result += terminalformat.Style{Color: "227"}.Format(w.Date().ToString() + ": " + w.Warning())
+	result += terminalformat.Style{Color: "227"}.Format(message)
 	result += "\n"
 	return result
 }

--- a/klog/app/cli/print.go
+++ b/klog/app/cli/print.go
@@ -44,7 +44,7 @@ func (opt *Print) Run(ctx app.Context) app.Error {
 	}()
 	ctx.Print(output + "\n")
 
-	opt.WarnArgs.PrintWarnings(ctx, records)
+	opt.WarnArgs.PrintWarnings(ctx, records, nil)
 	return nil
 }
 

--- a/klog/app/cli/report.go
+++ b/klog/app/cli/report.go
@@ -35,7 +35,7 @@ func (opt *Report) Run(ctx app.Context) app.Error {
 	if len(records) == 0 {
 		return nil
 	}
-	records, nErr := opt.ApplyNow(now, records...)
+	nErr := opt.ApplyNow(now, records...)
 	if nErr != nil {
 		return nErr
 	}
@@ -107,7 +107,7 @@ func (opt *Report) Run(ctx app.Context) app.Error {
 	}
 
 	table.Collect(ctx.Print)
-	opt.WarnArgs.PrintWarnings(ctx, records)
+	opt.WarnArgs.PrintWarnings(ctx, records, opt.GetNowWarnings())
 	return nil
 }
 

--- a/klog/app/cli/tags.go
+++ b/klog/app/cli/tags.go
@@ -28,7 +28,7 @@ func (opt *Tags) Run(ctx app.Context) app.Error {
 	}
 	now := ctx.Now()
 	records = opt.ApplyFilter(now, records)
-	records, nErr := opt.ApplyNow(now, records...)
+	nErr := opt.ApplyNow(now, records...)
 	if nErr != nil {
 		return nErr
 	}
@@ -66,6 +66,6 @@ func (opt *Tags) Run(ctx app.Context) app.Error {
 		}
 	}
 	table.Collect(ctx.Print)
-	opt.WarnArgs.PrintWarnings(ctx, records)
+	opt.WarnArgs.PrintWarnings(ctx, records, opt.GetNowWarnings())
 	return nil
 }

--- a/klog/app/cli/today_test.go
+++ b/klog/app/cli/today_test.go
@@ -104,11 +104,37 @@ All         10h25m    9h10m!   +1h15m      16:58
 `, state.printBuffer)
 }
 
+func TestPrintsEvaluationWithDiffAndNowEndTimeInParenthesisIfNoOpenRange(t *testing.T) {
+	state, err := NewTestingContext()._SetNow(1999, 3, 14, 21, 05)._SetRecords(`
+1999-03-12 (3h10m!)
+	6h50m
+
+1999-03-14 (6h!)
+	14:38 - 21:05
+`)._Run((&Today{
+		DiffArgs: lib.DiffArgs{Diff: true},
+		NowArgs:  lib.NowArgs{Now: true},
+		WarnArgs: lib.WarnArgs{NoWarn: true},
+	}).Run)
+	require.Nil(t, err)
+	assert.Equal(t, `
+             Total    Should     Diff   End-Time
+Today        6h27m       6h!     +27m    (20:38)
+Other        6h50m    3h10m!   +3h40m           
+          ======== ========= ========           
+All         13h17m    9h10m!    +4h7m    (16:58)
+`, state.printBuffer)
+}
+
 func TestPrintsPlaceholderIfEndTimeIsOutOfBounds(t *testing.T) {
 	state, err := NewTestingContext()._SetNow(1999, 3, 14, 18, 13)._SetRecords(`
 1999-03-14 (60h!)
 	1h
-`)._Run((&Today{DiffArgs: lib.DiffArgs{Diff: true}, NowArgs: lib.NowArgs{Now: true}}).Run)
+`)._Run((&Today{
+		DiffArgs: lib.DiffArgs{Diff: true},
+		NowArgs:  lib.NowArgs{Now: true},
+		WarnArgs: lib.WarnArgs{NoWarn: true},
+	}).Run)
 	require.Nil(t, err)
 	assert.Equal(t, `
              Total    Should     Diff   End-Time
@@ -123,7 +149,11 @@ func TestPrintsNAWhenNoCurrentRecord(t *testing.T) {
 	state, err := NewTestingContext()._SetNow(1999, 3, 16, 18, 13)._SetRecords(`
 1999-03-12 (3h10m!)
 	6h50m
-`)._Run((&Today{DiffArgs: lib.DiffArgs{Diff: true}, NowArgs: lib.NowArgs{Now: true}}).Run)
+`)._Run((&Today{
+		DiffArgs: lib.DiffArgs{Diff: true},
+		NowArgs:  lib.NowArgs{Now: true},
+		WarnArgs: lib.WarnArgs{NoWarn: true},
+	}).Run)
 	require.Nil(t, err)
 	assert.Equal(t, `
              Total    Should     Diff   End-Time

--- a/klog/app/cli/total.go
+++ b/klog/app/cli/total.go
@@ -34,7 +34,7 @@ func (opt *Total) Run(ctx app.Context) app.Error {
 	}
 	now := ctx.Now()
 	records = opt.ApplyFilter(now, records)
-	records, nErr := opt.ApplyNow(now, records...)
+	nErr := opt.ApplyNow(now, records...)
 	if nErr != nil {
 		return nErr
 	}
@@ -53,6 +53,6 @@ func (opt *Total) Run(ctx app.Context) app.Error {
 		return "s"
 	}()))
 
-	opt.WarnArgs.PrintWarnings(ctx, records)
+	opt.WarnArgs.PrintWarnings(ctx, records, opt.GetNowWarnings())
 	return nil
 }

--- a/klog/service/record_test.go
+++ b/klog/service/record_test.go
@@ -8,38 +8,41 @@ import (
 	gotime "time"
 )
 
-func TestReturnsOriginalRecordsIfNoOpenRange(t *testing.T) {
+func TestDoesNotTouchRecordsIfNoOpenRange(t *testing.T) {
 	r := klog.NewRecord(klog.Ɀ_Date_(2020, 1, 1))
 	r.AddDuration(klog.NewDuration(1, 0), nil)
 	r.AddRange(klog.Ɀ_Range_(klog.Ɀ_Time_(1, 0), klog.Ɀ_Time_(2, 0)), nil)
 
-	result, err := CloseOpenRanges(gotime.Now(), r)
+	hasClosedAnyRange, err := CloseOpenRanges(gotime.Now(), r)
 	require.Nil(t, err)
-	assert.Equal(t, klog.NewDuration(2, 0), Total(result...))
+	assert.False(t, hasClosedAnyRange)
+	assert.Equal(t, klog.NewDuration(2, 0), Total(r))
 }
 
-func TestReturnsRecordsWithClosedOpenRange(t *testing.T) {
+func TestClosesOpenRange(t *testing.T) {
 	r := klog.NewRecord(klog.Ɀ_Date_(2020, 1, 1))
 	r.AddDuration(klog.NewDuration(1, 0), nil)
 	r.AddRange(klog.Ɀ_Range_(klog.Ɀ_Time_(1, 0), klog.Ɀ_Time_(2, 0)), nil)
 	r.Start(klog.NewOpenRange(klog.Ɀ_Time_(3, 0)), nil)
 
 	endTime, _ := gotime.Parse("2006-01-02T15:04:05-0700", "2020-01-01T05:30:00-0000")
-	result, err := CloseOpenRanges(endTime, r)
+	hasClosedAnyRange, err := CloseOpenRanges(endTime, r)
 	require.Nil(t, err)
-	assert.Equal(t, klog.NewDuration(2+2, 30), Total(result...))
+	assert.True(t, hasClosedAnyRange)
+	assert.Equal(t, klog.NewDuration(2+2, 30), Total(r))
 }
 
-func TestReturnsRecordsWithClosedOpenRangeAndShiftedTime(t *testing.T) {
+func TestClosesOpenRangeAndShiftsTime(t *testing.T) {
 	r := klog.NewRecord(klog.Ɀ_Date_(2020, 1, 1))
 	r.AddDuration(klog.NewDuration(1, 0), nil)
 	r.AddRange(klog.Ɀ_Range_(klog.Ɀ_Time_(1, 0), klog.Ɀ_Time_(2, 0)), nil)
 	r.Start(klog.NewOpenRange(klog.Ɀ_Time_(3, 0)), nil)
 
 	endTime, _ := gotime.Parse("2006-01-02T15:04:05-0700", "2020-01-02T05:30:00-0000")
-	result, err := CloseOpenRanges(endTime, r)
+	hasClosedAnyRange, err := CloseOpenRanges(endTime, r)
 	require.Nil(t, err)
-	assert.Equal(t, klog.NewDuration(2+24+2, 30), Total(result...))
+	assert.True(t, hasClosedAnyRange)
+	assert.Equal(t, klog.NewDuration(2+24+2, 30), Total(r))
 }
 
 func TestReturnsErrorIfOpenRangeCannotBeClosedAnymore(t *testing.T) {
@@ -49,9 +52,8 @@ func TestReturnsErrorIfOpenRangeCannotBeClosedAnymore(t *testing.T) {
 	r.Start(klog.NewOpenRange(klog.Ɀ_Time_(3, 0)), nil)
 
 	endTime, _ := gotime.Parse("2006-01-02T15:04:05-0700", "2020-01-03T05:30:00-0000")
-	result, err := CloseOpenRanges(endTime, r)
+	_, err := CloseOpenRanges(endTime, r)
 	require.Error(t, err)
-	assert.Nil(t, result)
 }
 
 func TestReturnsErrorIfOpenRangeCannotBeClosedYet(t *testing.T) {
@@ -61,7 +63,6 @@ func TestReturnsErrorIfOpenRangeCannotBeClosedYet(t *testing.T) {
 	r.Start(klog.NewOpenRange(klog.Ɀ_Time_(3, 0)), nil)
 
 	endTime, _ := gotime.Parse("2006-01-02T15:04:05-0700", "2020-01-01T01:30:00-0000")
-	result, err := CloseOpenRanges(endTime, r)
+	_, err := CloseOpenRanges(endTime, r)
 	require.Error(t, err)
-	assert.Nil(t, result)
 }


### PR DESCRIPTION
Resolves https://github.com/jotaen/klog/issues/245.

When specifying `--now` without any open-ended time range being present in the data, then klog emits a warning, so that users are aware that the flag didn’t take any effect. For `klog today`, the forecasted end-time is additionally put into parentheses and rendered in subdued colour, to indicate that you are currently not actively moving towards the time goal.

<img width="660" alt="Screenshot 2023-02-11 at 10 14 36" src="https://user-images.githubusercontent.com/3618384/218250440-b9ab26f0-70ec-44c6-92f2-ecc7e8ae2364.png">

I also thought about the topic from the ticket what to do once the end-time has been reached, and whether it should be hidden in this case. I eventually think one can make good points either way: on the one hand, it’s true that the end-time is mostly interesting while it’s in the future. On the other hand, it might also potentially be interesting to know like “I could have gone home at 17:30 already”. My other concern is that it could cause confusion when the logic around the end-time display becomes too complex, i.e. that users wouldn’t intuitively understand the conditions under which the end-time would appear or disappear. So I think it’s most straightforward to leave it as is, and have the end-time always show up.

This PR also fixes a semi-related bug in `klog today` that I stumbled across: in case there are unclosable open time ranges (i.e. ones before yesterday), [then `klog today` now correctly produces an error](https://github.com/jotaen/klog/pull/247/files#diff-ebd93d213675b521dc9704a41f936f1aa3027234aa99c81fa57cd9e943370cc4L67-R65). Before, it would just render blank output, without any indication of an error.