### PR TITLE
Fix `print --with-totals` for multiline record summaries

### DIFF
--- a/klog/app/cli/print_test.go
+++ b/klog/app/cli/print_test.go
@@ -83,6 +83,7 @@ func TestPrintRecordsWithDurations(t *testing.T) {
 	state, err := NewTestingContext()._SetNow(2018, 02, 07, 19, 00)._SetRecords(`
 2018-01-31
 Hello #world
+Test test test
 	1h
 
 2018-02-04
@@ -93,6 +94,7 @@ Hello #world
 2018-02-07
 	35m
 		Foo
+		Bar
 	18:00 - ? I just
 		started something
 `)._Run((&Print{
@@ -102,6 +104,7 @@ Hello #world
 	assert.Equal(t, `
      1h  |  2018-01-31
          |  Hello #world
+         |  Test test test
      1h  |      1h
 
  13h17m  |  2018-02-04
@@ -112,6 +115,7 @@ Hello #world
     35m  |  2018-02-07
     35m  |      35m
          |          Foo
+         |          Bar
      0m  |      18:00 - ? I just
          |          started something
 

--- a/klog/parser/serialiser.go
+++ b/klog/parser/serialiser.go
@@ -61,8 +61,8 @@ func serialiseRecord(s Serialiser, r klog.Record) []Line {
 		headline += " (" + s.ShouldTotal(r.ShouldTotal()) + ")"
 	}
 	lines = append(lines, Line{headline, r, -1})
-	if r.Summary() != nil {
-		lines = append(lines, Line{s.Summary(SummaryText(r.Summary())), r, -1})
+	for _, l := range r.Summary().Lines() {
+		lines = append(lines, Line{s.Summary([]string{l}), r, -1})
 	}
 	for entryI, e := range r.Entries() {
 		entryValue := klog.Unbox[string](&e,


### PR DESCRIPTION
There was a bug when printing records with multiline summaries with the `--with-totals` flag.

It used to print:

```
 8h15m  |  2018-03-26
        |  Line 1
Line 2
 2h45m  |      8:30 - 11:15 asdf
        |          asdf
        |          asdf
        |          asdf
  1h5m  |      11:15 - 12:20
 4h25m  |      13:30 - 17:55`

```

Where it should (and now does) print:

```
 8h15m  |  2018-03-26
        |  Line 1
        |  Line 2
 2h45m  |      8:30 - 11:15 asdf
        |          asdf
        |          asdf
        |          asdf
  1h5m  |      11:15 - 12:20
 4h25m  |      13:30 - 17:55
```