### PR TITLE
Auto-appending tags from open range when pausing

### DIFF
--- a/klog/summary.go
+++ b/klog/summary.go
@@ -86,3 +86,17 @@ func (s EntrySummary) Equals(summary EntrySummary) bool {
 	}
 	return RecordSummary(s).Equals(RecordSummary(summary))
 }
+
+// Append appends a text to an entry summary
+func (s EntrySummary) Append(appendableText string) EntrySummary {
+	if len(s) == 0 {
+		return []string{appendableText}
+	}
+	delimiter := ""
+	lastLine := s[len(s)-1]
+	if len(lastLine) > 0 {
+		delimiter = " "
+	}
+	s[len(s)-1] = lastLine + delimiter + appendableText
+	return s
+}

--- a/klog/summary_test.go
+++ b/klog/summary_test.go
@@ -195,3 +195,26 @@ func TestRecognisesAllTags(t *testing.T) {
 	entrySummary, _ := NewEntrySummary("Hello #world, I feel #great #TODAY")
 	assert.Equal(t, entrySummary.Tags().ToStrings(), []string{"#great", "#today", "#world"})
 }
+
+func TestAppendsToEntrySummary(t *testing.T) {
+	t.Run("append empty to empty", func(t *testing.T) {
+		e := Ɀ_EntrySummary_().Append("")
+		assert.Equal(t, []string{""}, e.Lines())
+	})
+	t.Run("append non-empty to zero", func(t *testing.T) {
+		e := Ɀ_EntrySummary_().Append("foo")
+		assert.Equal(t, []string{"foo"}, e.Lines())
+	})
+	t.Run("append non-empty to empty", func(t *testing.T) {
+		e := Ɀ_EntrySummary_("").Append("foo")
+		assert.Equal(t, []string{"foo"}, e.Lines())
+	})
+	t.Run("append non-empty to existing", func(t *testing.T) {
+		e := Ɀ_EntrySummary_("hello").Append("foo")
+		assert.Equal(t, []string{"hello foo"}, e.Lines())
+	})
+	t.Run("append non-empty to multiline", func(t *testing.T) {
+		e := Ɀ_EntrySummary_("hello", "world").Append("foo")
+		assert.Equal(t, []string{"hello", "world foo"}, e.Lines())
+	})
+}


### PR DESCRIPTION
Resolves https://github.com/jotaen/klog/issues/283.

If the open range contains tags, then `klog pause` will automatically take them over (i.e., append) them to the pause entry.

## Example

```
2000-01-01
    5:00-? Did #work
```

Then `klog pause` yields:

```
2000-01-01
    5:00-? Did #work
    -0m #work
```

You can still use the `--summary` flag.

`--no-tags` disables this behaviour.