### PR TITLE
Make `klog start --resume` fall back to previous record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ## Next up
 - **[ FEATURE ]** Add new command `klog switch`, that stops a previously
   ongoing activity (open time range), and starts a new one.
+- **[ FEATURE ]** `klog start --resume` now falls back to the previous
+  record for determining the last entry summary.
 
 ## v6.1
 - **[ FEATURE ]** Add new flag `klog start --resume`, which takes over the

--- a/klog/app/cli/start_test.go
+++ b/klog/app/cli/start_test.go
@@ -264,7 +264,7 @@ default_rounding = 60m
 }
 
 func TestStartWithResume(t *testing.T) {
-	t.Run("No previous entry -> Empty entry summary", func(t *testing.T) {
+	t.Run("No previous entry, no previous record -> Empty entry summary", func(t *testing.T) {
 		state, err := NewTestingContext()._SetRecords(`1623-12-13
 `)._SetNow(1623, 12, 13, 12, 49)._Run((&Start{
 			Resume: true,
@@ -272,6 +272,25 @@ func TestStartWithResume(t *testing.T) {
 		require.Nil(t, err)
 		assert.Equal(t, `1623-12-13
     12:49 - ?
+`, state.writtenFileContents)
+	})
+
+	t.Run("No previous entry, but previous record -> Take over from previous record", func(t *testing.T) {
+		state, err := NewTestingContext()._SetRecords(`
+1623-12-12
+    14:00 - 15:00 Did something
+    10m Some activity
+`)._SetNow(1623, 12, 13, 12, 49)._Run((&Start{
+			Resume: true,
+		}).Run)
+		require.Nil(t, err)
+		assert.Equal(t, `
+1623-12-12
+    14:00 - 15:00 Did something
+    10m Some activity
+
+1623-12-13
+    12:49 - ? Some activity
 `, state.writtenFileContents)
 	})
 


### PR DESCRIPTION
Resolves https://github.com/jotaen/klog/issues/266.

In case there is no record at the current date, `klog start --resume` now falls back to the previous record for determining the last entry summary. E.g., for this file:

```
2020-01-01
    14:00-15:00 Something
```

Say today was `2020-01-02` + `13:39`, then `klog start --resume` would yield:

```
2020-01-01
    14:00-15:00 Something

2020-01-02
    13:39-? Something
```

Previously, the newly created entry wouldn’t have had a summary.