### PR TITLE
Introduce file-based user configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/posener/complete v1.2.3
 	github.com/stretchr/testify v1.7.2
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -18,5 +19,4 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/riywo/loginshell v0.0.0-20200815045211-7d26008be1ab // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/klog.go
+++ b/klog.go
@@ -79,7 +79,7 @@ func fail(e error, isDebug bool) {
 // readConfigFile reads the config file from disk, if present.
 // If not present, it returns empty string.
 func readConfigFile(klogFolderPath string) (string, error) {
-	file, fErr := app.NewFile(klogFolderPath + app.CONFIG_FILE)
+	file, fErr := app.NewFile(klogFolderPath + app.CONFIG_FILE_NAME)
 	if fErr != nil {
 		return "", fErr
 	}
@@ -113,5 +113,5 @@ func determineKlogFolderPath() (app.File, error) {
 	if fErr != nil {
 		return nil, fErr
 	}
-	return app.Join(f, app.KLOG_FOLDER), nil
+	return app.Join(f, app.KLOG_FOLDER_NAME), nil
 }

--- a/klog.go
+++ b/klog.go
@@ -95,7 +95,7 @@ func readConfigFile(location app.File) (string, error) {
 // - $XDG_CONFIG_HOME, if set
 // - The default home folder, e.g. `~`
 func determineKlogFolderLocation() (app.File, error) {
-	location := os.Getenv("$KLOG_FOLDER_LOCATION")
+	location := os.Getenv("KLOG_FOLDER_LOCATION")
 	if os.Getenv("XDG_CONFIG_HOME") != "" {
 		location = os.Getenv("XDG_CONFIG_HOME")
 	} else if location == "" {

--- a/klog.go
+++ b/klog.go
@@ -93,13 +93,16 @@ func readConfigFile(klogFolderPath string) (string, error) {
 	return contents, nil
 }
 
-// determineKlogFolderPath returns the path of the `.klog` folder, based on the
-// following precedence:
-// - $XDG_CONFIG_HOME if set
+// determineKlogFolderPath returns the path of the `.klog` folder, determined by
+// following this lookup precedence:
+// - $KLOG_FOLDER_LOCATION, if set
+// - $XDG_CONFIG_HOME, if set
 // - The default home folder, e.g. `~`
 func determineKlogFolderPath() (app.File, error) {
-	location := os.Getenv("XDG_CONFIG_HOME")
-	if location == "" {
+	location := os.Getenv("$KLOG_FOLDER_LOCATION")
+	if os.Getenv("XDG_CONFIG_HOME") != "" {
+		location = os.Getenv("XDG_CONFIG_HOME")
+	} else if location == "" {
 		homeDir, hErr := user.Current()
 		if hErr != nil {
 			return nil, hErr

--- a/klog/app/cli/config.go
+++ b/klog/app/cli/config.go
@@ -11,7 +11,7 @@ type Config struct {
 }
 
 func (opt *Config) Help() string {
-	return `You are able to configure some of klog’s behaviour via a YAML file in your ` + "`" + app.KLOG_FOLDER + "`" + ` folder. (Run ` + "`" + `klog config --file-path` + "`" + ` to print the exact location.)
+	return `You are able to configure some of klog’s behaviour via a YAML file in your ` + "`" + app.KLOG_FOLDER_NAME + "`" + ` folder. (Run ` + "`" + `klog config --file-path` + "`" + ` to print the exact location.)
 
 If you run ` + "`" + `klog config` + "`" + `, you can learn about the supported YAML properties in the file, and you also see what values are in effect at the moment.
 
@@ -20,7 +20,7 @@ Note: the output of the command does not print the actual file. You may, however
 
 func (opt *Config) Run(ctx app.Context) app.Error {
 	if opt.ConfigFilePath {
-		ctx.Print(app.Join(ctx.KlogFolder(), app.CONFIG_FILE).Path() + "\n")
+		ctx.Print(app.Join(ctx.KlogFolder(), app.CONFIG_FILE_NAME).Path() + "\n")
 		return nil
 	}
 	for i, e := range app.CONFIG_FILE_ENTRIES {

--- a/klog/app/cli/config.go
+++ b/klog/app/cli/config.go
@@ -11,9 +11,11 @@ type Config struct {
 }
 
 func (opt *Config) Help() string {
-	return `You are able to configure some of klog’s behaviour via a YAML filed in your ` + "`" + app.KLOG_FOLDER + "`" + ` folder. (Run ` + "`" + `klog config --file-path` + "`" + ` to print the exact location.)
+	return `You are able to configure some of klog’s behaviour via a YAML file in your ` + "`" + app.KLOG_FOLDER + "`" + ` folder. (Run ` + "`" + `klog config --file-path` + "`" + ` to print the exact location.)
 
-If you run ` + "`" + `klog config` + "`" + `, you can learn about the supported YAML properties in the file, and you also see what values are in effect at the moment. (Note: the output of the command does not print the actual file!)`
+If you run ` + "`" + `klog config` + "`" + `, you can learn about the supported YAML properties in the file, and you also see what values are in effect at the moment.
+
+Note: the output of the command does not print the actual file. You may, however, use the output as template for setting up the file, as its YAML-formatted.`
 }
 
 func (opt *Config) Run(ctx app.Context) app.Error {

--- a/klog/app/cli/config.go
+++ b/klog/app/cli/config.go
@@ -6,15 +6,21 @@ import (
 	"github.com/jotaen/klog/klog/app/cli/lib/terminalformat"
 )
 
-type Config struct{}
+type Config struct {
+	ConfigFilePath bool `name:"file-path" help:"Prints the path to your config file"`
+}
 
 func (opt *Config) Help() string {
-	return `By placing a YAML file at ~/` + app.KLOG_FOLDER + app.CONFIG_FILE + ` you are able to configure some of klog’s behaviour.
+	return `You are able to configure some of klog’s behaviour via a YAML filed in your ` + "`" + app.KLOG_FOLDER + "`" + ` folder. (Run ` + "`" + `klog config --file-path` + "`" + ` to print the exact location.)
 
 If you run ` + "`" + `klog config` + "`" + `, you can learn about the supported YAML properties in the file, and you also see what values are in effect at the moment. (Note: the output of the command does not print the actual file!)`
 }
 
 func (opt *Config) Run(ctx app.Context) app.Error {
+	if opt.ConfigFilePath {
+		ctx.Print(app.Join(ctx.KlogFolder(), app.CONFIG_FILE).Path() + "\n")
+		return nil
+	}
 	for i, e := range app.CONFIG_FILE_ENTRIES {
 		ctx.Print(lib.Subdued.Format(lib.Reflower.Reflow(e.Description+"\n"+e.Instructions, "# ")))
 		ctx.Print("\n")

--- a/klog/app/cli/config.go
+++ b/klog/app/cli/config.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"github.com/jotaen/klog/klog/app"
+	"github.com/jotaen/klog/klog/app/cli/lib"
+	"github.com/jotaen/klog/klog/app/cli/lib/terminalformat"
+)
+
+type Config struct{}
+
+func (opt *Config) Help() string {
+	return `By placing a YAML file at ~/` + app.KLOG_FOLDER + app.CONFIG_FILE + ` you are able to configure some of klog’s behaviour.
+
+If you run ` + "`" + `klog config` + "`" + `, you can learn about the supported YAML properties in the file, and you also see what values are in effect at the moment. (Note: the output of the command does not print the actual file!)`
+}
+
+func (opt *Config) Run(ctx app.Context) app.Error {
+	for i, e := range app.CONFIG_FILE_ENTRIES {
+		ctx.Print(lib.Subdued.Format(lib.Reflower.Reflow(e.Description+"\n"+e.Instructions, "# ")))
+		ctx.Print("\n")
+		ctx.Print(lib.Red.Format(e.Name) + `: ` + terminalformat.Style{Color: "227"}.Format(e.Value(ctx.Config())))
+		if i < len(app.CONFIG_FILE_ENTRIES)-1 {
+			ctx.Print("\n\n")
+		}
+	}
+	ctx.Print("\n")
+	return nil
+}

--- a/klog/app/cli/create.go
+++ b/klog/app/cli/create.go
@@ -25,12 +25,15 @@ func (opt *Create) Run(ctx app.Context) app.Error {
 	opt.NoStyleArgs.Apply(&ctx)
 	date, isAutoDate := opt.AtDate(ctx.Now())
 	atDate := reconciling.NewStyled[klog.Date](date, isAutoDate)
+	additionalData := reconciling.AdditionalData{ShouldTotal: opt.ShouldTotal, Summary: opt.Summary}
+	if additionalData.ShouldTotal == nil {
+		ctx.Config().DefaultShouldTotal.Map(func(s klog.ShouldTotal) {
+			additionalData.ShouldTotal = s
+		})
+	}
 	return lib.Reconcile(ctx, lib.ReconcileOpts{OutputFileArgs: opt.OutputFileArgs, WarnArgs: opt.WarnArgs},
 		[]reconciling.Creator{
-			reconciling.NewReconcilerForNewRecord(
-				atDate,
-				reconciling.AdditionalData{ShouldTotal: opt.ShouldTotal, Summary: opt.Summary},
-			),
+			reconciling.NewReconcilerForNewRecord(atDate, additionalData),
 		},
 
 		func(reconciler *reconciling.Reconciler) (*reconciling.Result, error) {

--- a/klog/app/cli/index.go
+++ b/klog/app/cli/index.go
@@ -29,6 +29,7 @@ type Cli struct {
 	// Misc
 	Edit       Edit             `cmd:"" group:"Misc" help:"Opens a file or bookmark in your editor"`
 	Goto       Goto             `cmd:"" group:"Misc" help:"Opens the file explorer at the given location"`
+	Config     Config           `cmd:"" group:"Misc" hidden:"" help:"Prints the current configuration"` // Still experimental / WIP
 	Json       Json             `cmd:"" group:"Misc" help:"Converts records to JSON"`
 	Info       Info             `cmd:"" group:"Misc" default:"withargs" help:"Displays meta info about klog"`
 	Version    Version          `cmd:"" group:"Misc" help:"Prints version info and check for updates"`

--- a/klog/app/cli/info.go
+++ b/klog/app/cli/info.go
@@ -9,9 +9,10 @@ const DESCRIPTION = "klog: command line app for time tracking with plain-text fi
 	"Documentation online at " + KLOG_WEBSITE_URL
 
 type Info struct {
-	Version bool `short:"v" name:"version" help:"Alias for 'klog version'"`
-	Spec    bool `name:"spec" help:"Print file format specification"`
-	License bool `name:"license" help:"Print license"`
+	Version    bool `short:"v" name:"version" help:"Alias for 'klog version'"`
+	Spec       bool `name:"spec" help:"Print file format specification"`
+	License    bool `name:"license" help:"Print license"`
+	KlogFolder bool `name:"klog-folder" help:"Print path of .klog folder"`
 }
 
 func (opt *Info) Help() string {
@@ -27,6 +28,9 @@ func (opt *Info) Run(ctx app.Context) app.Error {
 		return nil
 	} else if opt.License {
 		ctx.Print(ctx.Meta().License + "\n")
+		return nil
+	} else if opt.KlogFolder {
+		ctx.Print(ctx.KlogFolder().Path() + "\n")
 		return nil
 	}
 	ctx.Print(DESCRIPTION + "\n")

--- a/klog/app/cli/lib/args.go
+++ b/klog/app/cli/lib/args.go
@@ -43,7 +43,7 @@ type AtDateAndTimeArgs struct {
 	Round service.Rounding `name:"round" short:"r" help:"Round time to nearest multiple of 5m, 10m, 15m, 30m, or 60m / 1h"`
 }
 
-func (args *AtDateAndTimeArgs) AtTime(now gotime.Time) (klog.Time, bool, app.Error) {
+func (args *AtDateAndTimeArgs) AtTime(now gotime.Time, config app.Config) (klog.Time, bool, app.Error) {
 	if args.Time != nil {
 		return args.Time, false, nil
 	}
@@ -52,6 +52,10 @@ func (args *AtDateAndTimeArgs) AtTime(now gotime.Time) (klog.Time, bool, app.Err
 	time := klog.NewTimeFromGo(now)
 	if args.Round != nil {
 		time = service.RoundToNearest(time, args.Round)
+	} else {
+		config.DefaultRounding.Map(func(r service.Rounding) {
+			time = service.RoundToNearest(time, r)
+		})
 	}
 	if today.IsEqualTo(date) {
 		return time, true, nil

--- a/klog/app/cli/lib/prettifier.go
+++ b/klog/app/cli/lib/prettifier.go
@@ -9,9 +9,10 @@ import (
 	"strings"
 )
 
+var Reflower = terminalformat.NewReflower(60, "\n")
+
 // PrettifyError turns an error into a coloured and well-structured form.
 func PrettifyError(err error, isDebug bool) error {
-	reflower := terminalformat.NewReflower(60, "\n")
 	switch e := err.(type) {
 	case app.ParserErrors:
 		message := ""
@@ -34,13 +35,13 @@ func PrettifyError(err error, isDebug bool) error {
 			) + "\n"
 			message += fmt.Sprintf(
 				terminalformat.Style{Color: "227"}.Format("%s"),
-				reflower.Reflow(e.Message(), INDENT),
+				Reflower.Reflow(e.Message(), INDENT),
 			) + "\n\n"
 		}
 		return errors.New(message)
 	case app.Error:
 		message := "Error: " + e.Error() + "\n"
-		message += reflower.Reflow(e.Details(), "")
+		message += Reflower.Reflow(e.Details(), "")
 		if isDebug && e.Original() != nil {
 			message += "\n\nOriginal Error:\n" + e.Original().Error()
 		}

--- a/klog/app/cli/main/cli.go
+++ b/klog/app/cli/main/cli.go
@@ -15,7 +15,7 @@ import (
 	"reflect"
 )
 
-func Run(homeDir string, meta app.Meta, config app.Config, args []string) error {
+func Run(homeDir app.File, meta app.Meta, config app.Config, args []string) error {
 	kongApp, nErr := kong.New(
 		&cli.Cli{},
 		kong.Name("klog"),

--- a/klog/app/cli/main/cli.go
+++ b/klog/app/cli/main/cli.go
@@ -15,7 +15,7 @@ import (
 	"reflect"
 )
 
-func Run(homeDir string, meta app.Meta, config app.Config, args []string) (int, error) {
+func Run(homeDir string, meta app.Meta, config app.Config, args []string) error {
 	kongApp, nErr := kong.New(
 		&cli.Cli{},
 		kong.Name("klog"),
@@ -59,7 +59,7 @@ func Run(homeDir string, meta app.Meta, config app.Config, args []string) (int, 
 		}),
 	)
 	if nErr != nil {
-		return -1, nErr
+		return nErr
 	}
 
 	ctx := app.NewContext(
@@ -76,18 +76,9 @@ func Run(homeDir string, meta app.Meta, config app.Config, args []string) (int, 
 	kongcompletion.Register(kongApp, kongcompletion.WithPredictors(CompletionPredictors(ctx)))
 	kongCtx, cErr := kongApp.Parse(args)
 	if cErr != nil {
-		return -1, cErr
+		return cErr
 	}
 	kongCtx.BindTo(ctx, (*app.Context)(nil))
 
-	rErr := kongCtx.Run()
-	if rErr != nil {
-		ctx.Print(lib.PrettifyError(rErr, config.IsDebug.Value()).Error() + "\n")
-		if appErr, isAppError := rErr.(app.Error); isAppError {
-			return int(appErr.Code()), nil
-		} else {
-			return -1, rErr
-		}
-	}
-	return 0, nil
+	return kongCtx.Run()
 }

--- a/klog/app/cli/main/testutil_test.go
+++ b/klog/app/cli/main/testutil_test.go
@@ -33,7 +33,7 @@ func (e *Env) run(invocation ...[]string) []string {
 		r, w, _ := os.Pipe()
 		os.Stdout = w
 
-		runErr := Run(tmpDir, app.Meta{
+		runErr := Run(app.NewFileOrPanic(tmpDir), app.Meta{
 			Specification: "[Specification text]",
 			License:       "[License text]",
 			Version:       "v0.0",

--- a/klog/app/cli/main/testutil_test.go
+++ b/klog/app/cli/main/testutil_test.go
@@ -33,7 +33,7 @@ func (e *Env) run(invocation ...[]string) []string {
 		r, w, _ := os.Pipe()
 		os.Stdout = w
 
-		code, runErr := Run(tmpDir, app.Meta{
+		runErr := Run(tmpDir, app.Meta{
 			Specification: "[Specification text]",
 			License:       "[License text]",
 			Version:       "v0.0",
@@ -41,7 +41,7 @@ func (e *Env) run(invocation ...[]string) []string {
 		}, app.NewDefaultConfig(), args)
 
 		_ = w.Close()
-		if runErr != nil || code != 0 {
+		if runErr != nil {
 			outs[i] = runErr.Error()
 			continue
 		}

--- a/klog/app/cli/stop.go
+++ b/klog/app/cli/stop.go
@@ -24,7 +24,7 @@ func (opt *Stop) Run(ctx app.Context) app.Error {
 	opt.NoStyleArgs.Apply(&ctx)
 	now := ctx.Now()
 	date, isAutoDate := opt.AtDate(now)
-	time, isAutoTime, err := opt.AtTime(now)
+	time, isAutoTime, err := opt.AtTime(now, ctx.Config())
 	if err != nil {
 		return err
 	}

--- a/klog/app/cli/testcontext_test.go
+++ b/klog/app/cli/testcontext_test.go
@@ -116,7 +116,7 @@ func (ctx *TestingContext) HomeFolder() string {
 }
 
 func (ctx *TestingContext) KlogFolder() app.File {
-	return app.NewFileOrPanic(ctx.HomeFolder() + app.KLOG_FOLDER)
+	return app.NewFileOrPanic(ctx.HomeFolder() + app.KLOG_FOLDER_NAME)
 }
 
 func (ctx *TestingContext) Meta() app.Meta {

--- a/klog/app/cli/testcontext_test.go
+++ b/klog/app/cli/testcontext_test.go
@@ -14,6 +14,7 @@ import (
 
 func NewTestingContext() TestingContext {
 	bc := app.NewEmptyBookmarksCollection()
+	config := app.NewDefaultConfig()
 	return TestingContext{
 		State: State{
 			printBuffer:         "",
@@ -30,6 +31,7 @@ func NewTestingContext() TestingContext {
 		execute: func(_ command.Command) app.Error {
 			return nil
 		},
+		config: &config,
 	}
 }
 
@@ -56,6 +58,15 @@ func (ctx TestingContext) _SetEditors(auto []command.Command, explicit string) T
 
 func (ctx TestingContext) _SetFileExplorers(cs []command.Command) TestingContext {
 	ctx.fileExplorers = cs
+	return ctx
+}
+
+func (ctx TestingContext) _SetFileConfig(configFile string) TestingContext {
+	fileCfg := app.FromConfigFile{FileContents: configFile}
+	err := fileCfg.Apply(ctx.config)
+	if err != nil {
+		panic(err)
+	}
 	return ctx
 }
 
@@ -89,6 +100,7 @@ type TestingContext struct {
 	editorExplicit string
 	fileExplorers  []command.Command
 	execute        func(command.Command) app.Error
+	config         *app.Config
 }
 
 func (ctx *TestingContext) Print(s string) {
@@ -176,5 +188,5 @@ func (ctx *TestingContext) SetSerialiser(s parser.Serialiser) {
 func (ctx *TestingContext) Debug(_ func()) {}
 
 func (ctx *TestingContext) Config() app.Config {
-	return app.NewDefaultConfig()
+	return *ctx.config
 }

--- a/klog/app/cli/testcontext_test.go
+++ b/klog/app/cli/testcontext_test.go
@@ -115,8 +115,8 @@ func (ctx *TestingContext) HomeFolder() string {
 	return "~"
 }
 
-func (ctx *TestingContext) KlogFolder() string {
-	return ctx.HomeFolder() + "/.klog/"
+func (ctx *TestingContext) KlogFolder() app.File {
+	return app.NewFileOrPanic(ctx.HomeFolder() + app.KLOG_FOLDER)
 }
 
 func (ctx *TestingContext) Meta() app.Meta {

--- a/klog/app/cli/track.go
+++ b/klog/app/cli/track.go
@@ -29,10 +29,14 @@ func (opt *Track) Run(ctx app.Context) app.Error {
 	now := ctx.Now()
 	date, isAutoDate := opt.AtDate(now)
 	atDate := reconciling.NewStyled[klog.Date](date, isAutoDate)
+	additionalData := reconciling.AdditionalData{}
+	ctx.Config().DefaultShouldTotal.Map(func(s klog.ShouldTotal) {
+		additionalData.ShouldTotal = s
+	})
 	return lib.Reconcile(ctx, lib.ReconcileOpts{OutputFileArgs: opt.OutputFileArgs, WarnArgs: opt.WarnArgs},
 		[]reconciling.Creator{
 			reconciling.NewReconcilerAtRecord(atDate.Value),
-			reconciling.NewReconcilerForNewRecord(atDate, reconciling.AdditionalData{}),
+			reconciling.NewReconcilerForNewRecord(atDate, additionalData),
 		},
 
 		func(reconciler *reconciling.Reconciler) (*reconciling.Result, error) {

--- a/klog/app/cli/track_test.go
+++ b/klog/app/cli/track_test.go
@@ -51,6 +51,26 @@ func TestTrackEntryAtUnknownDateCreatesNewRecord(t *testing.T) {
 `, state.writtenFileContents)
 }
 
+func TestTrackNewRecordWithShouldTotal(t *testing.T) {
+	state, err := NewTestingContext()._SetRecords(`
+1855-04-25
+	1h
+`)._SetFileConfig(`
+default_should_total: 7h30m!
+`)._Run((&Track{
+		Entry:      klog.Ɀ_EntrySummary_("2h"),
+		AtDateArgs: lib.AtDateArgs{Date: klog.Ɀ_Date_(2000, 1, 1)},
+	}).Run)
+	require.Nil(t, err)
+	assert.Equal(t, `
+1855-04-25
+	1h
+
+2000-01-01 (7h30m!)
+	2h
+`, state.writtenFileContents)
+}
+
 func TestTrackFailsIfEntryInvalid(t *testing.T) {
 	state, err := NewTestingContext()._SetRecords(`
 1855-04-25

--- a/klog/app/config.go
+++ b/klog/app/config.go
@@ -190,7 +190,7 @@ func (e FromConfigFile) Apply(config *Config) Error {
 	lErr := yaml.Unmarshal([]byte(e.FileContents), &data)
 	if lErr != nil {
 		return NewError(
-			"Invalid config file (~/"+KLOG_FOLDER+CONFIG_FILE+")",
+			"Invalid config file",
 			"The syntax in the file is not valid YAML.",
 			lErr,
 		)
@@ -201,7 +201,7 @@ func (e FromConfigFile) Apply(config *Config) Error {
 				rErr := entry.Reader(value, config)
 				if rErr != nil {
 					return NewError(
-						"Invalid config file (~/"+KLOG_FOLDER+CONFIG_FILE+")",
+						"Invalid config file",
 						"The value for `"+key+"` is not valid: "+entry.Instructions,
 						rErr,
 					)

--- a/klog/app/config.go
+++ b/klog/app/config.go
@@ -196,6 +196,9 @@ func (e FromConfigFile) Apply(config *Config) Error {
 		)
 	}
 	for key, value := range data {
+		if value == "" {
+			continue
+		}
 		for _, entry := range CONFIG_FILE_ENTRIES {
 			if entry.Name == key {
 				rErr := entry.Reader(value, config)

--- a/klog/app/config.go
+++ b/klog/app/config.go
@@ -1,5 +1,14 @@
 package app
 
+import (
+	"github.com/jotaen/klog/klog"
+	"github.com/jotaen/klog/klog/service"
+	"gopkg.in/yaml.v3"
+	"strings"
+)
+
+// Config are all aspects and behaviour of the application that can be
+// controlled by the user.
 type Config struct {
 	// IsDebug indicates whether klog should print additional debug information.
 	IsDebug Param[bool]
@@ -13,48 +22,58 @@ type Config struct {
 	// CpuKernels is the number of available CPUs that klog is allowed to utilise.
 	// The value must be `1` or higher.
 	CpuKernels Param[int]
+
+	// DefaultRounding is the default for the --round flag.
+	DefaultRounding Param[service.Rounding]
+
+	// DefaultShouldTotal is the default should total for new records.
+	DefaultShouldTotal Param[klog.ShouldTotal]
 }
 
-type ConfigDeterminer interface {
-	Apply(*Config)
+type Reader interface {
+	Apply(*Config) Error
 }
 
-func NewConfig(c1 ConfigFromStaticValues, c2 ConfigFromEnvVars) Config {
+func NewConfig(c1 FromStaticValues, c2 FromEnvVars, c3 FromConfigFile) (Config, Error) {
 	config := NewDefaultConfig()
-	c1.Apply(&config)
-	c2.Apply(&config)
-	return config
+	for _, c := range []Reader{c1, c2, c3} {
+		err := c.Apply(&config)
+		if err != nil {
+			return Config{}, err
+		}
+	}
+	return config, nil
 }
 
 func NewDefaultConfig() Config {
+	defaultRounding, err := service.NewRounding(15)
+	if err != nil {
+		panic(err) // This can/should never happen
+	}
 	return Config{
-		IsDebug:    newDefaultParam(false),
-		Editor:     newDefaultParam(""),
-		NoColour:   newDefaultParam(false),
-		CpuKernels: newDefaultParam(1),
+		IsDebug:            newDefaultParam(false),
+		Editor:             newDefaultParam(""),
+		NoColour:           newDefaultParam(false),
+		CpuKernels:         newDefaultParam(1),
+		DefaultRounding:    newDefaultParam(defaultRounding),
+		DefaultShouldTotal: newDefaultParam(klog.NewShouldTotal(0, 0)),
 	}
 }
 
 type Param[T any] struct {
-	actualValue  T
-	defaultValue T
-	isExplicit   bool
+	actualValue T
+	isExplicit  bool
 }
 
 func newDefaultParam[T any](value T) Param[T] {
 	return Param[T]{
-		actualValue:  value,
-		defaultValue: value,
-		isExplicit:   false,
+		actualValue: value,
+		isExplicit:  false,
 	}
 }
 
 func (p Param[T]) Value() T {
 	return p.actualValue
-}
-
-func (p Param[T]) Default() T {
-	return p.defaultValue
 }
 
 func (p Param[T]) WasExplicitlySet() bool {
@@ -66,19 +85,24 @@ func (p *Param[T]) set(value T) {
 	p.isExplicit = true
 }
 
-type ConfigFromStaticValues struct {
+// FromStaticValues is the part of the configuration that is automatically
+// determined, e.g. by constraints of the runtime environment.
+type FromStaticValues struct {
 	NumCpus int
 }
 
-func (e ConfigFromStaticValues) Apply(config *Config) {
+func (e FromStaticValues) Apply(config *Config) Error {
 	config.CpuKernels.set(e.NumCpus)
+	return nil
 }
 
-type ConfigFromEnvVars struct {
+// FromEnvVars is the part of the configuration that is determined
+// by environment variables.
+type FromEnvVars struct {
 	GetVar func(string) string
 }
 
-func (e ConfigFromEnvVars) Apply(config *Config) {
+func (e FromEnvVars) Apply(config *Config) Error {
 	if e.GetVar("KLOG_DEBUG") != "" {
 		config.IsDebug.set(true)
 	}
@@ -90,4 +114,87 @@ func (e ConfigFromEnvVars) Apply(config *Config) {
 	} else if e.GetVar("EDITOR") != "" {
 		config.Editor.set(e.GetVar("EDITOR"))
 	}
+	return nil
+}
+
+// FromConfigFile is the part of the configuration that the user can
+// control via a configuration file.
+type FromConfigFile struct {
+	FileContents string
+}
+
+var CONFIG_FILE_ENTRIES = []ConfigFileEntries[any]{
+	{
+		Name: "default_rounding",
+		Reader: func(value string, config *Config) error {
+			rounding, err := service.NewRoundingFromString(value)
+			if err != nil {
+				return err
+			}
+			config.DefaultRounding.set(rounding)
+			return nil
+		},
+		Value: func(c Config) string {
+			if !c.DefaultRounding.WasExplicitlySet() {
+				return ""
+			}
+			return c.DefaultRounding.Value().ToString()
+		},
+		Description:  "The default value that shall be used for rounding time values via the `--round` flag, e.g. in `klog start --round 15m`. (If absent/empty, klog doesn’t round.)",
+		Instructions: "The value must be one of: `5m`, `10m`, `15m`, `20m`, `30m`, `60m`. ",
+	}, {
+		Name: "default_should_total",
+		Reader: func(value string, config *Config) error {
+			value = strings.TrimSuffix(value, "!")
+			d, err := klog.NewDurationFromString(value)
+			if err != nil {
+				return err
+			}
+			config.DefaultShouldTotal.set(klog.NewShouldTotal(0, d.InMinutes()))
+			return nil
+		},
+		Value: func(c Config) string {
+			if !c.DefaultShouldTotal.WasExplicitlySet() {
+				return ""
+			}
+			return c.DefaultShouldTotal.Value().ToString()
+		},
+		Description:  "The default duration value that shall be used as should-total when creating new records. (If absent/empty, klog doesn’t set a should-total on new records.)",
+		Instructions: "The value must be a duration followed by an exclamation mark. Examples: `8h!`, `6h30m!`. ",
+	},
+}
+
+type ConfigFileEntries[T any] struct {
+	Name         string
+	Reader       func(string, *Config) error
+	Value        func(Config) string
+	Description  string
+	Instructions string
+}
+
+func (e FromConfigFile) Apply(config *Config) Error {
+	data := map[string]string{}
+	lErr := yaml.Unmarshal([]byte(e.FileContents), &data)
+	if lErr != nil {
+		return NewError(
+			"Invalid config file (~/"+KLOG_FOLDER+CONFIG_FILE+")",
+			"The syntax in the file is not valid YAML.",
+			lErr,
+		)
+	}
+	for key, value := range data {
+		for _, entry := range CONFIG_FILE_ENTRIES {
+			if entry.Name == key {
+				rErr := entry.Reader(value, config)
+				if rErr != nil {
+					return NewError(
+						"Invalid config file (~/"+KLOG_FOLDER+CONFIG_FILE+")",
+						"The value for `"+key+"` is not valid: "+entry.Instructions,
+						rErr,
+					)
+				}
+			}
+		}
+	}
+	return nil
 }

--- a/klog/app/config_test.go
+++ b/klog/app/config_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 )
 
-func createMockConfigFromEnv(vs map[string]string) ConfigFromEnvVars {
-	return ConfigFromEnvVars{GetVar: func(n string) string {
+func createMockConfigFromEnv(vs map[string]string) FromEnvVars {
+	return FromEnvVars{GetVar: func(n string) string {
 		return vs[n]
 	}}
 }
@@ -17,6 +17,7 @@ func TestCreatesNewDefaultConfig(t *testing.T) {
 	assert.Equal(t, c.Editor.Value(), "")
 	assert.Equal(t, c.NoColour.Value(), false)
 	assert.Equal(t, c.CpuKernels.Value(), 1)
+	assert.Equal(t, c.DefaultRounding.Value().ToInt(), 15)
 }
 
 func TestSetsParamsMetadataIsHandledCorrectly(t *testing.T) {
@@ -24,29 +25,32 @@ func TestSetsParamsMetadataIsHandledCorrectly(t *testing.T) {
 		c := NewDefaultConfig()
 		assert.Equal(t, c.NoColour.Value(), false)
 		assert.False(t, c.NoColour.WasExplicitlySet())
-		assert.Equal(t, c.NoColour.Default(), false)
 	}
 	{
-		c := NewConfig(
-			ConfigFromStaticValues{NumCpus: 1},
+		c, _ := NewConfig(
+			FromStaticValues{NumCpus: 1},
 			createMockConfigFromEnv(map[string]string{
 				"NO_COLOR": "1",
 			}),
+			FromConfigFile{""},
 		)
 		assert.Equal(t, c.NoColour.Value(), true)
 		assert.True(t, c.NoColour.WasExplicitlySet())
-		assert.Equal(t, c.NoColour.Default(), false)
 	}
 }
 
 func TestSetsParamsFromEnv(t *testing.T) {
 	// Read plain environment variables.
 	{
-		c := NewConfig(ConfigFromStaticValues{NumCpus: 1}, createMockConfigFromEnv(map[string]string{
-			"EDITOR":     "subl",
-			"KLOG_DEBUG": "1",
-			"NO_COLOR":   "1",
-		}))
+		c, _ := NewConfig(
+			FromStaticValues{NumCpus: 1},
+			createMockConfigFromEnv(map[string]string{
+				"EDITOR":     "subl",
+				"KLOG_DEBUG": "1",
+				"NO_COLOR":   "1",
+			}),
+			FromConfigFile{""},
+		)
 		assert.Equal(t, c.IsDebug.Value(), true)
 		assert.Equal(t, c.NoColour.Value(), true)
 		assert.Equal(t, c.Editor.Value(), "subl")
@@ -54,10 +58,75 @@ func TestSetsParamsFromEnv(t *testing.T) {
 
 	// `KLOG_EDITOR` would trump `EDITOR`.
 	{
-		c := NewConfig(ConfigFromStaticValues{NumCpus: 1}, createMockConfigFromEnv(map[string]string{
-			"EDITOR":      "subl",
-			"KLOG_EDITOR": "vi",
-		}))
+		c, _ := NewConfig(
+			FromStaticValues{NumCpus: 1},
+			createMockConfigFromEnv(map[string]string{
+				"EDITOR":      "subl",
+				"KLOG_EDITOR": "vi",
+			}),
+			FromConfigFile{""},
+		)
 		assert.Equal(t, c.Editor.Value(), "vi")
+	}
+}
+
+func TestSetsDefaultRoundingParamFromConfigFile(t *testing.T) {
+	for _, tml := range []string{
+		`default_rounding: 30m`,
+	} {
+		c, _ := NewConfig(
+			FromStaticValues{NumCpus: 1},
+			createMockConfigFromEnv(map[string]string{}),
+			FromConfigFile{tml},
+		)
+		assert.Equal(t, c.DefaultRounding.Value().ToInt(), 30)
+		assert.True(t, c.DefaultRounding.WasExplicitlySet())
+	}
+}
+
+func TestSetsDefaultShouldTotalParamFromConfigFile(t *testing.T) {
+	for _, tml := range []string{
+		`default_should_total: 8h30m!`,
+	} {
+		c, _ := NewConfig(
+			FromStaticValues{NumCpus: 1},
+			createMockConfigFromEnv(map[string]string{}),
+			FromConfigFile{tml},
+		)
+		assert.Equal(t, c.DefaultShouldTotal.Value().ToString(), "8h30m!")
+		assert.True(t, c.DefaultShouldTotal.WasExplicitlySet())
+	}
+}
+
+func TestIgnoresUnknownPropertiesInConfigFile(t *testing.T) {
+	for _, tml := range []string{`
+unknown_property: 1
+what_is_this:
+  - 1
+  - 2
+`,
+	} {
+		c, _ := NewConfig(
+			FromStaticValues{NumCpus: 1},
+			createMockConfigFromEnv(map[string]string{}),
+			FromConfigFile{tml},
+		)
+		assert.False(t, c.DefaultRounding.WasExplicitlySet())
+	}
+}
+
+func TestRejectsInvalidConfigFile(t *testing.T) {
+	for _, tml := range []string{
+		`default_rounding: true`,              // Wrong type
+		`default_rounding: 22m`,               // Invalid value
+		`default_should_total: [true, false]`, // Wrong type
+		`default_should_total: 15`,            // Invalid value
+	} {
+		_, err := NewConfig(
+			FromStaticValues{NumCpus: 1},
+			createMockConfigFromEnv(map[string]string{}),
+			FromConfigFile{tml},
+		)
+		assert.Error(t, err)
 	}
 }

--- a/klog/app/config_test.go
+++ b/klog/app/config_test.go
@@ -130,6 +130,25 @@ what_is_this: true
 	}
 }
 
+func TestIgnoresEmptyConfigFileOrEmptyParameters(t *testing.T) {
+	for _, tml := range []string{
+		``,
+		`
+default_rounding:
+`,
+		`
+default_should_total: 
+`,
+	} {
+		_, err := NewConfig(
+			FromStaticValues{NumCpus: 1},
+			createMockConfigFromEnv(map[string]string{}),
+			FromConfigFile{tml},
+		)
+		assert.Nil(t, err)
+	}
+}
+
 func TestRejectsInvalidConfigFile(t *testing.T) {
 	for _, tml := range []string{
 		`default_rounding: true`,              // Wrong type

--- a/klog/app/context.go
+++ b/klog/app/context.go
@@ -102,13 +102,13 @@ type Meta struct {
 }
 
 // NewContext creates a new Context object.
-func NewContext(klogFolderPath File, meta Meta, serialiser parser.Serialiser, cfg Config) Context {
+func NewContext(klogFolder File, meta Meta, serialiser parser.Serialiser, cfg Config) Context {
 	parserEngine := parser.NewSerialParser()
 	if cfg.CpuKernels.Value() > 1 {
 		parserEngine = parser.NewParallelParser(cfg.CpuKernels.Value())
 	}
 	return &context{
-		klogFolderPath,
+		klogFolder,
 		parserEngine,
 		serialiser,
 		meta,
@@ -117,11 +117,11 @@ func NewContext(klogFolderPath File, meta Meta, serialiser parser.Serialiser, cf
 }
 
 type context struct {
-	klogFolderPath File
-	parser         parser.Parser
-	serialiser     parser.Serialiser
-	meta           Meta
-	config         Config
+	klogFolder File
+	parser     parser.Parser
+	serialiser parser.Serialiser
+	meta       Meta
+	config     Config
 }
 
 func (ctx *context) Print(text string) {
@@ -143,7 +143,7 @@ func (ctx *context) ReadLine() (string, Error) {
 }
 
 func (ctx *context) KlogFolder() File {
-	return ctx.klogFolderPath
+	return ctx.klogFolder
 }
 
 func (ctx *context) Meta() Meta {

--- a/klog/app/context.go
+++ b/klog/app/context.go
@@ -23,9 +23,9 @@ import (
 type FileOrBookmarkName string
 
 const (
-	KLOG_FOLDER    = ".klog"
-	BOOKMARKS_FILE = "bookmarks.json"
-	CONFIG_FILE    = "config.yml"
+	KLOG_FOLDER_NAME    = ".klog"
+	BOOKMARKS_FILE_NAME = "bookmarks.json"
+	CONFIG_FILE_NAME    = "config.yml"
 )
 
 // Context is a representation of the runtime environment of klog.
@@ -306,7 +306,7 @@ func (ctx *context) ManipulateBookmarks(manipulate func(BookmarksCollection) Err
 }
 
 func (ctx *context) bookmarkDatabasePath() File {
-	return Join(ctx.KlogFolder(), BOOKMARKS_FILE)
+	return Join(ctx.KlogFolder(), BOOKMARKS_FILE_NAME)
 }
 
 func (ctx *context) Execute(cmd command.Command) Error {

--- a/klog/app/file.go
+++ b/klog/app/file.go
@@ -83,6 +83,10 @@ func (f *fileWithContents) Contents() string {
 	return f.contents
 }
 
+func Join(f File, fileOrFolderName string) File {
+	return NewFileOrPanic(filepath.Join(f.Path(), fileOrFolderName))
+}
+
 // IsAbs checks whether the given path is absolute.
 func IsAbs(path string) bool {
 	return filepath.IsAbs(path)

--- a/klog/service/rounding.go
+++ b/klog/service/rounding.go
@@ -9,13 +9,18 @@ import (
 
 // Rounding is an integer divider of 60 that Time values can be rounded to.
 type Rounding interface {
-	toInt() int
+	ToInt() int
+	ToString() string
 }
 
 type rounding int
 
-func (r rounding) toInt() int {
+func (r rounding) ToInt() int {
 	return int(r)
+}
+
+func (r rounding) ToString() string {
+	return strconv.Itoa(r.ToInt()) + "m"
 }
 
 // NewRounding creates a Rounding from an integer. For non-allowed
@@ -51,7 +56,7 @@ func NewRoundingFromString(v string) (Rounding, error) {
 // E.g., for rounding=5m: 8:03 => 8:05, or for rounding=30m: 15:12 => 15:00
 func RoundToNearest(t klog.Time, r Rounding) klog.Time {
 	midnightOffset := t.MidnightOffset().InMinutes()
-	v := r.toInt()
+	v := r.ToInt()
 	remainder := midnightOffset % v
 	uprounder := func() int { // Decide whether to round up the value.
 		if remainder >= (v/2 + v%2) {

--- a/klog/service/rounding_test.go
+++ b/klog/service/rounding_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/jotaen/klog/klog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"strings"
 	"testing"
 )
 
@@ -21,7 +22,7 @@ func TestValidRoundingValues(t *testing.T) {
 	} {
 		fr, err := NewRounding(m)
 		require.Nil(t, err)
-		assert.Equal(t, m, fr.toInt())
+		assert.Equal(t, m, fr.ToInt())
 	}
 }
 
@@ -51,7 +52,11 @@ func TestParseRoundingValuesFromString(t *testing.T) {
 	} {
 		fr, err := NewRoundingFromString(x.value)
 		require.Nil(t, err)
-		assert.Equal(t, x.expected, fr.toInt())
+		assert.Equal(t, x.expected, fr.ToInt())
+		if strings.HasSuffix(x.value, "m") {
+			// It always stringifies with a `m` suffix.
+			assert.Equal(t, x.value, fr.ToString())
+		}
 	}
 }
 


### PR DESCRIPTION
This PR addresses https://github.com/jotaen/klog/discussions/158.

klog now looks for a config file at `~/.klog/config.yml`, where users are able to specify some preferences. For now, that is:

- `default_rounding`: the value for the `--round` flag, unless specified, e.g. in `klog start` or `klog stop`.
- `default_should_total`: the default for the `--should-total` flag, unless specified, that is used whenever klog creates a new record, e.g. in `klog create`, but also in `klog track` or `klog start`, as these might create new records on the fly.

More configuration parameters may follow later, now that the groundwork is set up.

When the config file is absent, everything behaves as before, so it’s strictly optional right now.

What’s also new is that klog will respect the `$KLOG_FOLDER_LOCATION` or `$XDG_CONFIG_HOME` environment variables, if set. In this case, **and** when users have bookmarks, then this will be a breaking change. The fix is for them to manually move over their `bookmarks.json` file to the new klog folder location. I’ll take note in the Changelog about this.

The `klog config` command is hidden from the help output for now, but it can be invoked nevertheless on the nightly build (when compiling klog from the `main` branch). I’ll do some more testing, refactoring, and enhancements in the next time, and plan to include this with the next release – probably within the next few weeks.