### PR TITLE
Change location of klog config folder

### DIFF
--- a/klog/app/cli/config.go
+++ b/klog/app/cli/config.go
@@ -11,7 +11,7 @@ type Config struct {
 }
 
 func (opt *Config) Help() string {
-	return `You are able to configure some of klog’s behaviour via an .ini file in your ` + "`" + app.KLOG_FOLDER_NAME + "`" + ` folder. (Run ` + "`" + `klog config --file-path` + "`" + ` to print the exact location.)
+	return `You are able to configure some of klog’s behaviour by providing a configuration file in your klog config folder. (Run ` + "`" + `klog config --file-path` + "`" + ` to print the path of that config file.)
 
 If you run ` + "`" + `klog config` + "`" + `, you can learn about the supported properties in the file, and you also see what values are in effect at the moment. (Note: the output of the command does not print the actual file, it rather shows the configuration as it is in effect!)
 
@@ -20,7 +20,7 @@ You may use the output as template for setting up your config file, as its forma
 
 func (opt *Config) Run(ctx app.Context) app.Error {
 	if opt.ConfigFilePath {
-		ctx.Print(app.Join(ctx.KlogFolder(), app.CONFIG_FILE_NAME).Path() + "\n")
+		ctx.Print(app.Join(ctx.KlogConfigFolder(), app.CONFIG_FILE_NAME).Path() + "\n")
 		return nil
 	}
 	for i, e := range app.CONFIG_FILE_ENTRIES {

--- a/klog/app/cli/index.go
+++ b/klog/app/cli/index.go
@@ -6,32 +6,30 @@ package cli
 import kcmpl "github.com/jotaen/kong-completion"
 
 type Cli struct {
-	// Evaluate
+	// Evaluate Files
 	Print  Print  `cmd:"" group:"Evaluate Files" help:"Pretty-prints records"`
 	Total  Total  `cmd:"" group:"Evaluate Files" help:"Evaluates the total time"`
 	Report Report `cmd:"" group:"Evaluate Files" help:"Prints a calendar report summarising all days"`
 	Tags   Tags   `cmd:"" group:"Evaluate Files" help:"Prints total times aggregated by tags"`
 	Today  Today  `cmd:"" group:"Evaluate Files" help:"Evaluates the current day"`
 
-	// Manipulate
+	// Manipulate Files
 	Track  Track  `cmd:"" group:"Manipulate Files" help:"Adds a new entry to a record"`
 	Start  Start  `cmd:"" group:"Manipulate Files" aliases:"in" help:"Starts a new open time range"`
 	Stop   Stop   `cmd:"" group:"Manipulate Files" aliases:"out" help:"Closes the open time range"`
 	Pause  Pause  `cmd:"" group:"Manipulate Files" help:"Pauses the open time range"`
 	Create Create `cmd:"" group:"Manipulate Files" help:"Creates a new record"`
 
-	// Bookmarks
-	Bookmarks Bookmarks `cmd:"" group:"Bookmarks (bk)" help:"Named aliases for often-used files"`
-	Bookmark  Bookmarks `cmd:"" group:"Bookmarks" hidden:"" help:"Alias"`
-	Bm        Bookmarks `cmd:"" group:"Bookmarks" hidden:"" help:"Alias"`
-	Bk        Bookmarks `cmd:"" group:"Bookmarks" hidden:"" help:"Alias"`
+	// Manage Files
+	Bookmarks Bookmarks `cmd:"" group:"Manage Files" aliases:"bk" help:"Named aliases for often-used files"`
+	Bookmark  Bookmarks `cmd:"" hidden:"" help:"(Alias)"` // Hidden alias for convenience / typo
+	Edit      Edit      `cmd:"" group:"Manage Files" help:"Opens a file or bookmark in your editor"`
+	Goto      Goto      `cmd:"" group:"Manage Files" help:"Opens the file explorer at a file or bookmark"`
 
 	// Misc
-	Edit       Edit             `cmd:"" group:"Misc" help:"Opens a file or bookmark in your editor"`
-	Goto       Goto             `cmd:"" group:"Misc" help:"Opens the file explorer at the given location"`
+	Version    Version          `cmd:"" group:"Misc" help:"Prints version info and check for updates"`
+	Info       Info             `cmd:"" group:"Misc" default:"withargs" help:"Displays meta info about klog"`
 	Config     Config           `cmd:"" group:"Misc" help:"Prints the current configuration"`
 	Json       Json             `cmd:"" group:"Misc" help:"Converts records to JSON"`
-	Info       Info             `cmd:"" group:"Misc" default:"withargs" help:"Displays meta info about klog"`
-	Version    Version          `cmd:"" group:"Misc" help:"Prints version info and check for updates"`
 	Completion kcmpl.Completion `cmd:"" group:"Misc" help:"Outputs shell code for enabling tab completion"`
 }

--- a/klog/app/cli/info.go
+++ b/klog/app/cli/info.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"github.com/jotaen/klog/klog/app"
+	"path/filepath"
+	"strings"
 )
 
 const DESCRIPTION = "klog: command line app for time tracking with plain-text files.\n" +
@@ -9,10 +11,10 @@ const DESCRIPTION = "klog: command line app for time tracking with plain-text fi
 	"Documentation online at " + KLOG_WEBSITE_URL
 
 type Info struct {
-	Version    bool `short:"v" name:"version" help:"Alias for 'klog version'"`
-	Spec       bool `name:"spec" help:"Print file format specification"`
-	License    bool `name:"license" help:"Print license"`
-	KlogFolder bool `name:"klog-folder" help:"Print path of .klog folder"`
+	Version      bool `short:"v" name:"version" help:"Alias for 'klog version'"`
+	ConfigFolder bool `name:"config-folder" help:"Prints path of klog config folder"`
+	Spec         bool `name:"spec" help:"Prints file format specification"`
+	License      bool `name:"license" help:"Prints license"`
 }
 
 func (opt *Info) Help() string {
@@ -29,8 +31,13 @@ func (opt *Info) Run(ctx app.Context) app.Error {
 	} else if opt.License {
 		ctx.Print(ctx.Meta().License + "\n")
 		return nil
-	} else if opt.KlogFolder {
-		ctx.Print(ctx.KlogFolder().Path() + "\n")
+	} else if opt.ConfigFolder {
+		ctx.Print(ctx.KlogConfigFolder().Path() + "\n")
+		lookups := make([]string, len(app.KLOG_CONFIG_FOLDER))
+		for i, f := range app.KLOG_CONFIG_FOLDER {
+			lookups[i] = filepath.Join(f.EnvVarSymbol(), f.Location)
+		}
+		ctx.Print("(Lookup order: " + strings.Join(lookups, ", ") + ")\n")
 		return nil
 	}
 	ctx.Print(DESCRIPTION + "\n")

--- a/klog/app/cli/main/cli.go
+++ b/klog/app/cli/main/cli.go
@@ -55,7 +55,8 @@ func Run(homeDir app.File, meta app.Meta, config app.Config, args []string) erro
 			return kong.TypeMapper(reflect.TypeOf(&s).Elem(), entrySummaryDecoder())
 		}(),
 		kong.ConfigureHelp(kong.HelpOptions{
-			Compact: true,
+			Compact:             true,
+			NoExpandSubcommands: true,
 		}),
 	)
 	if nErr != nil {

--- a/klog/app/cli/testcontext_test.go
+++ b/klog/app/cli/testcontext_test.go
@@ -115,8 +115,8 @@ func (ctx *TestingContext) HomeFolder() string {
 	return "~"
 }
 
-func (ctx *TestingContext) KlogFolder() app.File {
-	return app.NewFileOrPanic(ctx.HomeFolder() + app.KLOG_FOLDER_NAME)
+func (ctx *TestingContext) KlogConfigFolder() app.File {
+	return app.NewFileOrPanic("/tmp/sample-klog-config-folder")
 }
 
 func (ctx *TestingContext) Meta() app.Meta {

--- a/klog/app/context.go
+++ b/klog/app/context.go
@@ -23,7 +23,6 @@ import (
 type FileOrBookmarkName string
 
 const (
-	KLOG_FOLDER_NAME    = ".klog"
 	BOOKMARKS_FILE_NAME = "bookmarks.json"
 	CONFIG_FILE_NAME    = "config.ini"
 )
@@ -37,8 +36,8 @@ type Context interface {
 	// ReadLine reads user input from stdin.
 	ReadLine() (string, Error)
 
-	// KlogFolder returns the path of the .klog folder.
-	KlogFolder() File
+	// KlogConfigFolder returns the path of the klog config folder.
+	KlogConfigFolder() File
 
 	// Meta returns miscellaneous meta information.
 	Meta() Meta
@@ -142,7 +141,7 @@ func (ctx *context) ReadLine() (string, Error) {
 	)
 }
 
-func (ctx *context) KlogFolder() File {
+func (ctx *context) KlogConfigFolder() File {
 	return ctx.klogFolder
 }
 
@@ -264,13 +263,12 @@ func (ctx *context) Now() gotime.Time {
 }
 
 func (ctx *context) initialiseKlogFolder() Error {
-	klogFolder := ctx.KlogFolder()
+	klogFolder := ctx.KlogConfigFolder()
 	err := os.MkdirAll(klogFolder.Path(), 0700)
-	flagAsHidden(klogFolder.Path())
 	if err != nil {
 		return NewError(
-			"Unable to initialise ~/.klog folder",
-			"Please create a ~/.klog folder manually",
+			"Unable to initialise klog config folder",
+			"Please create a klog config folder manually",
 			err,
 		)
 	}
@@ -306,7 +304,7 @@ func (ctx *context) ManipulateBookmarks(manipulate func(BookmarksCollection) Err
 }
 
 func (ctx *context) bookmarkDatabasePath() File {
-	return Join(ctx.KlogFolder(), BOOKMARKS_FILE_NAME)
+	return Join(ctx.KlogConfigFolder(), BOOKMARKS_FILE_NAME)
 }
 
 func (ctx *context) Execute(cmd command.Command) Error {

--- a/klog/app/error.go
+++ b/klog/app/error.go
@@ -20,7 +20,7 @@ const (
 	// IO_ERROR should be used for errors during I/O processes.
 	IO_ERROR
 
-	// CONFIG_ERROR should be used for .klog-folder-related problems.
+	// CONFIG_ERROR should be used for config-folder-related problems.
 	CONFIG_ERROR
 
 	// NO_SUCH_BOOKMARK_ERROR should be used if the specified an unknown bookmark name.

--- a/klog/app/file.go
+++ b/klog/app/file.go
@@ -29,13 +29,14 @@ type FileWithContents interface {
 
 // NewFile creates a new File object from an absolute or relative path.
 // It returns an error if the given path cannot be resolved.
-func NewFile(path string) (File, Error) {
-	absolutePath, err := filepath.Abs(path)
+func NewFile(path ...string) (File, Error) {
+	fullPath := filepath.Join(path...)
+	absolutePath, err := filepath.Abs(fullPath)
 	if err != nil {
 		return nil, NewErrorWithCode(
 			IO_ERROR,
 			"Invalid file path",
-			"Location: "+path,
+			"Location: "+fullPath,
 			err,
 		)
 	}

--- a/klog/app/sys.go
+++ b/klog/app/sys.go
@@ -1,0 +1,6 @@
+package app
+
+type KlogFolder struct {
+	BasePathEnvVar string
+	Location       string
+}

--- a/klog/app/sys_darwin.go
+++ b/klog/app/sys_darwin.go
@@ -2,7 +2,9 @@
 
 package app
 
-import "github.com/jotaen/klog/klog/app/cli/lib/command"
+import (
+	"github.com/jotaen/klog/klog/app/cli/lib/command"
+)
 
 var POTENTIAL_EDITORS = []command.Command{
 	command.New("vim", nil),
@@ -16,6 +18,12 @@ var POTENTIAL_FILE_EXLORERS = []command.Command{
 	command.New("open", nil),
 }
 
-func flagAsHidden(path string) {
-	// Nothing to do on UNIX due to the dotfile convention
+var KLOG_CONFIG_FOLDER = []KlogFolder{
+	{"KLOG_CONFIG_HOME", ""},
+	{"XDG_CONFIG_HOME", "klog"},
+	{"HOME", ".klog"},
+}
+
+func (kf KlogFolder) EnvVarSymbol() string {
+	return "$" + kf.BasePathEnvVar
 }

--- a/klog/app/sys_linux.go
+++ b/klog/app/sys_linux.go
@@ -15,6 +15,12 @@ var POTENTIAL_FILE_EXLORERS = []command.Command{
 	command.New("xdg-open", nil),
 }
 
-func flagAsHidden(path string) {
-	// Nothing to do on UNIX due to the dotfile convention
+var KLOG_CONFIG_FOLDER = []KlogFolder{
+	{"KLOG_CONFIG_HOME", ""},
+	{"XDG_CONFIG_HOME", "klog"},
+	{"HOME", ".config/klog"},
+}
+
+func (kf KlogFolder) EnvVarSymbol() string {
+	return "$" + kf.BasePathEnvVar
 }

--- a/klog/app/sys_windows.go
+++ b/klog/app/sys_windows.go
@@ -17,12 +17,13 @@ var POTENTIAL_FILE_EXLORERS = []command.Command{
 	command.New("cmd.exe", []string{"/C", "start"}),
 }
 
-func flagAsHidden(path string) {
-	winFileName, err := syscall.UTF16PtrFromString(path)
-	if err != nil {
-		return
-	}
-	_ = syscall.SetFileAttributes(winFileName, syscall.FILE_ATTRIBUTE_HIDDEN)
+var KLOG_CONFIG_FOLDER = []KlogFolder{
+	{"KLOG_CONFIG_HOME", ""},
+	{"AppData", "klog"},
+}
+
+func (kf KlogFolder) EnvVarSymbol() string {
+	return "%" + kf.BasePathEnvVar + "%"
 }
 
 func init() {


### PR DESCRIPTION
Resolves https://github.com/jotaen/klog/issues/250.

The lookup order for klog’s config folder (previously referred to as “klog folder”, residing at `~/.klog` by default on all OS’es) is now this:

- macOS:
  - `$KLOG_CONFIG_HOME` (expects full path including the “suffix” bit, so you can also set it to be `/foo/bar/all-my-klog-configs` if that fancies you)
  - `$XDG_CONFIG_HOME/klog` (for XDG-addicts that stranded on macOS for some reason)
  - `$HOME/.klog` (the default / most “idiomatic” config location on macOS)
- Linux:
  - `$KLOG_CONFIG_HOME` (see above)
  - `$XDG_CONFIG_HOME/klog`
  - `$HOME/.config/klog` (the default / most “idiomatic” config location on Linux)
- Windows
  - `%KLOG_CONFIG_HOME%` (see above)
  - `%AppData%\klog` (the default / most “idiomatic” config location on Windows)

klog iterates through these respective locations, and the first env var that’s set wins. klog will look for (and potentially initialise) the config folder at that location.

By doing `klog --config-folder`, you can see which one it chose, and it also prints the lookup order for reference – e.g., on macOS:

```
$ klog --config-folder
/Users/jan/.klog
(Lookup order: $KLOG_CONFIG_HOME, $XDG_CONFIG_HOME/klog, $HOME/.klog)
```

For the env var name, I eventually settled on `KLOG_CONFIG_HOME`, as I find that most clear and straightforward.