### PR TITLE
Add option to filter by entry type

### DIFF
--- a/klog/app/cli/create.go
+++ b/klog/app/cli/create.go
@@ -8,8 +8,8 @@ import (
 )
 
 type Create struct {
-	ShouldTotal      klog.ShouldTotal   `name:"should" help:"The should-total of the record"`
-	ShouldTotalAlias klog.ShouldTotal   `name:"should-total" hidden:""` // Alias for “canonical” term
+	ShouldTotal      klog.ShouldTotal   `name:"should" placeholder:"DURATION" help:"The should-total of the record"`
+	ShouldTotalAlias klog.ShouldTotal   `name:"should-total" placeholder:"DURATION" hidden:""` // Alias for “canonical” term
 	Summary          klog.RecordSummary `name:"summary" short:"s" placeholder:"TEXT" help:"Summary text for the new record"`
 	util.AtDateArgs
 	util.NoStyleArgs

--- a/klog/app/cli/report.go
+++ b/klog/app/cli/report.go
@@ -12,7 +12,7 @@ import (
 )
 
 type Report struct {
-	AggregateBy string `name:"aggregate" short:"a" help:"Aggregate data by: day, week, month, quarter, year" enum:"DAY,day,d,WEEK,week,w,MONTH,month,m,QUARTER,quarter,q,YEAR,year,y," default:"day"`
+	AggregateBy string `name:"aggregate" placeholder:"KIND" short:"a" help:"Aggregate data by: day (default), week, month, quarter, year" enum:"DAY,day,d,WEEK,week,w,MONTH,month,m,QUARTER,quarter,q,YEAR,year,y," default:"day"`
 	Fill        bool   `name:"fill" short:"f" help:"Fill the gaps and show a consecutive stream"`
 	util.DiffArgs
 	util.FilterArgs

--- a/klog/app/cli/util/args.go
+++ b/klog/app/cli/util/args.go
@@ -20,7 +20,7 @@ type OutputFileArgs struct {
 }
 
 type AtDateArgs struct {
-	Date      klog.Date `name:"date" short:"d" help:"The date of the record"`
+	Date      klog.Date `name:"date" placeholder:"DATE" short:"d" help:"The date of the record"`
 	Today     bool      `name:"today" help:"Use today’s date (default)"`
 	Yesterday bool      `name:"yesterday" help:"Use yesterday’s date"`
 	Tomorrow  bool      `name:"tomorrow" help:"Use tomorrow’s date"`
@@ -52,8 +52,8 @@ func (args *AtDateArgs) DateFormat(config app.Config) reconciling.ReformatDirect
 
 type AtDateAndTimeArgs struct {
 	AtDateArgs
-	Time  klog.Time        `name:"time" short:"t" help:"Specify the time (defaults to now)"`
-	Round service.Rounding `name:"round" short:"r" help:"Round time to nearest multiple of 5m, 10m, 12m, 15m, 20m, 30m, or 60m / 1h"`
+	Time  klog.Time        `name:"time" placeholder:"TIME" short:"t" help:"Specify the time (defaults to now)"`
+	Round service.Rounding `name:"round" placeholder:"ROUNDING" short:"r" help:"Round time to nearest multiple of 5m, 10m, 12m, 15m, 20m, 30m, or 60m / 1h"`
 }
 
 func (args *AtDateAndTimeArgs) AtTime(now gotime.Time, config app.Config) (klog.Time, app.Error) {
@@ -141,13 +141,14 @@ func (args *NowArgs) GetNowWarnings() []string {
 
 type FilterArgs struct {
 	// General filters
-	Tags   []klog.Tag    `name:"tag" group:"Filter" help:"Records (or entries) that match these tags"`
-	Date   klog.Date     `name:"date" group:"Filter" help:"Records at this date"`
-	Since  klog.Date     `name:"since" group:"Filter" help:"Records since this date (inclusive)"`
-	Until  klog.Date     `name:"until" group:"Filter" help:"Records until this date (inclusive)"`
-	After  klog.Date     `name:"after" group:"Filter" help:"Records after this date (exclusive)"`
-	Before klog.Date     `name:"before" group:"Filter" help:"Records before this date (exclusive)"`
-	Period period.Period `name:"period" group:"Filter" help:"Records in period: YYYY, YYYY-MM, YYYY-Www, or YYYY-Qq"`
+	Tags      []klog.Tag        `name:"tag" placeholder:"TAG" group:"Filter" help:"Records (or entries) that match these tags"`
+	Date      klog.Date         `name:"date" placeholder:"DATE" group:"Filter" help:"Records at this date"`
+	Since     klog.Date         `name:"since" placeholder:"DATE" group:"Filter" help:"Records since this date (inclusive)"`
+	Until     klog.Date         `name:"until" placeholder:"DATE" group:"Filter" help:"Records until this date (inclusive)"`
+	After     klog.Date         `name:"after" placeholder:"DATE" group:"Filter" help:"Records after this date (exclusive)"`
+	Before    klog.Date         `name:"before" placeholder:"DATE" group:"Filter" help:"Records before this date (exclusive)"`
+	EntryType service.EntryType `name:"entry-type" placeholder:"TYPE" group:"Filter" help:"Entries of this type (duration, range, open-range)"`
+	Period    period.Period     `name:"period" placeholder:"PERIOD" group:"Filter" help:"Records in period: YYYY, YYYY-MM, YYYY-Www, or YYYY-Qq"`
 
 	// Shortcut filters
 	// The `XXX` ones are dummy entries just for the help output
@@ -215,6 +216,9 @@ func (args *FilterArgs) ApplyFilter(now gotime.Time, rs []klog.Record) []klog.Re
 	}
 	if args.Tomorrow {
 		qry.AtDate = today.PlusDays(+1)
+	}
+	if args.EntryType != "" {
+		qry.EntryType = args.EntryType
 	}
 	shortcutPeriod := func() period.Period {
 		if args.ThisWeek || args.ThisWeekAlias {
@@ -284,7 +288,7 @@ type QuietArgs struct {
 }
 
 type SortArgs struct {
-	Sort string `name:"sort" help:"Sort output by date (asc or desc)" enum:"asc,desc,ASC,DESC," default:""`
+	Sort string `name:"sort" placeholder:"ORDER" help:"Sort output by date (asc or desc)" enum:"asc,desc,ASC,DESC," default:""`
 }
 
 func (args *SortArgs) ApplySort(rs []klog.Record) []klog.Record {

--- a/klog/app/main/cli.go
+++ b/klog/app/main/cli.go
@@ -56,6 +56,10 @@ func Run(homeDir app.File, meta app.Meta, config app.Config, args []string) (int
 			s, _ := klog.NewEntrySummary("test")
 			return kong.TypeMapper(reflect.TypeOf(&s).Elem(), entrySummaryDecoder())
 		}(),
+		func() kong.Option {
+			t := service.ENTRY_TYPE_DURATION
+			return kong.TypeMapper(reflect.TypeOf(&t).Elem(), entryTypeDecoder())
+		}(),
 		kong.ConfigureHelp(kong.HelpOptions{
 			Compact:             true,
 			NoExpandSubcommands: true,

--- a/klog/app/main/cli_test.go
+++ b/klog/app/main/cli_test.go
@@ -203,3 +203,29 @@ func TestDecodesRecordSummary(t *testing.T) {
 	assert.True(t, strings.Contains(out[2], "A record summary cannot contain blank lines"), out)
 	assert.True(t, strings.Contains(out[3], "A record summary cannot contain blank lines"), out)
 }
+
+func TestDecodesEntryType(t *testing.T) {
+	klog := &Env{
+		files: map[string]string{
+			"test.klg": "2020-01-01\n\t1h\n\t9:00-12:00",
+		},
+	}
+	out := klog.run(
+		[]string{"total", "--entry-type", "duration", "test.klg"},
+		[]string{"total", "--entry-type", "DURATION", "test.klg"},
+		[]string{"total", "--entry-type", "duration-positive", "test.klg"},
+		[]string{"total", "--entry-type", "duration-negative", "test.klg"},
+		[]string{"total", "--entry-type", "open_range", "test.klg"},
+		[]string{"total", "--entry-type", "open-range", "test.klg"},
+		[]string{"total", "--entry-type", "range", "test.klg"},
+		[]string{"total", "--entry-type", "asdf", "test.klg"},
+	)
+	assert.True(t, strings.Contains(out[0], "1h"), out)
+	assert.True(t, strings.Contains(out[1], "1h"), out)
+	assert.True(t, strings.Contains(out[2], "1h"), out)
+	assert.True(t, strings.Contains(out[3], "0m"), out)
+	assert.True(t, strings.Contains(out[4], "0m"), out)
+	assert.True(t, strings.Contains(out[5], "0m"), out)
+	assert.True(t, strings.Contains(out[6], "3h"), out)
+	assert.True(t, strings.Contains(out[7], "is not a valid entry type"), out)
+}

--- a/klog/app/main/decoder.go
+++ b/klog/app/main/decoder.go
@@ -169,3 +169,28 @@ func entrySummaryDecoder() kong.MapperFunc {
 		return nil
 	}
 }
+
+func entryTypeDecoder() kong.MapperFunc {
+	return func(ctx *kong.DecodeContext, target reflect.Value) error {
+		var value string
+		if err := ctx.Scan.PopValueInto("entryType", &value); err != nil {
+			return err
+		}
+		if value == "" {
+			return errors.New("Please provide a valid entry type")
+		}
+		ts := map[service.EntryType]bool{
+			service.ENTRY_TYPE_RANGE:             true,
+			service.ENTRY_TYPE_OPEN_RANGE:        true,
+			service.ENTRY_TYPE_DURATION:          true,
+			service.ENTRY_TYPE_POSITIVE_DURATION: true,
+			service.ENTRY_TYPE_NEGATIVE_DURATION: true,
+		}
+		t := service.EntryType(strings.ReplaceAll(strings.ToUpper(value), "-", "_"))
+		if ok := ts[t]; !ok {
+			return errors.New("`" + value + "` is not a valid entry type")
+		}
+		target.Set(reflect.ValueOf(t))
+		return nil
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/jotaen/klog/issues/286.

This let’s you do `klog total --entry-type duration` (for only summing up duration entries) or `klog print --entry-type open-range` (for only showing open ranges).