### PR TITLE
Config option to disable warnings

### DIFF
--- a/klog/app/cli/util/args.go
+++ b/klog/app/cli/util/args.go
@@ -260,7 +260,7 @@ type WarnArgs struct {
 
 func (args *WarnArgs) PrintWarnings(ctx app.Context, records []klog.Record, additionalWarnings []string) {
 	styler, _ := ctx.Serialise()
-	if args.NoWarn {
+	if args.NoWarn || ctx.Config().HideWarnings.UnwrapOr(false) {
 		return
 	}
 	for _, msg := range additionalWarnings {

--- a/klog/app/cli/util/args.go
+++ b/klog/app/cli/util/args.go
@@ -1,14 +1,15 @@
 package util
 
 import (
+	"strings"
+	gotime "time"
+
 	"github.com/jotaen/klog/klog"
 	"github.com/jotaen/klog/klog/app"
 	tf "github.com/jotaen/klog/klog/app/cli/terminalformat"
 	"github.com/jotaen/klog/klog/parser/reconciling"
 	"github.com/jotaen/klog/klog/service"
 	"github.com/jotaen/klog/klog/service/period"
-	"strings"
-	gotime "time"
 )
 
 type InputFilesArgs struct {
@@ -260,15 +261,16 @@ type WarnArgs struct {
 
 func (args *WarnArgs) PrintWarnings(ctx app.Context, records []klog.Record, additionalWarnings []string) {
 	styler, _ := ctx.Serialise()
-	if args.NoWarn || ctx.Config().HideWarnings.UnwrapOr(false) {
+	if args.NoWarn {
 		return
 	}
 	for _, msg := range additionalWarnings {
 		ctx.Print(PrettifyGeneralWarning(msg, styler))
 	}
+	disabledCheckers := ctx.Config().HideWarnings.UnwrapOr([]string{})
 	service.CheckForWarnings(func(w service.Warning) {
 		ctx.Print(PrettifyWarning(w, styler))
-	}, ctx.Now(), records)
+	}, ctx.Now(), records, disabledCheckers)
 }
 
 type NoStyleArgs struct {

--- a/klog/app/cli/util/args.go
+++ b/klog/app/cli/util/args.go
@@ -267,7 +267,7 @@ func (args *WarnArgs) PrintWarnings(ctx app.Context, records []klog.Record, addi
 	for _, msg := range additionalWarnings {
 		ctx.Print(PrettifyGeneralWarning(msg, styler))
 	}
-	disabledCheckers := ctx.Config().HideWarnings.UnwrapOr([]string{})
+	disabledCheckers := ctx.Config().NoWarnings.UnwrapOr(service.NewDisabledCheckers())
 	service.CheckForWarnings(func(w service.Warning) {
 		ctx.Print(PrettifyWarning(w, styler))
 	}, ctx.Now(), records, disabledCheckers)

--- a/klog/app/config.go
+++ b/klog/app/config.go
@@ -330,7 +330,9 @@ var CONFIG_FILE_ENTRIES = []ConfigFileEntries[any]{
 			disabledCheckers := service.NewDisabledCheckers()
 			for _, c := range warningConfigs {
 				if _, nameExists := disabledCheckers[c]; !nameExists {
-					return errors.New("The value must be a valid warning name, such as `UNCLOSED_OPEN_RANGE`")
+					return errors.New(
+						"The value must be a valid warning name, such as `UNCLOSED_OPEN_RANGE`, got: " + c + ".",
+					)
 				}
 				disabledCheckers[c] = true
 			}

--- a/klog/app/config_test.go
+++ b/klog/app/config_test.go
@@ -1,11 +1,12 @@
 package app
 
 import (
+	"testing"
+
 	"github.com/jotaen/klog/klog"
 	tf "github.com/jotaen/klog/klog/app/cli/terminalformat"
 	"github.com/jotaen/klog/klog/service"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func createMockConfigFromEnv(vs map[string]string) FromEnvVars {
@@ -20,6 +21,7 @@ func TestCreatesNewDefaultConfig(t *testing.T) {
 	assert.Equal(t, c.Editor.UnwrapOr(""), "")
 	assert.Equal(t, c.CpuKernels.Value(), 1)
 	assert.Equal(t, c.ColourScheme.Value(), tf.COLOUR_THEME_NO_COLOUR)
+	assert.False(t, c.HideWarnings.UnwrapOr(false))
 
 	isRoundingSet := false
 	c.DefaultRounding.Unwrap(func(_ service.Rounding) {
@@ -197,7 +199,8 @@ func TestSetTimeFormatParamFromConfigFile(t *testing.T) {
 }
 
 func TestIgnoresUnknownPropertiesInConfigFile(t *testing.T) {
-	for _, tml := range []string{`
+	for _, tml := range []string{
+		`
 unknown_property = 1
 what_is_this = true
 `,

--- a/klog/app/config_test.go
+++ b/klog/app/config_test.go
@@ -21,7 +21,7 @@ func TestCreatesNewDefaultConfig(t *testing.T) {
 	assert.Equal(t, c.Editor.UnwrapOr(""), "")
 	assert.Equal(t, c.CpuKernels.Value(), 1)
 	assert.Equal(t, c.ColourScheme.Value(), tf.COLOUR_THEME_NO_COLOUR)
-	assert.False(t, c.HideWarnings.UnwrapOr(false))
+	assert.Equal(t, len(c.HideWarnings.UnwrapOr([]string{})), 0)
 
 	isRoundingSet := false
 	c.DefaultRounding.Unwrap(func(_ service.Rounding) {
@@ -199,7 +199,8 @@ func TestSetTimeFormatParamFromConfigFile(t *testing.T) {
 }
 
 func TestIgnoresUnknownPropertiesInConfigFile(t *testing.T) {
-	for _, tml := range []string{`
+	for _, tml := range []string{
+		`
 unknown_property = 1
 what_is_this = true
 `,

--- a/klog/app/config_test.go
+++ b/klog/app/config_test.go
@@ -21,7 +21,6 @@ func TestCreatesNewDefaultConfig(t *testing.T) {
 	assert.Equal(t, c.Editor.UnwrapOr(""), "")
 	assert.Equal(t, c.CpuKernels.Value(), 1)
 	assert.Equal(t, c.ColourScheme.Value(), tf.COLOUR_THEME_NO_COLOUR)
-	assert.Equal(t, len(c.HideWarnings.UnwrapOr([]string{})), 0)
 
 	isRoundingSet := false
 	c.DefaultRounding.Unwrap(func(_ service.Rounding) {
@@ -34,6 +33,12 @@ func TestCreatesNewDefaultConfig(t *testing.T) {
 		isShouldTotalSet = true
 	})
 	assert.False(t, isShouldTotalSet)
+
+	isNoWarningsSet := false
+	c.NoWarnings.Unwrap(func(_ service.DisabledCheckers) {
+		isNoWarningsSet = true
+	})
+	assert.False(t, isNoWarningsSet)
 }
 
 func TestSetsParamsMetadataIsHandledCorrectly(t *testing.T) {
@@ -198,6 +203,84 @@ func TestSetTimeFormatParamFromConfigFile(t *testing.T) {
 	}
 }
 
+func TestNoWarningsParamFromConfigFile(t *testing.T) {
+	for _, x := range []struct {
+		cfg string
+		exp service.DisabledCheckers
+	}{
+		// Single value
+		{`no_warnings = MORE_THAN_24H`, func() service.DisabledCheckers {
+			dc := service.NewDisabledCheckers()
+			dc["MORE_THAN_24H"] = true
+			return dc
+		}()},
+		// Multiple values
+		{`no_warnings = MORE_THAN_24H, OVERLAPPING_RANGES`, func() service.DisabledCheckers {
+			dc := service.NewDisabledCheckers()
+			dc["MORE_THAN_24H"] = true
+			dc["OVERLAPPING_RANGES"] = true
+			return dc
+		}()},
+		// Multiple values with additional whitespace
+		{`no_warnings =    MORE_THAN_24H  ,       OVERLAPPING_RANGES  `, func() service.DisabledCheckers {
+			dc := service.NewDisabledCheckers()
+			dc["MORE_THAN_24H"] = true
+			dc["OVERLAPPING_RANGES"] = true
+			return dc
+		}()},
+	} {
+		c, _ := NewConfig(
+			FromDeterminedValues{NumCpus: 1},
+			createMockConfigFromEnv(map[string]string{}),
+			FromConfigFile{x.cfg},
+		)
+		var value service.DisabledCheckers
+		c.NoWarnings.Unwrap(func(s service.DisabledCheckers) {
+			value = s
+		})
+		assert.Equal(t, x.exp, value)
+	}
+}
+
+func TestSerialisesConfigFile(t *testing.T) {
+	for _, tml := range []string{`
+editor = 
+colour_scheme = 
+default_rounding = 
+default_should_total = 
+date_format = 
+time_convention = 
+no_warnings = 
+`, `
+editor = 
+colour_scheme = light
+default_rounding = 
+default_should_total = 
+date_format = YYYY/MM/DD
+time_convention = 
+no_warnings = FUTURE_ENTRIES
+`, `
+editor = subl
+colour_scheme = dark
+default_rounding = 15m
+default_should_total = 8h!
+date_format = YYYY-MM-DD
+time_convention = 24h
+no_warnings = OVERLAPPING_RANGES, MORE_THAN_24H
+`} {
+		cfg, _ := NewConfig(
+			FromDeterminedValues{NumCpus: 1},
+			createMockConfigFromEnv(map[string]string{}),
+			FromConfigFile{tml},
+		)
+		serialisedFile := "\n"
+		for _, e := range CONFIG_FILE_ENTRIES {
+			serialisedFile += e.Name + " = " + e.Value(cfg) + "\n"
+		}
+		assert.Equal(t, serialisedFile, tml)
+	}
+}
+
 func TestIgnoresUnknownPropertiesInConfigFile(t *testing.T) {
 	for _, tml := range []string{`
 unknown_property = 1
@@ -222,6 +305,7 @@ func TestIgnoresEmptyConfigFileOrEmptyParameters(t *testing.T) {
 		`default_should_total = `,
 		`date_format = `,
 		`time_convention = `,
+		`no_warnings = `,
 	} {
 		_, err := NewConfig(
 			FromDeterminedValues{NumCpus: 1},
@@ -234,16 +318,24 @@ func TestIgnoresEmptyConfigFileOrEmptyParameters(t *testing.T) {
 
 func TestRejectsInvalidConfigFile(t *testing.T) {
 	for _, tml := range []string{
-		`default_rounding = true`,              // Wrong type
-		`default_rounding = 25m`,               // Invalid value
-		`colour_scheme = true`,                 // Wrong type
-		`colour_scheme = yellow`,               // Invalid value
-		`default_should_total = [true, false]`, // Wrong type
-		`default_should_total = 15`,            // Invalid value
-		`date_format = [true, false]`,          // Wrong type
-		`date_format = YYYY.MM.DD`,             // Invalid value
-		`time_convention = [true, false]`,      // Wrong type
-		`time_convention = 2h`,                 // Invalid value
+		`default_rounding = true`,                           // Wrong type
+		`default_rounding = 25m`,                            // Invalid value
+		`default_rounding = 15M`,                            // Malformed value
+		`colour_scheme = true`,                              // Wrong type
+		`colour_scheme = yellow`,                            // Invalid value
+		`colour_scheme = DARK`,                              // Malformed value
+		`default_should_total = [true, false]`,              // Wrong type
+		`default_should_total = 15`,                         // Invalid value
+		`default_should_total = 8H`,                         // Malformed value
+		`date_format = [true, false]`,                       // Wrong type
+		`date_format = YYYY.MM.DD`,                          // Invalid value
+		`date_format = yyyy-mm-dd`,                          // Malformed value
+		`time_convention = [true, false]`,                   // Wrong type
+		`time_convention = 2h`,                              // Invalid value
+		`time_convention = 24H`,                             // Malformed value
+		`no_warnings = [OVERLAPPING_RANGES, MORE_THAN_24H]`, // Wrong type
+		`no_warnings = yes`,                                 // Invalid value
+		`no_warnings = overlapping_ranges`,                  // Malformed value
 	} {
 		_, err := NewConfig(
 			FromDeterminedValues{NumCpus: 1},

--- a/klog/app/config_test.go
+++ b/klog/app/config_test.go
@@ -199,8 +199,7 @@ func TestSetTimeFormatParamFromConfigFile(t *testing.T) {
 }
 
 func TestIgnoresUnknownPropertiesInConfigFile(t *testing.T) {
-	for _, tml := range []string{
-		`
+	for _, tml := range []string{`
 unknown_property = 1
 what_is_this = true
 `,

--- a/klog/service/warning_test.go
+++ b/klog/service/warning_test.go
@@ -27,7 +27,7 @@ func checkForWarningsWithCollect(reference gotime.Time, rs []klog.Record) []Warn
 }
 
 func TestNoWarnForOpenRanges(t *testing.T) {
-	timestamp := gotime.Date(2000, 3, 5, 12, 0o0, 0, 0, gotime.Local)
+	timestamp := gotime.Date(2000, 3, 5, 12, 00, 0, 0, gotime.Local)
 	today := klog.NewDateFromGo(timestamp)
 	now := klog.NewTimeFromGo(timestamp)
 
@@ -57,7 +57,7 @@ func TestNoWarnForOpenRanges(t *testing.T) {
 }
 
 func TestOpenRangeWarningWhenUnclosedOpenRangeBeforeTodayRegardlessOfOrder(t *testing.T) {
-	timestamp := gotime.Date(2000, 3, 5, 12, 0o0, 0, 0, gotime.Local)
+	timestamp := gotime.Date(2000, 3, 5, 12, 00, 0, 0, gotime.Local)
 	today := klog.NewDateFromGo(timestamp)
 	now := klog.NewTimeFromGo(timestamp)
 	// The warnings must work reliably even when the records are not ordered by date initially
@@ -84,7 +84,7 @@ func TestOpenRangeWarningWhenUnclosedOpenRangeBeforeTodayRegardlessOfOrder(t *te
 }
 
 func TestNoWarningForFutureEntries(t *testing.T) {
-	timestamp := gotime.Date(2000, 3, 5, 12, 0o0, 0, 0, gotime.Local)
+	timestamp := gotime.Date(2000, 3, 5, 12, 00, 0, 0, gotime.Local)
 	today := klog.NewDateFromGo(timestamp)
 	rs := []klog.Record{
 		func() klog.Record {
@@ -118,7 +118,7 @@ func TestNoWarningForFutureEntries(t *testing.T) {
 }
 
 func TestFutureEntriesWarning(t *testing.T) {
-	timestamp := gotime.Date(2000, 3, 5, 12, 0o0, 0, 0, gotime.Local)
+	timestamp := gotime.Date(2000, 3, 5, 12, 00, 0, 0, gotime.Local)
 	today := klog.NewDateFromGo(timestamp)
 	rs := []klog.Record{
 		func() klog.Record {
@@ -138,13 +138,13 @@ func TestFutureEntriesWarning(t *testing.T) {
 		}(),
 		func() klog.Record {
 			r := klog.NewRecord(today)
-			r.AddRange(klog.Ɀ_Range_(klog.Ɀ_Time_(11, 0o0), klog.Ɀ_Time_(12, 31)), nil)
+			r.AddRange(klog.Ɀ_Range_(klog.Ɀ_Time_(11, 00), klog.Ɀ_Time_(12, 31)), nil)
 			return r
 		}(),
 		func() klog.Record {
 			r := klog.NewRecord(today)
 			// Times shifted to next day
-			r.AddRange(klog.Ɀ_Range_(klog.Ɀ_TimeTomorrow_(1, 0o0), klog.Ɀ_TimeTomorrow_(3, 0)), nil)
+			r.AddRange(klog.Ɀ_Range_(klog.Ɀ_TimeTomorrow_(1, 00), klog.Ɀ_TimeTomorrow_(3, 0)), nil)
 			return r
 		}(),
 		func() klog.Record {
@@ -165,7 +165,7 @@ func TestFutureEntriesWarning(t *testing.T) {
 }
 
 func TestNoWarnForMoreThan24HoursPerRecord(t *testing.T) {
-	timestamp := gotime.Date(2000, 3, 5, 12, 0o0, 0, 0, gotime.Local)
+	timestamp := gotime.Date(2000, 3, 5, 12, 00, 0, 0, gotime.Local)
 	today := klog.NewDateFromGo(timestamp)
 	rs := []klog.Record{
 		func() klog.Record {
@@ -179,7 +179,7 @@ func TestNoWarnForMoreThan24HoursPerRecord(t *testing.T) {
 }
 
 func TestMoreThan24HoursPerRecord(t *testing.T) {
-	timestamp := gotime.Date(2000, 3, 5, 12, 0o0, 0, 0, gotime.Local)
+	timestamp := gotime.Date(2000, 3, 5, 12, 00, 0, 0, gotime.Local)
 	today := klog.NewDateFromGo(timestamp)
 	rs := []klog.Record{
 		func() klog.Record {
@@ -198,7 +198,7 @@ func TestMoreThan24HoursPerRecord(t *testing.T) {
 }
 
 func TestNoWarnForOverlappingTimeRanges(t *testing.T) {
-	timestamp := gotime.Date(2000, 3, 5, 12, 0o0, 0, 0, gotime.Local)
+	timestamp := gotime.Date(2000, 3, 5, 12, 00, 0, 0, gotime.Local)
 	today := klog.NewDateFromGo(timestamp)
 	rs := []klog.Record{
 		func() klog.Record {
@@ -218,7 +218,7 @@ func TestNoWarnForOverlappingTimeRanges(t *testing.T) {
 }
 
 func TestOverlappingTimeRanges(t *testing.T) {
-	timestamp := gotime.Date(2000, 3, 5, 12, 0o0, 0, 0, gotime.Local)
+	timestamp := gotime.Date(2000, 3, 5, 12, 00, 0, 0, gotime.Local)
 	today := klog.NewDateFromGo(timestamp)
 	rs := []klog.Record{
 		func() klog.Record {

--- a/klog/service/warning_test.go
+++ b/klog/service/warning_test.go
@@ -18,11 +18,11 @@ func countWarningsOfKind(c checker, ws []Warning) int {
 	return count
 }
 
-func checkForWarningsWithCollect(reference gotime.Time, rs []klog.Record) []Warning {
+func collectWarnings(reference gotime.Time, rs []klog.Record) []Warning {
 	var ws []Warning
 	CheckForWarnings(func(w Warning) {
 		ws = append(ws, w)
-	}, reference, rs, []string{})
+	}, reference, rs, NewDisabledCheckers())
 	return ws
 }
 
@@ -42,7 +42,7 @@ func TestNoWarnForOpenRanges(t *testing.T) {
 			return r
 		}(),
 	}
-	ws1 := checkForWarningsWithCollect(timestamp, rs1)
+	ws1 := collectWarnings(timestamp, rs1)
 	assert.Equal(t, 0, countWarningsOfKind(&unclosedOpenRangeChecker{}, ws1))
 
 	rs2 := []klog.Record{
@@ -52,7 +52,7 @@ func TestNoWarnForOpenRanges(t *testing.T) {
 			return r
 		}(),
 	}
-	ws2 := checkForWarningsWithCollect(timestamp, rs2)
+	ws2 := collectWarnings(timestamp, rs2)
 	assert.Equal(t, 0, countWarningsOfKind(&unclosedOpenRangeChecker{}, ws2))
 }
 
@@ -77,7 +77,7 @@ func TestOpenRangeWarningWhenUnclosedOpenRangeBeforeTodayRegardlessOfOrder(t *te
 			return r
 		}(),
 	}
-	ws := checkForWarningsWithCollect(timestamp, rs)
+	ws := collectWarnings(timestamp, rs)
 	assert.Equal(t, 2, countWarningsOfKind(&unclosedOpenRangeChecker{}, ws))
 	assert.Equal(t, today.PlusDays(-1), ws[0].Date())
 	assert.Equal(t, today.PlusDays(-2), ws[1].Date())
@@ -113,7 +113,7 @@ func TestNoWarningForFutureEntries(t *testing.T) {
 			return r
 		}(),
 	}
-	ws := checkForWarningsWithCollect(timestamp, rs)
+	ws := collectWarnings(timestamp, rs)
 	assert.Equal(t, 0, countWarningsOfKind(&futureEntriesChecker{}, ws))
 }
 
@@ -160,7 +160,7 @@ func TestFutureEntriesWarning(t *testing.T) {
 			return r
 		}(),
 	}
-	ws := checkForWarningsWithCollect(timestamp, rs)
+	ws := collectWarnings(timestamp, rs)
 	assert.Equal(t, len(rs), countWarningsOfKind(&futureEntriesChecker{}, ws))
 }
 
@@ -174,7 +174,7 @@ func TestNoWarnForMoreThan24HoursPerRecord(t *testing.T) {
 			return r
 		}(),
 	}
-	ws := checkForWarningsWithCollect(timestamp, rs)
+	ws := collectWarnings(timestamp, rs)
 	assert.Equal(t, 0, countWarningsOfKind(&moreThan24HoursChecker{}, ws))
 }
 
@@ -193,7 +193,7 @@ func TestMoreThan24HoursPerRecord(t *testing.T) {
 			return r
 		}(),
 	}
-	ws := checkForWarningsWithCollect(timestamp, rs)
+	ws := collectWarnings(timestamp, rs)
 	assert.Equal(t, len(rs), countWarningsOfKind(&moreThan24HoursChecker{}, ws))
 }
 
@@ -213,7 +213,7 @@ func TestNoWarnForOverlappingTimeRanges(t *testing.T) {
 			return r
 		}(),
 	}
-	ws := checkForWarningsWithCollect(timestamp, rs)
+	ws := collectWarnings(timestamp, rs)
 	assert.Equal(t, 0, countWarningsOfKind(&overlappingTimeRangesChecker{}, ws))
 }
 
@@ -244,6 +244,80 @@ func TestOverlappingTimeRanges(t *testing.T) {
 			return r
 		}(),
 	}
-	ws := checkForWarningsWithCollect(timestamp, rs)
+	ws := collectWarnings(timestamp, rs)
 	assert.Equal(t, len(rs), countWarningsOfKind(&overlappingTimeRangesChecker{}, ws))
+}
+
+func TestNoWarningsWithDisabledCheckers(t *testing.T) {
+	timestamp := gotime.Date(2000, 3, 5, 12, 00, 0, 0, gotime.Local)
+	today := klog.NewDateFromGo(timestamp)
+	now := klog.NewTimeFromGo(timestamp)
+
+	for _, x := range []struct {
+		dc  DisabledCheckers
+		exp int
+	}{
+		// No disabled checkers (default)
+		{func() DisabledCheckers {
+			dc := NewDisabledCheckers()
+			return dc
+		}(), 4},
+		// One checker disabled
+		{func() DisabledCheckers {
+			dc := NewDisabledCheckers()
+			dc["MORE_THAN_24H"] = true
+			return dc
+		}(), 3},
+		// Multiple checkers disabled
+		{func() DisabledCheckers {
+			dc := NewDisabledCheckers()
+			dc["FUTURE_ENTRIES"] = true
+			dc["UNCLOSED_OPEN_RANGE"] = true
+			return dc
+		}(), 2},
+		// All checkers disabled
+		{func() DisabledCheckers {
+			dc := NewDisabledCheckers()
+			dc["MORE_THAN_24H"] = true
+			dc["OVERLAPPING_RANGES"] = true
+			dc["FUTURE_ENTRIES"] = true
+			dc["UNCLOSED_OPEN_RANGE"] = true
+			return dc
+		}(), 0},
+	} {
+		rs := []klog.Record{
+			// Unclosed open range
+			func() klog.Record {
+				r := klog.NewRecord(today.PlusDays(-2))
+				r.Start(klog.NewOpenRange(now), nil)
+				return r
+			}(),
+			// Future entries
+			func() klog.Record {
+				r := klog.NewRecord(today.PlusDays(4))
+				r.AddDuration(klog.NewDuration(2, 0), nil)
+				return r
+			}(),
+			// More than 24h
+			func() klog.Record {
+				r := klog.NewRecord(today.PlusDays(-3))
+				r.AddDuration(klog.NewDuration(25, 0), nil)
+				return r
+			}(),
+			// Overlapping entries
+			func() klog.Record {
+				r := klog.NewRecord(today.PlusDays(-2))
+				r.AddRange(klog.Ɀ_Range_(klog.Ɀ_Time_(0, 15), klog.Ɀ_Time_(1, 30)), nil)
+				r.AddRange(klog.Ɀ_Range_(klog.Ɀ_Time_(0, 45), klog.Ɀ_Time_(3, 45)), nil)
+				return r
+			}(),
+		}
+
+		var ws []Warning
+		CheckForWarnings(func(w Warning) {
+			ws = append(ws, w)
+		}, timestamp, rs, x.dc)
+
+		assert.Len(t, ws, x.exp)
+	}
 }

--- a/klog/service/warning_test.go
+++ b/klog/service/warning_test.go
@@ -1,10 +1,11 @@
 package service
 
 import (
-	"github.com/jotaen/klog/klog"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	gotime "time"
+
+	"github.com/jotaen/klog/klog"
+	"github.com/stretchr/testify/assert"
 )
 
 func countWarningsOfKind(c checker, ws []Warning) int {
@@ -21,12 +22,12 @@ func checkForWarningsWithCollect(reference gotime.Time, rs []klog.Record) []Warn
 	var ws []Warning
 	CheckForWarnings(func(w Warning) {
 		ws = append(ws, w)
-	}, reference, rs)
+	}, reference, rs, []string{})
 	return ws
 }
 
 func TestNoWarnForOpenRanges(t *testing.T) {
-	timestamp := gotime.Date(2000, 3, 5, 12, 00, 0, 0, gotime.Local)
+	timestamp := gotime.Date(2000, 3, 5, 12, 0o0, 0, 0, gotime.Local)
 	today := klog.NewDateFromGo(timestamp)
 	now := klog.NewTimeFromGo(timestamp)
 
@@ -56,7 +57,7 @@ func TestNoWarnForOpenRanges(t *testing.T) {
 }
 
 func TestOpenRangeWarningWhenUnclosedOpenRangeBeforeTodayRegardlessOfOrder(t *testing.T) {
-	timestamp := gotime.Date(2000, 3, 5, 12, 00, 0, 0, gotime.Local)
+	timestamp := gotime.Date(2000, 3, 5, 12, 0o0, 0, 0, gotime.Local)
 	today := klog.NewDateFromGo(timestamp)
 	now := klog.NewTimeFromGo(timestamp)
 	// The warnings must work reliably even when the records are not ordered by date initially
@@ -83,7 +84,7 @@ func TestOpenRangeWarningWhenUnclosedOpenRangeBeforeTodayRegardlessOfOrder(t *te
 }
 
 func TestNoWarningForFutureEntries(t *testing.T) {
-	timestamp := gotime.Date(2000, 3, 5, 12, 00, 0, 0, gotime.Local)
+	timestamp := gotime.Date(2000, 3, 5, 12, 0o0, 0, 0, gotime.Local)
 	today := klog.NewDateFromGo(timestamp)
 	rs := []klog.Record{
 		func() klog.Record {
@@ -117,7 +118,7 @@ func TestNoWarningForFutureEntries(t *testing.T) {
 }
 
 func TestFutureEntriesWarning(t *testing.T) {
-	timestamp := gotime.Date(2000, 3, 5, 12, 00, 0, 0, gotime.Local)
+	timestamp := gotime.Date(2000, 3, 5, 12, 0o0, 0, 0, gotime.Local)
 	today := klog.NewDateFromGo(timestamp)
 	rs := []klog.Record{
 		func() klog.Record {
@@ -137,13 +138,13 @@ func TestFutureEntriesWarning(t *testing.T) {
 		}(),
 		func() klog.Record {
 			r := klog.NewRecord(today)
-			r.AddRange(klog.Ɀ_Range_(klog.Ɀ_Time_(11, 00), klog.Ɀ_Time_(12, 31)), nil)
+			r.AddRange(klog.Ɀ_Range_(klog.Ɀ_Time_(11, 0o0), klog.Ɀ_Time_(12, 31)), nil)
 			return r
 		}(),
 		func() klog.Record {
 			r := klog.NewRecord(today)
 			// Times shifted to next day
-			r.AddRange(klog.Ɀ_Range_(klog.Ɀ_TimeTomorrow_(1, 00), klog.Ɀ_TimeTomorrow_(3, 0)), nil)
+			r.AddRange(klog.Ɀ_Range_(klog.Ɀ_TimeTomorrow_(1, 0o0), klog.Ɀ_TimeTomorrow_(3, 0)), nil)
 			return r
 		}(),
 		func() klog.Record {
@@ -164,7 +165,7 @@ func TestFutureEntriesWarning(t *testing.T) {
 }
 
 func TestNoWarnForMoreThan24HoursPerRecord(t *testing.T) {
-	timestamp := gotime.Date(2000, 3, 5, 12, 00, 0, 0, gotime.Local)
+	timestamp := gotime.Date(2000, 3, 5, 12, 0o0, 0, 0, gotime.Local)
 	today := klog.NewDateFromGo(timestamp)
 	rs := []klog.Record{
 		func() klog.Record {
@@ -178,7 +179,7 @@ func TestNoWarnForMoreThan24HoursPerRecord(t *testing.T) {
 }
 
 func TestMoreThan24HoursPerRecord(t *testing.T) {
-	timestamp := gotime.Date(2000, 3, 5, 12, 00, 0, 0, gotime.Local)
+	timestamp := gotime.Date(2000, 3, 5, 12, 0o0, 0, 0, gotime.Local)
 	today := klog.NewDateFromGo(timestamp)
 	rs := []klog.Record{
 		func() klog.Record {
@@ -197,7 +198,7 @@ func TestMoreThan24HoursPerRecord(t *testing.T) {
 }
 
 func TestNoWarnForOverlappingTimeRanges(t *testing.T) {
-	timestamp := gotime.Date(2000, 3, 5, 12, 00, 0, 0, gotime.Local)
+	timestamp := gotime.Date(2000, 3, 5, 12, 0o0, 0, 0, gotime.Local)
 	today := klog.NewDateFromGo(timestamp)
 	rs := []klog.Record{
 		func() klog.Record {
@@ -217,7 +218,7 @@ func TestNoWarnForOverlappingTimeRanges(t *testing.T) {
 }
 
 func TestOverlappingTimeRanges(t *testing.T) {
-	timestamp := gotime.Date(2000, 3, 5, 12, 00, 0, 0, gotime.Local)
+	timestamp := gotime.Date(2000, 3, 5, 12, 0o0, 0, 0, gotime.Local)
 	today := klog.NewDateFromGo(timestamp)
 	rs := []klog.Record{
 		func() klog.Record {


### PR DESCRIPTION
My use case ends up with a lot of overlapping entries as I tag a certain timeperiod multiple times and instead of passing --no-warn each time I would like to just throw this into a configurable and be done with it.

- [x] extended args.NoWarn flag with a new config HideWarnings
- [x] Documented in `klog config` calls
- [x] Added quick test case
