### PR TITLE
Add rounding options `12m` and `20m`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 **Summary of changes of the command line tool**
 
+## Next Up
+- **[ FEATURE ]** Add two new rounding options: `12m` and `20m`.
+  (E.g., when using `klog start --round`.)
+
 ## v6.2
 - **[ FEATURE ]** Add new command `klog switch`, that stops a previously
   ongoing activity (open time range), and starts a new one.

--- a/klog/app/cli/lib/args.go
+++ b/klog/app/cli/lib/args.go
@@ -52,7 +52,7 @@ func (args *AtDateArgs) DateFormat(config app.Config) reconciling.ReformatDirect
 type AtDateAndTimeArgs struct {
 	AtDateArgs
 	Time  klog.Time        `name:"time" short:"t" help:"Specify the time (defaults to now)"`
-	Round service.Rounding `name:"round" short:"r" help:"Round time to nearest multiple of 5m, 10m, 15m, 30m, or 60m / 1h"`
+	Round service.Rounding `name:"round" short:"r" help:"Round time to nearest multiple of 5m, 10m, 12m, 15m, 20m, 30m, or 60m / 1h"`
 }
 
 func (args *AtDateAndTimeArgs) AtTime(now gotime.Time, config app.Config) (klog.Time, app.Error) {

--- a/klog/app/config_test.go
+++ b/klog/app/config_test.go
@@ -200,7 +200,7 @@ func TestIgnoresEmptyConfigFileOrEmptyParameters(t *testing.T) {
 func TestRejectsInvalidConfigFile(t *testing.T) {
 	for _, tml := range []string{
 		`default_rounding = true`,              // Wrong type
-		`default_rounding = 20m`,               // Invalid value
+		`default_rounding = 25m`,               // Invalid value
 		`default_should_total = [true, false]`, // Wrong type
 		`default_should_total = 15`,            // Invalid value
 		`date_format = [true, false]`,          // Wrong type

--- a/klog/service/rounding.go
+++ b/klog/service/rounding.go
@@ -26,7 +26,7 @@ func (r rounding) ToString() string {
 // NewRounding creates a Rounding from an integer. For non-allowed
 // values, it returns error.
 func NewRounding(r int) (Rounding, error) {
-	for _, validRounding := range []int{5, 10, 15, 30, 60} {
+	for _, validRounding := range []int{5, 10, 12, 15, 20, 30, 60} {
 		if r == validRounding {
 			return rounding(r), nil
 		}

--- a/klog/service/rounding_test.go
+++ b/klog/service/rounding_test.go
@@ -28,7 +28,7 @@ func TestValidRoundingValues(t *testing.T) {
 
 func TestInvalidRoundingValues(t *testing.T) {
 	for _, m := range []int{
-		-60, -30, -15, -10, -5, 0, 1, 2, 3, 4, 6, 7, 8, 9, 11, 12, 13, 14, 16, 17, 18, 19, 20, 25, 35, 45, 55, 120, 600,
+		-60, -30, -15, -10, -5, 0, 1, 2, 3, 4, 6, 7, 8, 9, 11, 13, 14, 16, 17, 18, 19, 25, 35, 45, 55, 120, 600,
 	} {
 		fr, err := NewRounding(m)
 		require.Nil(t, fr)
@@ -45,7 +45,9 @@ func TestParseRoundingValuesFromString(t *testing.T) {
 		{"5m", 5},
 		{"10", 10},
 		{"10m", 10},
+		{"12m", 12},
 		{"15m", 15},
+		{"20m", 20},
 		{"30m", 30},
 		{"60m", 60},
 		{"1h", 60},
@@ -98,6 +100,17 @@ func TestRound(t *testing.T) {
 		{RoundToNearest(klog.Ɀ_Time_(8, 15), r(10)), klog.Ɀ_Time_(8, 20)},
 		{RoundToNearest(klog.Ɀ_Time_(8, 55), r(10)), klog.Ɀ_Time_(9, 00)},
 
+		// Round to 12s
+		{RoundToNearest(klog.Ɀ_Time_(8, 00), r(12)), klog.Ɀ_Time_(8, 00)},
+		{RoundToNearest(klog.Ɀ_Time_(8, 04), r(12)), klog.Ɀ_Time_(8, 00)},
+		{RoundToNearest(klog.Ɀ_Time_(8, 05), r(12)), klog.Ɀ_Time_(8, 00)},
+		{RoundToNearest(klog.Ɀ_Time_(8, 06), r(12)), klog.Ɀ_Time_(8, 12)},
+		{RoundToNearest(klog.Ɀ_Time_(8, 11), r(12)), klog.Ɀ_Time_(8, 12)},
+		{RoundToNearest(klog.Ɀ_Time_(8, 12), r(12)), klog.Ɀ_Time_(8, 12)},
+		{RoundToNearest(klog.Ɀ_Time_(8, 13), r(12)), klog.Ɀ_Time_(8, 12)},
+		{RoundToNearest(klog.Ɀ_Time_(8, 17), r(12)), klog.Ɀ_Time_(8, 12)},
+		{RoundToNearest(klog.Ɀ_Time_(8, 18), r(12)), klog.Ɀ_Time_(8, 24)},
+
 		// Round to 15s
 		{RoundToNearest(klog.Ɀ_Time_(8, 00), r(15)), klog.Ɀ_Time_(8, 00)},
 		{RoundToNearest(klog.Ɀ_Time_(8, 07), r(15)), klog.Ɀ_Time_(8, 00)},
@@ -105,6 +118,17 @@ func TestRound(t *testing.T) {
 		{RoundToNearest(klog.Ɀ_Time_(8, 15), r(15)), klog.Ɀ_Time_(8, 15)},
 		{RoundToNearest(klog.Ɀ_Time_(8, 22), r(15)), klog.Ɀ_Time_(8, 15)},
 		{RoundToNearest(klog.Ɀ_Time_(8, 23), r(15)), klog.Ɀ_Time_(8, 30)},
+		{RoundToNearest(klog.Ɀ_Time_(8, 55), r(15)), klog.Ɀ_Time_(9, 00)},
+
+		// Round to 20s
+		{RoundToNearest(klog.Ɀ_Time_(8, 00), r(20)), klog.Ɀ_Time_(8, 00)},
+		{RoundToNearest(klog.Ɀ_Time_(8, 9), r(20)), klog.Ɀ_Time_(8, 00)},
+		{RoundToNearest(klog.Ɀ_Time_(8, 10), r(20)), klog.Ɀ_Time_(8, 20)},
+		{RoundToNearest(klog.Ɀ_Time_(8, 20), r(20)), klog.Ɀ_Time_(8, 20)},
+		{RoundToNearest(klog.Ɀ_Time_(8, 29), r(20)), klog.Ɀ_Time_(8, 20)},
+		{RoundToNearest(klog.Ɀ_Time_(8, 30), r(20)), klog.Ɀ_Time_(8, 40)},
+		{RoundToNearest(klog.Ɀ_Time_(8, 49), r(20)), klog.Ɀ_Time_(8, 40)},
+		{RoundToNearest(klog.Ɀ_Time_(8, 50), r(20)), klog.Ɀ_Time_(9, 00)},
 
 		// Round to 30s
 		{RoundToNearest(klog.Ɀ_Time_(8, 00), r(30)), klog.Ɀ_Time_(8, 00)},


### PR DESCRIPTION
Add two new rounding options: `12m` and `20m`. That way, all whole fractions of 60 are supported (from 1–12, with the exception of 10/`6m`).