### PR TITLE
Add command `klog switch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 **Summary of changes of the command line tool**
 
+## Next up
+- **[ FEATURE ]** Add new command `klog switch`, that stops previously
+  ongoing activity (open time range), and starts a new one.
+
 ## v6.1
 - **[ FEATURE ]** Add new flag `klog start --resume`, which takes over the
   summary of the last entry for the new open-ended entry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 **Summary of changes of the command line tool**
 
 ## Next up
-- **[ FEATURE ]** Add new command `klog switch`, that stops previously
+- **[ FEATURE ]** Add new command `klog switch`, that stops a previously
   ongoing activity (open time range), and starts a new one.
 
 ## v6.1

--- a/klog/app/cli/create.go
+++ b/klog/app/cli/create.go
@@ -35,10 +35,6 @@ func (opt *Create) Run(ctx app.Context) app.Error {
 		[]reconciling.Creator{
 			reconciling.NewReconcilerForNewRecord(date, opt.DateFormat(ctx.Config()), additionalData),
 		},
-
-		func(reconciler *reconciling.Reconciler) error {
-			return nil
-		},
 	)
 }
 

--- a/klog/app/cli/create.go
+++ b/klog/app/cli/create.go
@@ -36,8 +36,8 @@ func (opt *Create) Run(ctx app.Context) app.Error {
 			reconciling.NewReconcilerForNewRecord(date, opt.DateFormat(ctx.Config()), additionalData),
 		},
 
-		func(reconciler *reconciling.Reconciler) (*reconciling.Result, error) {
-			return reconciler.MakeResult()
+		func(reconciler *reconciling.Reconciler) error {
+			return nil
 		},
 	)
 }

--- a/klog/app/cli/index.go
+++ b/klog/app/cli/index.go
@@ -23,6 +23,7 @@ type Cli struct {
 	Start  Start  `cmd:"" name:"start" group:"Manipulate Files" aliases:"in" help:"Starts a new open time range"`
 	Stop   Stop   `cmd:"" name:"stop" group:"Manipulate Files" aliases:"out" help:"Closes the open time range"`
 	Pause  Pause  `cmd:"" name:"pause" group:"Manipulate Files" help:"Pauses the open time range"`
+	Switch Switch `cmd:"" name:"switch" group:"Manipulate Files" help:"Closes open range and starts a new one"`
 	Create Create `cmd:"" name:"create" group:"Manipulate Files" help:"Creates a new, empty record"`
 
 	// Manage Files

--- a/klog/app/cli/lib/helper.go
+++ b/klog/app/cli/lib/helper.go
@@ -11,8 +11,8 @@ type ReconcileOpts struct {
 	WarnArgs
 }
 
-func Reconcile(ctx app.Context, opts ReconcileOpts, creators []reconciling.Creator, reconcile reconciling.Reconcile) app.Error {
-	result, err := ctx.ReconcileFile(opts.OutputFileArgs.File, creators, reconcile)
+func Reconcile(ctx app.Context, opts ReconcileOpts, creators []reconciling.Creator, reconcile ...reconciling.Reconcile) app.Error {
+	result, err := ctx.ReconcileFile(opts.OutputFileArgs.File, creators, reconcile...)
 	if err != nil {
 		return err
 	}

--- a/klog/app/cli/pause.go
+++ b/klog/app/cli/pause.go
@@ -44,7 +44,7 @@ func (opt *Pause) Run(ctx app.Context) app.Error {
 	// Ensure that an open range exists, and set up the pause entry:
 	// - Without `--extend`, append a new entry, including the summary
 	// - With `--extend`, find a pause and append the summary
-	lastResult, err := doReconcile(func(reconciler *reconciling.Reconciler) (*reconciling.Result, error) {
+	lastResult, err := doReconcile(func(reconciler *reconciling.Reconciler) error {
 		if opt.Extend {
 			return reconciler.ExtendPause(klog.NewDuration(0, 0), opt.Summary)
 		}
@@ -70,7 +70,7 @@ func (opt *Pause) Run(ctx app.Context) app.Error {
 			ctx.Print("\n")
 		})
 		if uncapturedIncrement > 0 {
-			lastResult, err = doReconcile(func(reconciler *reconciling.Reconciler) (*reconciling.Result, error) {
+			lastResult, err = doReconcile(func(reconciler *reconciling.Reconciler) error {
 				// Don’t add the summary here, as we already appended it in the initial run.
 				return reconciler.ExtendPause(klog.NewDuration(0, -1*uncapturedIncrement), nil)
 			})

--- a/klog/app/cli/start.go
+++ b/klog/app/cli/start.go
@@ -40,10 +40,10 @@ func (opt *Start) Run(ctx app.Context) app.Error {
 			reconciling.NewReconcilerForNewRecord(date, opt.DateFormat(ctx.Config()), additionalData),
 		},
 
-		func(reconciler *reconciling.Reconciler) (*reconciling.Result, error) {
+		func(reconciler *reconciling.Reconciler) error {
 			summary, sErr := opt.Summary(reconciler.Record)
 			if sErr != nil {
-				return nil, sErr
+				return sErr
 			}
 			return reconciler.StartOpenRange(time, opt.TimeFormat(ctx.Config()), summary)
 		},

--- a/klog/app/cli/stop.go
+++ b/klog/app/cli/stop.go
@@ -45,7 +45,7 @@ func (opt *Stop) Run(ctx app.Context) app.Error {
 			}(),
 		},
 
-		func(reconciler *reconciling.Reconciler) (*reconciling.Result, error) {
+		func(reconciler *reconciling.Reconciler) error {
 			if shouldTryYesterday && reconciler.Record.Date().IsEqualTo(yesterday) {
 				time, _ = time.Plus(klog.NewDuration(24, 0))
 			}

--- a/klog/app/cli/switch.go
+++ b/klog/app/cli/switch.go
@@ -31,7 +31,6 @@ func (opt *Switch) Run(ctx app.Context) app.Error {
 		return tErr
 	}
 
-	// Start new range at the exact same time.
 	return lib.Reconcile(ctx, lib.ReconcileOpts{OutputFileArgs: opt.OutputFileArgs, WarnArgs: opt.WarnArgs},
 		[]reconciling.Creator{
 			reconciling.NewReconcilerAtRecord(date),

--- a/klog/app/cli/switch.go
+++ b/klog/app/cli/switch.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"github.com/jotaen/klog/klog"
+	"github.com/jotaen/klog/klog/app"
+	"github.com/jotaen/klog/klog/app/cli/lib"
+	"github.com/jotaen/klog/klog/parser/reconciling"
+)
+
+type Switch struct {
+	SummaryText klog.EntrySummary `name:"summary" short:"s" placeholder:"TEXT" help:"Summary text for the new entry"`
+	lib.AtDateAndTimeArgs
+	lib.NoStyleArgs
+	lib.OutputFileArgs
+	lib.WarnArgs
+}
+
+func (opt *Switch) Help() string {
+	return `Closes a previously ongoing activity (i.e., open time range), and starts a new one.
+
+The end time of the previous activity will be the same as the start time for the new entry.
+`
+}
+
+func (opt *Switch) Run(ctx app.Context) app.Error {
+	opt.NoStyleArgs.Apply(&ctx)
+	now := ctx.Now()
+	date := opt.AtDate(now)
+	time, tErr := opt.AtTime(now, ctx.Config())
+	if tErr != nil {
+		return tErr
+	}
+
+	// Start new range at the exact same time.
+	return lib.Reconcile(ctx, lib.ReconcileOpts{OutputFileArgs: opt.OutputFileArgs, WarnArgs: opt.WarnArgs},
+		[]reconciling.Creator{
+			reconciling.NewReconcilerAtRecord(date),
+		},
+
+		func(reconciler *reconciling.Reconciler) error {
+			return reconciler.CloseOpenRange(time, opt.TimeFormat(ctx.Config()), nil)
+		},
+		func(reconciler *reconciling.Reconciler) error {
+			return reconciler.StartOpenRange(time, opt.TimeFormat(ctx.Config()), opt.SummaryText)
+		},
+	)
+}

--- a/klog/app/cli/switch_test.go
+++ b/klog/app/cli/switch_test.go
@@ -1,0 +1,189 @@
+package cli
+
+import (
+	"github.com/jotaen/klog/klog"
+	"github.com/jotaen/klog/klog/app/cli/lib"
+	"github.com/jotaen/klog/klog/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestSwitch(t *testing.T) {
+	state, err := NewTestingContext()._SetRecords(`
+1920-02-02
+	11:22-?
+`)._SetNow(1920, 2, 2, 15, 24)._Run((&Switch{
+		AtDateAndTimeArgs: lib.AtDateAndTimeArgs{
+			AtDateArgs: lib.AtDateArgs{Date: klog.Ɀ_Date_(1920, 2, 2)},
+		},
+	}).Run)
+	require.Nil(t, err)
+	assert.Equal(t, `
+1920-02-02
+	11:22-15:24
+	15:24-?
+`, state.writtenFileContents)
+}
+
+func TestSwitchWithSummaries(t *testing.T) {
+	state, err := NewTestingContext()._SetRecords(`
+1920-02-02
+	11:22-? Currently ongoing...
+		...task
+
+1920-02-03
+Next day
+`)._SetNow(1920, 2, 2, 15, 24)._Run((&Switch{
+		AtDateAndTimeArgs: lib.AtDateAndTimeArgs{
+			AtDateArgs: lib.AtDateArgs{Date: klog.Ɀ_Date_(1920, 2, 2)},
+		},
+		SummaryText: klog.Ɀ_EntrySummary_("Start", "over"),
+	}).Run)
+	require.Nil(t, err)
+	assert.Equal(t, `
+1920-02-02
+	11:22-15:24 Currently ongoing...
+		...task
+	15:24-? Start
+		over
+
+1920-02-03
+Next day
+`, state.writtenFileContents)
+}
+
+func TestSwitchWithStyle(t *testing.T) {
+	// Without any preference, detect from file.
+	{
+		state, err := NewTestingContext()._SetRecords(`
+1920-02-02
+	10:22am-???
+`)._SetNow(1920, 2, 2, 14, 49)._Run((&Switch{}).Run)
+		require.Nil(t, err)
+		assert.Equal(t, `
+1920-02-02
+	10:22am-2:49pm
+	2:49pm-???
+`, state.writtenFileContents)
+	}
+
+	// Use preference from config file, if given.
+	{
+		state, err := NewTestingContext()._SetRecords(`
+1920-02-02
+	10:22am-?
+`)._SetFileConfig(`
+time_convention = 24h
+`)._SetNow(1920, 2, 2, 14, 49)._Run((&Switch{}).Run)
+		require.Nil(t, err)
+		assert.Equal(t, `
+1920-02-02
+	10:22am-14:49
+	14:49-?
+`, state.writtenFileContents)
+	}
+
+	// If explicit flag was provided, that takes ultimate precedence.
+	{
+		state, err := NewTestingContext()._SetRecords(`
+1920-02-02
+	10:22am-?
+`)._SetFileConfig(`
+time_convention = 12h
+`)._SetNow(1920, 2, 2, 14, 49)._Run((&Switch{
+			AtDateAndTimeArgs: lib.AtDateAndTimeArgs{Time: klog.Ɀ_Time_(14, 49)},
+		}).Run)
+		require.Nil(t, err)
+		assert.Equal(t, `
+1920-02-02
+	10:22am-14:49
+	14:49-?
+`, state.writtenFileContents)
+	}
+}
+
+func TestSwitchFailsIfNoRecentRecord(t *testing.T) {
+	state, err := NewTestingContext()._SetRecords(`
+1623-12-12
+	15:00-?
+`)._Run((&Switch{
+		AtDateAndTimeArgs: lib.AtDateAndTimeArgs{
+			AtDateArgs: lib.AtDateArgs{Date: klog.Ɀ_Date_(1624, 02, 1)},
+			Time:       klog.Ɀ_Time_(16, 00),
+		},
+	}).Run)
+	require.Error(t, err)
+	assert.Equal(t, "No such record", err.Error())
+	assert.Equal(t, "", state.writtenFileContents)
+}
+
+func TestSwitchFailsIfNoOpenRange(t *testing.T) {
+	state, err := NewTestingContext()._SetRecords(`
+1623-12-12
+	15:00-16:00
+`)._Run((&Switch{
+		AtDateAndTimeArgs: lib.AtDateAndTimeArgs{
+			AtDateArgs: lib.AtDateArgs{Date: klog.Ɀ_Date_(1623, 12, 12)},
+			Time:       klog.Ɀ_Time_(16, 00),
+		},
+	}).Run)
+	require.Error(t, err)
+	assert.Equal(t, "Manipulation failed", err.Error())
+	assert.Equal(t, "No open time range", err.Details())
+	assert.Equal(t, "", state.writtenFileContents)
+}
+
+func TestSwitchWithRounding(t *testing.T) {
+	// With --round flag
+	{
+		r15, _ := service.NewRounding(15)
+		state, err := NewTestingContext()._SetRecords(`
+2005-05-05
+    8:10 - ?
+`)._SetNow(2005, 5, 5, 11, 24)._Run((&Switch{
+			AtDateAndTimeArgs: lib.AtDateAndTimeArgs{Round: r15},
+		}).Run)
+		require.Nil(t, err)
+		assert.Equal(t, `
+2005-05-05
+    8:10 - 11:30
+    11:30 - ?
+`, state.writtenFileContents)
+	}
+
+	// With file config
+	{
+		state, err := NewTestingContext()._SetRecords(`
+2005-05-05
+    8:10 - ?
+`)._SetNow(2005, 5, 5, 11, 24)._SetFileConfig(`
+default_rounding = 30m
+`)._Run((&Switch{}).Run)
+		require.Nil(t, err)
+		assert.Equal(t, `
+2005-05-05
+    8:10 - 11:30
+    11:30 - ?
+`, state.writtenFileContents)
+	}
+
+	// --round flag trumps file config
+	{
+		r5, _ := service.NewRounding(5)
+		state, err := NewTestingContext()._SetRecords(`
+2005-05-05
+    8:10 - ?
+`)._SetNow(2005, 5, 5, 11, 24)._SetFileConfig(`
+default_rounding = 30m
+`)._Run((&Switch{
+			AtDateAndTimeArgs: lib.AtDateAndTimeArgs{Round: r5},
+		}).Run)
+		require.Nil(t, err)
+		assert.Equal(t, `
+2005-05-05
+    8:10 - 11:25
+    11:25 - ?
+`, state.writtenFileContents)
+	}
+}

--- a/klog/app/cli/testcontext_test.go
+++ b/klog/app/cli/testcontext_test.go
@@ -132,8 +132,8 @@ func (ctx *TestingContext) ReadInputs(_ ...app.FileOrBookmarkName) ([]klog.Recor
 	return ctx.records, nil
 }
 
-func (ctx *TestingContext) ReconcileFile(_ app.FileOrBookmarkName, creators []reconciling.Creator, reconcile reconciling.Reconcile) (*reconciling.Result, app.Error) {
-	result, err := app.ApplyReconciler(ctx.records, ctx.blocks, creators, reconcile)
+func (ctx *TestingContext) ReconcileFile(_ app.FileOrBookmarkName, creators []reconciling.Creator, reconcile ...reconciling.Reconcile) (*reconciling.Result, app.Error) {
+	result, err := app.ApplyReconciler(ctx.records, ctx.blocks, creators, reconcile...)
 	if err != nil {
 		return nil, err
 	}

--- a/klog/app/cli/track.go
+++ b/klog/app/cli/track.go
@@ -38,7 +38,7 @@ func (opt *Track) Run(ctx app.Context) app.Error {
 			reconciling.NewReconcilerForNewRecord(date, opt.DateFormat(ctx.Config()), additionalData),
 		},
 
-		func(reconciler *reconciling.Reconciler) (*reconciling.Result, error) {
+		func(reconciler *reconciling.Reconciler) error {
 			return reconciler.AppendEntry(opt.Entry)
 		},
 	)

--- a/klog/parser/reconciling/append_entry.go
+++ b/klog/parser/reconciling/append_entry.go
@@ -4,7 +4,7 @@ import "github.com/jotaen/klog/klog"
 
 // AppendEntry adds a new entry to the end of the record.
 // `newEntry` must include the entry value at the beginning of its first line.
-func (r *Reconciler) AppendEntry(newEntry klog.EntrySummary) (*Result, error) {
+func (r *Reconciler) AppendEntry(newEntry klog.EntrySummary) error {
 	r.insert(r.lastLinePointer, toMultilineEntryTexts("", newEntry))
-	return r.MakeResult()
+	return nil
 }

--- a/klog/parser/reconciling/append_entry_test.go
+++ b/klog/parser/reconciling/append_entry_test.go
@@ -9,14 +9,21 @@ import (
 	"testing"
 )
 
+func assertResult(t *testing.T, r *Reconciler) *Result {
+	result, err := r.MakeResult()
+	require.Nil(t, err)
+	return result
+}
+
 func TestReconcilerAddsNewlyCreatedEntryAtEndOfFile(t *testing.T) {
 	original := "\n2018-01-01\n    1h"
 	rs, bs, _ := parser.NewSerialParser().Parse(original)
-
 	reconciler := NewReconcilerAtRecord(klog.Ɀ_Date_(2018, 1, 1))(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.AppendEntry(klog.Ɀ_EntrySummary_("16:00-17:00"))
+	err := reconciler.AppendEntry(klog.Ɀ_EntrySummary_("16:00-17:00"))
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2018-01-01
     1h
@@ -41,8 +48,10 @@ Hello World
 	rs, bs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(klog.Ɀ_Date_(2018, 1, 2))(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.AppendEntry(klog.Ɀ_EntrySummary_("2h30m"))
+	err := reconciler.AppendEntry(klog.Ɀ_EntrySummary_("2h30m"))
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	require.NotNil(t, result)
 	require.Equal(t, 150, result.Record.Entries()[2].Duration().InMinutes())
 	require.Equal(t, 315, service.Total(result.Record).InMinutes())
@@ -68,8 +77,10 @@ func TestReconcilerCanHandleUTF8Input(t *testing.T) {
 
 	reconciler := NewReconcilerAtRecord(klog.Ɀ_Date_(2018, 1, 1))(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.AppendEntry(klog.Ɀ_EntrySummary_("20m 掃除機"))
+	err := reconciler.AppendEntry(klog.Ɀ_EntrySummary_("20m 掃除機"))
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2018-01-01
 家事
@@ -84,8 +95,10 @@ func TestReconcilerSplitsUpSummaryText(t *testing.T) {
 
 	reconciler := NewReconcilerAtRecord(klog.Ɀ_Date_(2018, 1, 1))(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.AppendEntry(klog.Ɀ_EntrySummary_("2h This is a", "multiline summary"))
+	err := reconciler.AppendEntry(klog.Ɀ_EntrySummary_("2h This is a", "multiline summary"))
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2018-01-01
     1h
@@ -100,8 +113,10 @@ func TestReconcilerStartsSummaryTextOnNextLine(t *testing.T) {
 
 	reconciler := NewReconcilerAtRecord(klog.Ɀ_Date_(2018, 1, 1))(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.AppendEntry(klog.Ɀ_EntrySummary_("2h", "Some activity"))
+	err := reconciler.AppendEntry(klog.Ɀ_EntrySummary_("2h", "Some activity"))
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2018-01-01
     1h
@@ -115,7 +130,11 @@ func TestReconcilerRejectsInvalidEntry(t *testing.T) {
 	rs, bs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(klog.Ɀ_Date_(2018, 1, 1))(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.AppendEntry(klog.Ɀ_EntrySummary_("this is not valid entry text"))
-	require.Nil(t, result)
-	assert.Error(t, err)
+
+	err := reconciler.AppendEntry(klog.Ɀ_EntrySummary_("this is not valid entry text"))
+	assert.Nil(t, err) // This doesn’t create an error yet, only calling `MakingResult` will!
+
+	result, rErr := reconciler.MakeResult()
+	assert.Error(t, rErr)
+	assert.Nil(t, result)
 }

--- a/klog/parser/reconciling/append_entry_test.go
+++ b/klog/parser/reconciling/append_entry_test.go
@@ -132,7 +132,7 @@ func TestReconcilerRejectsInvalidEntry(t *testing.T) {
 	require.NotNil(t, reconciler)
 
 	err := reconciler.AppendEntry(klog.Ɀ_EntrySummary_("this is not valid entry text"))
-	assert.Nil(t, err) // This doesn’t create an error yet, only calling `MakingResult` will!
+	assert.Nil(t, err) // This doesn’t produce an error yet, but calling `MakingResult` will!
 
 	result, rErr := reconciler.MakeResult()
 	assert.Error(t, rErr)

--- a/klog/parser/reconciling/close_open_range.go
+++ b/klog/parser/reconciling/close_open_range.go
@@ -7,14 +7,14 @@ import (
 )
 
 // CloseOpenRange tries to close the open time range.
-func (r *Reconciler) CloseOpenRange(endTime klog.Time, format ReformatDirective[klog.TimeFormat], additionalSummary klog.EntrySummary) (*Result, error) {
+func (r *Reconciler) CloseOpenRange(endTime klog.Time, format ReformatDirective[klog.TimeFormat], additionalSummary klog.EntrySummary) error {
 	openRangeEntryIndex := r.findOpenRangeIndex()
 	if openRangeEntryIndex == -1 {
-		return nil, errors.New("No open time range")
+		return errors.New("No open time range")
 	}
 	eErr := r.Record.EndOpenRange(endTime)
 	if eErr != nil {
-		return nil, errors.New("Start and end time must be in chronological order")
+		return errors.New("Start and end time must be in chronological order")
 	}
 
 	// Replace question mark with end time.
@@ -30,5 +30,5 @@ func (r *Reconciler) CloseOpenRange(endTime klog.Time, format ReformatDirective[
 		)
 
 	r.concatenateSummary(openRangeEntryIndex, openRangeValueLineIndex, additionalSummary)
-	return r.MakeResult()
+	return nil
 }

--- a/klog/parser/reconciling/close_open_range_test.go
+++ b/klog/parser/reconciling/close_open_range_test.go
@@ -18,8 +18,10 @@ func TestReconcilerClosesOpenRange(t *testing.T) {
 	atTime := klog.Ɀ_Time_(15, 30)
 	reconciler := NewReconcilerAtRecord(atDate)(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.CloseOpenRange(atTime, NoReformat[klog.TimeFormat](), nil)
+	err := reconciler.CloseOpenRange(atTime, NoReformat[klog.TimeFormat](), nil)
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2010-04-27
     15:00 - 15:30
@@ -36,8 +38,10 @@ func TestReconcilerClosesOpenRangeWithNewSummary(t *testing.T) {
 	atTime := klog.Ɀ_Time_(15, 22)
 	reconciler := NewReconcilerAtRecord(atDate)(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.CloseOpenRange(atTime, NoReformat[klog.TimeFormat](), klog.Ɀ_EntrySummary_("Finished."))
+	err := reconciler.CloseOpenRange(atTime, NoReformat[klog.TimeFormat](), klog.Ɀ_EntrySummary_("Finished."))
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2018-01-01
     15:00 - 15:22 Finished.
@@ -54,8 +58,10 @@ func TestReconcilerClosesOpenRangeWithNewMultilineSummary(t *testing.T) {
 	atTime := klog.Ɀ_Time_(15, 22)
 	reconciler := NewReconcilerAtRecord(atDate)(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.CloseOpenRange(atTime, NoReformat[klog.TimeFormat](), klog.Ɀ_EntrySummary_("", "Finished."))
+	err := reconciler.CloseOpenRange(atTime, NoReformat[klog.TimeFormat](), klog.Ɀ_EntrySummary_("", "Finished."))
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2018-01-01
     15:00 - 15:22
@@ -77,8 +83,10 @@ func TestReconcilerClosesOpenRangeWithExtendingSummary(t *testing.T) {
 	atTime := klog.Ɀ_Time_(16, 42)
 	reconciler := NewReconcilerAtRecord(atDate)(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.CloseOpenRange(atTime, NoReformat[klog.TimeFormat](), klog.Ɀ_EntrySummary_("Yes!"))
+	err := reconciler.CloseOpenRange(atTime, NoReformat[klog.TimeFormat](), klog.Ɀ_EntrySummary_("Yes!"))
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2018-01-01
     1h Multiline...
@@ -100,8 +108,10 @@ Arbeiten rund um’s Haus… 🏡
 	atTime := klog.Ɀ_Time_(16, 15)
 	reconciler := NewReconcilerAtRecord(atDate)(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.CloseOpenRange(atTime, NoReformat[klog.TimeFormat](), klog.Ɀ_EntrySummary_("🪴"))
+	err := reconciler.CloseOpenRange(atTime, NoReformat[klog.TimeFormat](), klog.Ɀ_EntrySummary_("🪴"))
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2018-01-01
 Arbeiten rund um’s Haus… 🏡
@@ -120,8 +130,10 @@ func TestReconcilerClosesOpenRangeWithExtendingSummaryOnNextLine(t *testing.T) {
 	atTime := klog.Ɀ_Time_(18, 01)
 	reconciler := NewReconcilerAtRecord(atDate)(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.CloseOpenRange(atTime, NoReformat[klog.TimeFormat](), klog.Ɀ_EntrySummary_("", "Stopped."))
+	err := reconciler.CloseOpenRange(atTime, NoReformat[klog.TimeFormat](), klog.Ɀ_EntrySummary_("", "Stopped."))
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2018-01-01
     16:00-18:01 Started...
@@ -140,8 +152,10 @@ func TestReconcilerClosesOpenRangeDetectsStyle(t *testing.T) {
 	atTime := klog.Ɀ_Time_(15, 30)
 	reconciler := NewReconcilerAtRecord(atDate)(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.CloseOpenRange(atTime, ReformatAutoStyle[klog.TimeFormat](), nil)
+	err := reconciler.CloseOpenRange(atTime, ReformatAutoStyle[klog.TimeFormat](), nil)
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2010-04-27
     3:00pm - 3:30pm
@@ -158,8 +172,10 @@ func TestReconcilerClosesOpenRangeWithExplicitOverrideStyle(t *testing.T) {
 	atTime := klog.Ɀ_Time_(15, 30)
 	reconciler := NewReconcilerAtRecord(atDate)(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.CloseOpenRange(atTime, ReformatExplicitly[klog.TimeFormat](klog.TimeFormat{Use24HourClock: true}), nil)
+	err := reconciler.CloseOpenRange(atTime, ReformatExplicitly[klog.TimeFormat](klog.TimeFormat{Use24HourClock: true}), nil)
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2010-04-27
     3:00pm - 15:30
@@ -176,8 +192,10 @@ func TestReconcilerClosesOpenRangeWithOwnStyle(t *testing.T) {
 	atTime := klog.Ɀ_Time_(15, 30) // Not an am/pm time!
 	reconciler := NewReconcilerAtRecord(atDate)(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.CloseOpenRange(atTime, NoReformat[klog.TimeFormat](), nil)
+	err := reconciler.CloseOpenRange(atTime, NoReformat[klog.TimeFormat](), nil)
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2010-04-27
     3:00pm - 15:30

--- a/klog/parser/reconciling/creator_test.go
+++ b/klog/parser/reconciling/creator_test.go
@@ -28,8 +28,10 @@ func TestReconcilerRespectsIndentationStyle(t *testing.T) {
 	} {
 		rs, bs, _ := parser.NewSerialParser().Parse(x.original)
 		reconciler := NewReconcilerAtRecord(klog.Ɀ_Date_(1444, 10, 9))(rs, bs)
-		result, err := reconciler.AppendEntry(klog.Ɀ_EntrySummary_("30m"))
+		err := reconciler.AppendEntry(klog.Ɀ_EntrySummary_("30m"))
 		require.Nil(t, err)
+
+		result := assertResult(t, reconciler)
 		assert.Equal(t, x.expected, result.AllSerialised)
 	}
 }
@@ -44,8 +46,10 @@ func TestReconcilerRespectsLineEndingStyle(t *testing.T) {
 	} {
 		rs, bs, _ := parser.NewSerialParser().Parse(x.original)
 		reconciler := NewReconcilerAtRecord(klog.Ɀ_Date_(1444, 10, 9))(rs, bs)
-		result, err := reconciler.AppendEntry(klog.Ɀ_EntrySummary_("30m"))
+		err := reconciler.AppendEntry(klog.Ɀ_EntrySummary_("30m"))
 		require.Nil(t, err)
+
+		result := assertResult(t, reconciler)
 		assert.Equal(t, x.expected, result.AllSerialised)
 	}
 }

--- a/klog/parser/reconciling/pause_open_range.go
+++ b/klog/parser/reconciling/pause_open_range.go
@@ -8,9 +8,9 @@ import (
 )
 
 // AppendPause adds a new pause entry to a record that contains an open range.
-func (r *Reconciler) AppendPause(summary klog.EntrySummary) (*Result, error) {
+func (r *Reconciler) AppendPause(summary klog.EntrySummary) error {
 	if r.findOpenRangeIndex() == -1 {
-		return nil, errors.New("No open time range found")
+		return errors.New("No open time range found")
 	}
 	entryValue := "-0m"
 	if len(summary) == 0 {
@@ -24,9 +24,9 @@ func (r *Reconciler) AppendPause(summary klog.EntrySummary) (*Result, error) {
 }
 
 // ExtendPause extends an existing pause entry.
-func (r *Reconciler) ExtendPause(increment klog.Duration, additionalSummary klog.EntrySummary) (*Result, error) {
+func (r *Reconciler) ExtendPause(increment klog.Duration, additionalSummary klog.EntrySummary) error {
 	if r.findOpenRangeIndex() == -1 {
-		return nil, errors.New("No open time range found")
+		return errors.New("No open time range found")
 	}
 
 	pauseEntryI := r.findLastEntry(func(e klog.Entry) bool {
@@ -39,7 +39,7 @@ func (r *Reconciler) ExtendPause(increment klog.Duration, additionalSummary klog
 		})
 	})
 	if pauseEntryI == -1 {
-		return nil, errors.New("Could not find existing pause to extend")
+		return errors.New("Could not find existing pause to extend")
 	}
 
 	extendedPause := r.Record.Entries()[pauseEntryI].Duration().Plus(increment)
@@ -51,5 +51,5 @@ func (r *Reconciler) ExtendPause(increment klog.Duration, additionalSummary klog
 	}
 
 	r.concatenateSummary(pauseEntryI, pauseLineIndex, additionalSummary)
-	return r.MakeResult()
+	return nil
 }

--- a/klog/parser/reconciling/pause_open_range_test.go
+++ b/klog/parser/reconciling/pause_open_range_test.go
@@ -16,8 +16,10 @@ func TestReconcilerAppendingPauseAddsNewEntry(t *testing.T) {
 	rs, bs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(klog.Ɀ_Date_(2010, 4, 27))(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.AppendPause(nil)
+	err := reconciler.AppendPause(nil)
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2010-04-27
     3:00pm - ?
@@ -33,8 +35,10 @@ func TestReconcilerAppendingPauseWithSummary(t *testing.T) {
 	rs, bs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(klog.Ɀ_Date_(2010, 4, 27))(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.AppendPause(klog.Ɀ_EntrySummary_("Lunch break"))
+	err := reconciler.AppendPause(klog.Ɀ_EntrySummary_("Lunch break"))
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2010-04-27
     3:00pm - ?
@@ -50,8 +54,10 @@ func TestReconcilerAppendingPauseWithMultilineSummary(t *testing.T) {
 	rs, bs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(klog.Ɀ_Date_(2010, 4, 27))(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.AppendPause(klog.Ɀ_EntrySummary_("Lunch", "break"))
+	err := reconciler.AppendPause(klog.Ɀ_EntrySummary_("Lunch", "break"))
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2010-04-27
     3:00pm - ?
@@ -69,8 +75,10 @@ func TestReconcilerAppendPauseWithUTF8Summary(t *testing.T) {
 	rs, bs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(klog.Ɀ_Date_(2010, 4, 27))(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.AppendPause(klog.Ɀ_EntrySummary_("午休"))
+	err := reconciler.AppendPause(klog.Ɀ_EntrySummary_("午休"))
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2010-04-27
 你好！你好吗？
@@ -87,9 +95,8 @@ func TestReconcilerAppendingPauseFailsIfThereIsNoOpenRange(t *testing.T) {
 	rs, bs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(klog.Ɀ_Date_(2010, 4, 27))(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.AppendPause(nil)
+	err := reconciler.AppendPause(nil)
 	require.Error(t, err)
-	assert.Nil(t, result)
 }
 
 func TestReconcilerExtendingPauseExtendsPause(t *testing.T) {
@@ -103,8 +110,10 @@ Foo
 	rs, bs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(klog.Ɀ_Date_(2010, 4, 27))(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.ExtendPause(klog.NewDuration(0, -3), nil)
+	err := reconciler.ExtendPause(klog.NewDuration(0, -3), nil)
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2010-04-27
 Foo
@@ -125,8 +134,10 @@ Foo
 	rs, bs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(klog.Ɀ_Date_(2010, 4, 27))(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.ExtendPause(klog.NewDuration(0, -3), klog.Ɀ_EntrySummary_("and more break"))
+	err := reconciler.ExtendPause(klog.NewDuration(0, -3), klog.Ɀ_EntrySummary_("and more break"))
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2010-04-27
 Foo
@@ -147,8 +158,10 @@ Foo
 	rs, bs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(klog.Ɀ_Date_(2010, 4, 27))(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.ExtendPause(klog.NewDuration(-1, 0), klog.Ɀ_EntrySummary_("", "and more break"))
+	err := reconciler.ExtendPause(klog.NewDuration(-1, 0), klog.Ɀ_EntrySummary_("", "and more break"))
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2010-04-27
 Foo
@@ -171,8 +184,10 @@ Foo
 	rs, bs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(klog.Ɀ_Date_(2010, 4, 27))(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.ExtendPause(klog.NewDuration(-1, 0), klog.Ɀ_EntrySummary_("and more break"))
+	err := reconciler.ExtendPause(klog.NewDuration(-1, 0), klog.Ɀ_EntrySummary_("and more break"))
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2010-04-27
 Foo
@@ -195,8 +210,10 @@ Foo
 	rs, bs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(klog.Ɀ_Date_(2010, 4, 27))(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.ExtendPause(klog.NewDuration(-2, -51), nil)
+	err := reconciler.ExtendPause(klog.NewDuration(-2, -51), nil)
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2010-04-27
 Foo
@@ -218,8 +235,10 @@ Foo
 	rs, bs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(klog.Ɀ_Date_(2010, 4, 27))(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.ExtendPause(klog.NewDuration(0, 0), nil)
+	err := reconciler.ExtendPause(klog.NewDuration(0, 0), nil)
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2010-04-27
 Foo
@@ -238,9 +257,8 @@ func TestReconcilerExtendingPauseFailsIfThereIsNoOpenRange(t *testing.T) {
 	rs, bs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(klog.Ɀ_Date_(2010, 4, 27))(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.ExtendPause(klog.NewDuration(2, 0), nil)
+	err := reconciler.ExtendPause(klog.NewDuration(2, 0), nil)
 	require.Error(t, err)
-	assert.Nil(t, result)
 }
 
 func TestReconcilerDoesNotExtendNonNegativeDurations(t *testing.T) {
@@ -252,7 +270,6 @@ func TestReconcilerDoesNotExtendNonNegativeDurations(t *testing.T) {
 	rs, bs, _ := parser.NewSerialParser().Parse(original)
 	reconciler := NewReconcilerAtRecord(klog.Ɀ_Date_(2010, 4, 27))(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.ExtendPause(klog.NewDuration(0, -10), nil)
+	err := reconciler.ExtendPause(klog.NewDuration(0, -10), nil)
 	require.Error(t, err)
-	assert.Nil(t, result)
 }

--- a/klog/parser/reconciling/reconciler.go
+++ b/klog/parser/reconciling/reconciler.go
@@ -33,7 +33,7 @@ type Result struct {
 }
 
 // Reconcile is a function interface for applying a reconciler.
-type Reconcile func(*Reconciler) (*Result, error)
+type Reconcile func(*Reconciler) error
 
 func countLines(es []klog.Entry) int {
 	result := 0

--- a/klog/parser/reconciling/start_open_range.go
+++ b/klog/parser/reconciling/start_open_range.go
@@ -6,9 +6,9 @@ import (
 )
 
 // StartOpenRange appends a new open range entry in a record.
-func (r *Reconciler) StartOpenRange(startTime klog.Time, format ReformatDirective[klog.TimeFormat], entrySummary klog.EntrySummary) (*Result, error) {
+func (r *Reconciler) StartOpenRange(startTime klog.Time, format ReformatDirective[klog.TimeFormat], entrySummary klog.EntrySummary) error {
 	if r.findOpenRangeIndex() != -1 {
-		return nil, errors.New("There is already an open range in this record")
+		return errors.New("There is already an open range in this record")
 	}
 	format.apply(r.style.timeFormat(), func(f klog.TimeFormat) {
 		// Re-parse time to apply format.
@@ -21,5 +21,5 @@ func (r *Reconciler) StartOpenRange(startTime klog.Time, format ReformatDirectiv
 	or := klog.NewOpenRangeWithFormat(startTime, r.style.openRangeFormat())
 	entryValue := or.ToString()
 	r.insert(r.lastLinePointer, toMultilineEntryTexts(entryValue, entrySummary))
-	return r.MakeResult()
+	return nil
 }

--- a/klog/parser/reconciling/start_open_range_test.go
+++ b/klog/parser/reconciling/start_open_range_test.go
@@ -18,8 +18,10 @@ func TestReconcilerStartsOpenRange(t *testing.T) {
 	atTime := klog.Ɀ_Time_(8, 3)
 	reconciler := NewReconcilerAtRecord(atDate)(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.StartOpenRange(atTime, NoReformat[klog.TimeFormat](), nil)
+	err := reconciler.StartOpenRange(atTime, NoReformat[klog.TimeFormat](), nil)
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2018-01-01
 	5h22m
@@ -38,8 +40,10 @@ func TestReconcilerStartsOpenRangeWithSummary(t *testing.T) {
 	atTime := klog.Ɀ_Time_(8, 3)
 	reconciler := NewReconcilerAtRecord(atDate)(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.StartOpenRange(atTime, NoReformat[klog.TimeFormat](), klog.Ɀ_EntrySummary_("Test"))
+	err := reconciler.StartOpenRange(atTime, NoReformat[klog.TimeFormat](), klog.Ɀ_EntrySummary_("Test"))
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2018-01-01
 	5h22m
@@ -59,8 +63,10 @@ func TestReconcilerStartsOpenRangeWithUTF8Summary(t *testing.T) {
 	atTime := klog.Ɀ_Time_(12, 00)
 	reconciler := NewReconcilerAtRecord(atDate)(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.StartOpenRange(atTime, NoReformat[klog.TimeFormat](), klog.Ɀ_EntrySummary_("ናይ ምሳሕ ዕረፍቲ"))
+	err := reconciler.StartOpenRange(atTime, NoReformat[klog.TimeFormat](), klog.Ɀ_EntrySummary_("ናይ ምሳሕ ዕረፍቲ"))
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2018-01-01
 ኣብ ቤት ጽሕፈት ሓደ መዓልቲ።
@@ -79,8 +85,10 @@ func TestReconcilerStartsOpenRangeWithNewMultilineSummary(t *testing.T) {
 	atTime := klog.Ɀ_Time_(8, 3)
 	reconciler := NewReconcilerAtRecord(atDate)(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.StartOpenRange(atTime, NoReformat[klog.TimeFormat](), klog.Ɀ_EntrySummary_("", "Started...", "something!"))
+	err := reconciler.StartOpenRange(atTime, NoReformat[klog.TimeFormat](), klog.Ɀ_EntrySummary_("", "Started...", "something!"))
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2018-01-01
 	5h22m
@@ -100,8 +108,10 @@ func TestReconcilerStartsOpenRangeWithAutoStyleFromSameRecord(t *testing.T) {
 	atTime := klog.Ɀ_Time_(8, 3)
 	reconciler := NewReconcilerAtRecord(atDate)(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.StartOpenRange(atTime, ReformatAutoStyle[klog.TimeFormat](), nil)
+	err := reconciler.StartOpenRange(atTime, ReformatAutoStyle[klog.TimeFormat](), nil)
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	// Conforms to both am/pm and spaces around dash
 	assert.Equal(t, `
 2018-01-01
