### PR TITLE
Add `--create` flag for `klog bookmarks set`

### DIFF
--- a/klog/app/cli/bookmarks.go
+++ b/klog/app/cli/bookmarks.go
@@ -121,10 +121,6 @@ func (opt *BookmarksSet) Run(ctx app.Context) error {
 				err,
 			)
 		}
-		_, err = app.NewFile(opt.File)
-		if err != nil {
-			return err
-		}
 	}
 	file, err := app.NewFile(opt.File)
 	if err != nil {

--- a/klog/app/file.go
+++ b/klog/app/file.go
@@ -131,6 +131,31 @@ func WriteToFile(target File, contents string) Error {
 	return nil
 }
 
+// CreateEmptyFile creates a new file on disk.
+// It returns an error if the file already exists, or if the file cannot be
+// created.
+func CreateEmptyFile(file File) Error {
+	if _, sErr := os.Stat(file.Path()); !os.IsNotExist(sErr) {
+		return NewErrorWithCode(
+			GENERAL_ERROR,
+			"Cannot create file",
+			"There is already a file at that location",
+			sErr,
+		)
+	}
+	// Note: `os.Create` would truncate the file if it already exists.
+	_, cErr := os.Create(file.Path())
+	if cErr != nil {
+		return NewErrorWithCode(
+			GENERAL_ERROR,
+			"Cannot create file",
+			"Please check the file name and permissions",
+			cErr,
+		)
+	}
+	return nil
+}
+
 // ReadStdin reads the entire input from stdin and returns it as string.
 // It returns an error if stdin cannot be accessed, or if reading from it fails.
 func ReadStdin() (string, Error) {

--- a/klog/app/main/cli_test.go
+++ b/klog/app/main/cli_test.go
@@ -46,7 +46,7 @@ func TestPrintAppErrors(t *testing.T) {
 	assert.True(t, strings.Contains(out[2], "There is already an open range in this record"), out)
 }
 
-func TestBookmarkFile(t *testing.T) {
+func TestConfigureAndUseBookmark(t *testing.T) {
 	klog := &Env{
 		files: map[string]string{
 			"test.klg": "2020-01-01\nSome stuff\n\t1h7m\n",
@@ -69,6 +69,21 @@ func TestBookmarkFile(t *testing.T) {
 	assert.True(t, strings.Contains(out[2], "@tst"), out)
 	// Out 3 like: `Total: 1h7m`
 	assert.True(t, strings.Contains(out[3], "1h7m"), out)
+}
+
+func TestCreateBookmarkTargetFileOnDemand(t *testing.T) {
+	klog := &Env{}
+	out := klog.run(
+		[]string{"bookmarks", "set", "--create", "test.klg", "tst"},
+		[]string{"bookmarks", "set", "--create", "test.klg", "tst"},
+	)
+	// Out 0 like: `Created new bookmark`, `@tst -> /tmp/.../test.klg`
+	assert.True(t, strings.Contains(out[0], "Created new bookmark and created target file:"), out)
+	assert.True(t, strings.Contains(out[0], "@tst"), out)
+	assert.True(t, strings.Contains(out[0], "test.klg"), out)
+	// Out 1 like: `Error: Cannot create file`, `There is already a file at that location`
+	assert.True(t, strings.Contains(out[1], "Error: Cannot create file"), out)
+	assert.True(t, strings.Contains(out[1], "There is already a file at that location"), out)
 }
 
 func TestWriteToFile(t *testing.T) {


### PR DESCRIPTION
Resolves https://github.com/jotaen/klog/issues/310

- [x] Added new flag to `klog bk set` `--create`
- [x] Will create the file if it does not exist prior to performing other tasks including `--force`
