### PR TITLE
Add subcommand for CSV output

### DIFF
--- a/klog/app/cli/csv.go
+++ b/klog/app/cli/csv.go
@@ -53,8 +53,12 @@ func (opt *Csv) Run(ctx app.Context) app.Error {
 			recordText := strings.Join(sanitizedText, " ")
 
 			tags := summary.Tags().ToStrings()
-			for _, tag := range tags {
-				fmt.Printf("%s,%d,\"%s\",\"%s\"\n", date, duration, tag, recordText)
+			if len(tags) == 0 {
+				fmt.Printf("%s,%d,,\"%s\"\n", date, duration, recordText)
+			} else {
+				for _, tag := range tags {
+					fmt.Printf("%s,%d,\"%s\",\"%s\"\n", date, duration, tag, recordText)
+				}
 			}
 		}
 	}

--- a/klog/app/cli/csv.go
+++ b/klog/app/cli/csv.go
@@ -18,9 +18,9 @@ type Csv struct {
 func (opt *Csv) Help() string {
 	return `
 This commands outputs the records into a simple csv format with the following collumns:
-| Date | Duration | Tags | Description |
+
 Example:
-date       ,duration, tag           , description          
+date, duration, tag, description
 2020-01-01 , 60     , #science      , Worked on the project
 Please note: Entries with >1 tag will be repeated for each tag.
 duration will always be in minutes.

--- a/klog/app/cli/csv.go
+++ b/klog/app/cli/csv.go
@@ -50,6 +50,10 @@ func (opt *Csv) Run(ctx app.Context) app.Error {
 	fmt.Print(csvHeader)
 	for _, record := range records {
 		entries := record.Entries()
+		if len(entries) == 0 {
+			fmt.Printf("%s,0,,\n", record.Date().ToString())
+			continue
+		}
 		for _, entry := range entries {
 			date := record.Date().ToString()
 			duration := entry.Duration().InMinutes()

--- a/klog/app/cli/csv.go
+++ b/klog/app/cli/csv.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jotaen/klog/klog/app"
+	"github.com/jotaen/klog/klog/app/cli/util"
+)
+
+type Csv struct {
+	util.NowArgs
+	util.FilterArgs
+	util.SortArgs
+	util.InputFilesArgs
+}
+
+func (opt *Csv) Help() string {
+	return `
+This commands outputs the records into a simple csv format with the following collumns:
+| Date | Duration | Tags | Description |
+Example:
+date       ,duration, tag           , description          
+2020-01-01 , 60     , #science      , Worked on the project
+Please note: Entries with >1 tag will be repeated for each tag.
+duration will always be in minutes.
+If there are errors in the parsing, they will be printed on separate lines. and
+the operation will return a non-zero exit code.
+`
+}
+
+func (opt *Csv) Run(ctx app.Context) app.Error {
+	records, err := ctx.ReadInputs(opt.File...)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("date,duration,tag,description\n")
+	for _, record := range records {
+		entries := record.Entries()
+		for _, entry := range entries {
+			duration := entry.Duration().InMinutes()
+			summary := entry.Summary()
+			date := record.Date().ToString()
+
+			text := strings.Join(summary.Lines(), " ")
+			sanitizedText := []string{}
+			words := strings.Fields(text)
+			for _, word := range words {
+				if !strings.HasPrefix(word, "#") {
+					sanitizedText = append(sanitizedText, word)
+				}
+			}
+			recordText := strings.Join(sanitizedText, " ")
+
+			tags := summary.Tags().ToStrings()
+			for _, tag := range tags {
+				fmt.Printf("%s,%d,\"%s\",\"%s\"\n", date, duration, tag, recordText)
+			}
+		}
+	}
+	return nil
+}

--- a/klog/app/cli/index.go
+++ b/klog/app/cli/index.go
@@ -46,6 +46,7 @@ type Cli struct {
 	Config     Config        `cmd:"" name:"config" group:"Misc" help:"Print the current configuration."`
 	Info       Info          `cmd:"" name:"info" group:"Misc" help:"Print information about klog."`
 	Json       Json          `cmd:"" name:"json" group:"Misc" help:"Convert records to JSON."`
+	Csv       Csv          `cmd:"" name:"csv" group:"Misc" help:"Convert records to CSV."`
 	Completion kc.Completion `cmd:"" name:"completion" group:"Misc" help:"Output shell code for enabling tab completion."`
 }
 


### PR DESCRIPTION
Implemented a quick csv output with a few behaviors
- [x] Repeats entry for each tag on the line
- [x] Prints to stdout
- [x] Duration is always in minutes

```
> klog csv
date,duration,tag,description
2024-07-15,91,"#my-tag","Did some work on klog"
2024-07-15,92,"#my-tag","Did some other work on klog"
```