@@ -120,8 +130,10 @@ func TestReconcilerStartsOpenRangeWithAutoStyleFromOtherRecord(t *testing.T) {
 	atTime := klog.Ɀ_Time_(8, 3)
 	reconciler := NewReconcilerForNewRecord(atDate, ReformatAutoStyle[klog.DateFormat](), AdditionalData{})(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.StartOpenRange(atTime, ReformatAutoStyle[klog.TimeFormat](), nil)
+	err := reconciler.StartOpenRange(atTime, ReformatAutoStyle[klog.TimeFormat](), nil)
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	// Conforms to both am/pm and spaces around dash
 	assert.Equal(t, `
 2018/01/01
@@ -141,8 +153,10 @@ func TestReconcilerStartsOpenRangeExplicitFormatOverrulesAutoFormat(t *testing.T
 	atTime := klog.Ɀ_IsAmPm_(klog.Ɀ_Time_(8, 3))
 	reconciler := NewReconcilerForNewRecord(atDate, ReformatExplicitly[klog.DateFormat](atDate.Format()), AdditionalData{})(rs, bs)
 	require.NotNil(t, reconciler)
-	result, err := reconciler.StartOpenRange(atTime, ReformatExplicitly[klog.TimeFormat](atTime.Format()), nil)
+	err := reconciler.StartOpenRange(atTime, ReformatExplicitly[klog.TimeFormat](atTime.Format()), nil)
 	require.Nil(t, err)
+
+	result := assertResult(t, reconciler)
 	assert.Equal(t, `
 2018-01-01
 


### PR DESCRIPTION
Resolves https://github.com/jotaen/klog/issues/268.

`klog switch` stops an ongoing activity (open range) and starts a new one at the same time. It’s basically a convenience shortcut for separately issuing `klog stop` and `klog start` – with a few subtle differences, though:

- The command is atomic, so it only writes to the file once. The end time of the previously open range and the start time of the newly opened range are guaranteed to be the same.
- The command doesn’t have fallback-behaviour. It neither falls back to the previous date like `klog stop` does, nor would it create a new record like `klog start` would.
- A summary for the new entry can be specified via the `-s`/`--summary` flag. Appending to the summary for the previously open range is not possible.

The command deliberately fails if there is not open range in the record.