### PR TITLE
update macOS install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,7 +11,9 @@ For an archive of all klog releases, [see here](https://github.com/jotaen/klog/r
 1. Download the latest version and unzip
    - [**Download for Intel**](https://github.com/jotaen/klog/releases/latest/download/klog-mac-intel.zip)
    - [**Download for M1 (ARM)**](https://github.com/jotaen/klog/releases/latest/download/klog-mac-arm.zip)
-2. Remove the quarantine flag for the downloaded and extracted executable, e.g. `xattr -d com.apple.quarantine Downloads/klog-mac-arm/klog`
+2. Make [MacOS “Gatekeeper”](https://support.apple.com/en-us/HT202491) trust the executable:
+   - Either right-click on the binary in the Finder, and select “Open“
+   - Or remove the “quarantine” flag from the binary via the CLI: `xattr -d com.apple.quarantine klog`
 3. Copy to path, e.g. `mv klog /usr/local/bin/klog` (might require `sudo`)
 
 ## Linux

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,8 +11,7 @@ For an archive of all klog releases, [see here](https://github.com/jotaen/klog/r
 1. Download the latest version and unzip
    - [**Download for Intel**](https://github.com/jotaen/klog/releases/latest/download/klog-mac-intel.zip)
    - [**Download for M1 (ARM)**](https://github.com/jotaen/klog/releases/latest/download/klog-mac-arm.zip)
-2. Right-click on the binary and select “Open“
-   (due to [Gatekeeper](https://support.apple.com/en-us/HT202491))
+2. Remove the quarantine flag for the downloaded and extracted executable, e.g. `xattr -d com.apple.quarantine Downloads/klog-mac-arm/klog`
 3. Copy to path, e.g. `mv klog /usr/local/bin/klog` (might require `sudo`)
 
 ## Linux


### PR DESCRIPTION
provide a cleaner way to make the downloaded but not properly signed binary executable