### PR TITLE
Introduce light colour theme

### DIFF
--- a/klog/app/cli/terminalformat/colour_theme.go
+++ b/klog/app/cli/terminalformat/colour_theme.go
@@ -5,6 +5,7 @@ type ColourTheme string
 const (
 	NO_COLOUR = ColourTheme("no_colour")
 	DARK      = ColourTheme("dark")
+	LIGHT     = ColourTheme("light")
 )
 
 func NewStyler(c ColourTheme) Styler {
@@ -42,6 +43,19 @@ func NewStyler(c ColourTheme) Styler {
 			SUBDUED:      "249",
 			PURPLE:       "213",
 			YELLOW:       "221",
+		}
+		return baseColouredStyler
+	case LIGHT:
+		baseColouredStyler.colourCodes = map[Colour]string{
+			TEXT:         "000",
+			TEXT_INVERSE: "015",
+			GREEN:        "028",
+			RED:          "124",
+			BLUE_DARK:    "025",
+			BLUE_LIGHT:   "033",
+			SUBDUED:      "237",
+			PURPLE:       "055",
+			YELLOW:       "208",
 		}
 		return baseColouredStyler
 	}

--- a/klog/app/config.go
+++ b/klog/app/config.go
@@ -193,8 +193,10 @@ var CONFIG_FILE_ENTRIES = []ConfigFileEntries[any]{
 				config.ColourScheme.override(tf.DARK, configOriginFile)
 			case string(tf.NO_COLOUR):
 				config.ColourScheme.override(tf.NO_COLOUR, configOriginFile)
+			case string(tf.LIGHT):
+				config.ColourScheme.override(tf.LIGHT, configOriginFile)
 			default:
-				return errors.New("The value must be `dark` or `no_colour`")
+				return errors.New("The value must be `dark`, `light` or `no_colour`")
 			}
 			return nil
 		},
@@ -203,7 +205,7 @@ var CONFIG_FILE_ENTRIES = []ConfigFileEntries[any]{
 		},
 		Help: Help{
 			Summary: "The colour scheme of your terminal, so that klog can choose an optimal colour theme for its output.",
-			Value:   "The config property must be one of: `dark` or `no_colour`",
+			Value:   "The config property must be one of: `dark`, `light` or `no_colour`",
 			Default: "If absent/empty, klog assumes a `dark` theme.",
 		},
 	}, {


### PR DESCRIPTION
Resolves https://github.com/jotaen/klog/issues/289.

klog now supports light-themed terminals via the `colour_scheme = light` entry in the `config.ini` file (see `klog config --help`).

<img width="749" alt="Screenshot 2024-03-02 at 10 28 58" src="https://github.com/jotaen/klog/assets/3618384/0819f07d-dce7-4f06-b4e8-b3f8e0c9db15">
