### PR TITLE
Add “resume” flags to `klog switch`

### DIFF
--- a/klog/app/cli/start.go
+++ b/klog/app/cli/start.go
@@ -10,9 +10,7 @@ import (
 )
 
 type Start struct {
-	SummaryText klog.EntrySummary `name:"summary" short:"s" placeholder:"TEXT" help:"Summary text for this entry."`
-	Resume      bool              `name:"resume" short:"R" help:"Take over summary of last entry (if applicable). If the target record is new or empty, it looks at the previous record."`
-	ResumeNth   int               `name:"resume-nth" short:"N" help:"Take over summary of nth entry. If INT is positive, it counts from the start (beginning with '1'); if negative, it counts from the end (beginning with '-1')"`
+	util.SummaryArgs
 	util.AtDateAndTimeArgs
 	util.NoStyleArgs
 	util.WarnArgs
@@ -22,6 +20,7 @@ type Start struct {
 func (opt *Start) Help() string {
 	return `
 This appends a new open-ended entry to the record.
+
 By default, it uses the record at today’s date for the new entry, or creates a new record if there no record at today’s date.
 You can otherwise specify a date with '--date'.
 
@@ -45,6 +44,7 @@ func (opt *Start) Run(ctx app.Context) app.Error {
 	ctx.Config().DefaultShouldTotal.Unwrap(func(s klog.ShouldTotal) {
 		additionalData.ShouldTotal = s
 	})
+
 	spy := PreviousRecordSpy{}
 	return util.Reconcile(ctx, util.ReconcileOpts{OutputFileArgs: opt.OutputFileArgs, WarnArgs: opt.WarnArgs},
 		[]reconciling.Creator{
@@ -61,74 +61,6 @@ func (opt *Start) Run(ctx app.Context) app.Error {
 			return reconciler.StartOpenRange(time, opt.TimeFormat(ctx.Config()), summary)
 		},
 	)
-}
-
-func (opt *Start) Summary(currentRecord klog.Record, previousRecord klog.Record) (klog.EntrySummary, app.Error) {
-	// Check for conflicting flags.
-	if opt.SummaryText != nil && (opt.Resume || opt.ResumeNth != 0) {
-		return nil, app.NewErrorWithCode(
-			app.LOGICAL_ERROR,
-			"Conflicting flags: --summary and --resume cannot be used at the same time",
-			"",
-			nil,
-		)
-	}
-	if opt.Resume && opt.ResumeNth != 0 {
-		return nil, app.NewError(
-			"Illegal flag combination",
-			"Cannot combine --resume and --resume-nth",
-			nil,
-		)
-	}
-
-	// Return summary flag, if specified.
-	if opt.SummaryText != nil {
-		return opt.SummaryText, nil
-	}
-
-	// If --resume was specified: return summary of last entry from current record, if
-	// it has any entries. Otherwise, return summary of last entry from previous record,
-	// if exists.
-	if opt.Resume {
-		if e, ok := findNthEntry(currentRecord, -1); ok {
-			return e.Summary(), nil
-		}
-		if previousRecord != nil {
-			if e, ok := findNthEntry(previousRecord, -1); ok {
-				return e.Summary(), nil
-			}
-		}
-		return nil, nil
-	}
-
-	// If --resume-nth was specified: return summary of nth-entry. In contrast to --resume,
-	// don’t fall back to previous record, as that would be unintuitive here.
-	if opt.ResumeNth != 0 {
-		if e, ok := findNthEntry(currentRecord, opt.ResumeNth); ok {
-			return e.Summary(), nil
-		}
-		return nil, app.NewError(
-			"No such entry",
-			"",
-			nil,
-		)
-	}
-
-	return nil, nil
-}
-
-func findNthEntry(r klog.Record, nr int) (klog.Entry, bool) {
-	entriesCount := len(r.Entries())
-	i := func() int {
-		if nr > 0 {
-			return nr - 1
-		}
-		return entriesCount + nr
-	}()
-	if i < 0 || i > entriesCount-1 {
-		return klog.Entry{}, false
-	}
-	return r.Entries()[i], true
 }
 
 type PreviousRecordSpy struct {

--- a/klog/app/cli/start_test.go
+++ b/klog/app/cli/start_test.go
@@ -111,7 +111,9 @@ func TestStartWithSummary(t *testing.T) {
 		AtDateAndTimeArgs: util.AtDateAndTimeArgs{
 			AtDateArgs: util.AtDateArgs{Date: klog.Ɀ_Date_(1920, 2, 2)},
 		},
-		SummaryText: klog.Ɀ_EntrySummary_("Started something"),
+		SummaryArgs: util.SummaryArgs{
+			SummaryText: klog.Ɀ_EntrySummary_("Started something"),
+		},
 	}).Run)
 	require.Nil(t, err)
 	assert.Equal(t, `
@@ -267,7 +269,9 @@ func TestStartWithResume(t *testing.T) {
 	t.Run("No previous entry, no previous record -> Empty entry summary", func(t *testing.T) {
 		state, err := NewTestingContext()._SetRecords(`1623-12-13
 `)._SetNow(1623, 12, 13, 12, 49)._Run((&Start{
-			Resume: true,
+			SummaryArgs: util.SummaryArgs{
+				Resume: true,
+			},
 		}).Run)
 		require.Nil(t, err)
 		assert.Equal(t, `1623-12-13
@@ -281,7 +285,9 @@ func TestStartWithResume(t *testing.T) {
     14:00 - 15:00 Did something
     10m Some activity
 `)._SetNow(1623, 12, 13, 12, 49)._Run((&Start{
-			Resume: true,
+			SummaryArgs: util.SummaryArgs{
+				Resume: true,
+			},
 		}).Run)
 		require.Nil(t, err)
 		assert.Equal(t, `
@@ -298,7 +304,9 @@ func TestStartWithResume(t *testing.T) {
 		state, err := NewTestingContext()._SetRecords(`
 1623-12-12
 `)._SetNow(1623, 12, 13, 12, 49)._Run((&Start{
-			Resume: true,
+			SummaryArgs: util.SummaryArgs{
+				Resume: true,
+			},
 		}).Run)
 		require.Nil(t, err)
 		assert.Equal(t, `
@@ -313,7 +321,9 @@ func TestStartWithResume(t *testing.T) {
 		state, err := NewTestingContext()._SetRecords(`1623-12-13
     8:13 - 9:44
 `)._SetNow(1623, 12, 13, 12, 49)._Run((&Start{
-			Resume: true,
+			SummaryArgs: util.SummaryArgs{
+				Resume: true,
+			},
 		}).Run)
 		require.Nil(t, err)
 		assert.Equal(t, `1623-12-13
@@ -326,7 +336,9 @@ func TestStartWithResume(t *testing.T) {
 		state, err := NewTestingContext()._SetRecords(`1623-12-13
     8:13 - 9:44 Work
 `)._SetNow(1623, 12, 13, 12, 49)._Run((&Start{
-			Resume: true,
+			SummaryArgs: util.SummaryArgs{
+				Resume: true,
+			},
 		}).Run)
 		require.Nil(t, err)
 		assert.Equal(t, `1623-12-13
@@ -340,7 +352,9 @@ func TestStartWithResume(t *testing.T) {
     8:13 - 9:44 Work
     9:51 - 11:22 More work
 `)._SetNow(1623, 12, 13, 12, 49)._Run((&Start{
-			Resume: true,
+			SummaryArgs: util.SummaryArgs{
+				Resume: true,
+			},
 		}).Run)
 		require.Nil(t, err)
 		assert.Equal(t, `1623-12-13
@@ -355,7 +369,9 @@ func TestStartWithResume(t *testing.T) {
     8:13 - 9:44
         Work
 `)._SetNow(1623, 12, 13, 12, 49)._Run((&Start{
-			Resume: true,
+			SummaryArgs: util.SummaryArgs{
+				Resume: true,
+			},
 		}).Run)
 		require.Nil(t, err)
 		assert.Equal(t, `1623-12-13
@@ -371,8 +387,10 @@ func TestStartWithResume(t *testing.T) {
     8:13 - 9:44
         Work
 `)._SetNow(1623, 12, 13, 12, 49)._Run((&Start{
-			Resume:      true,
-			SummaryText: klog.Ɀ_EntrySummary_("Test"),
+			SummaryArgs: util.SummaryArgs{
+				Resume:      true,
+				SummaryText: klog.Ɀ_EntrySummary_("Test"),
+			},
 		}).Run)
 		require.Error(t, err)
 	})
@@ -382,8 +400,10 @@ func TestStartWithResume(t *testing.T) {
     8:13 - 9:44
         Work
 `)._SetNow(1623, 12, 13, 12, 49)._Run((&Start{
-			Resume:    true,
-			ResumeNth: 1,
+			SummaryArgs: util.SummaryArgs{
+				Resume:    true,
+				ResumeNth: 1,
+			},
 		}).Run)
 		require.Error(t, err)
 	})
@@ -397,7 +417,9 @@ func TestStartWithResumeNth(t *testing.T) {
     2h Bar
     3h Asdf
 `)._SetNow(1623, 12, 13, 12, 49)._Run((&Start{
-				ResumeNth: nth,
+				SummaryArgs: util.SummaryArgs{
+					ResumeNth: nth,
+				},
 			}).Run)
 			require.Nil(t, err)
 			assert.Equal(t, `1623-12-13
@@ -416,7 +438,9 @@ func TestStartWithResumeNth(t *testing.T) {
     2h Bar
     3h Asdf
 `)._SetNow(1623, 12, 13, 12, 49)._Run((&Start{
-				ResumeNth: nth,
+				SummaryArgs: util.SummaryArgs{
+					ResumeNth: nth,
+				},
 			}).Run)
 			require.Nil(t, err)
 			assert.Equal(t, `1623-12-13
@@ -435,7 +459,9 @@ func TestStartWithResumeNth(t *testing.T) {
     2h Bar
     3h
 `)._SetNow(1623, 12, 13, 12, 49)._Run((&Start{
-				ResumeNth: nth,
+				SummaryArgs: util.SummaryArgs{
+					ResumeNth: nth,
+				},
 			}).Run)
 			require.Nil(t, err)
 			assert.Equal(t, `1623-12-13
@@ -454,7 +480,9 @@ func TestStartWithResumeNth(t *testing.T) {
     2h Bar
     3h Asdf
 `)._SetNow(1623, 12, 13, 12, 49)._Run((&Start{
-				ResumeNth: nth,
+				SummaryArgs: util.SummaryArgs{
+					ResumeNth: nth,
+				},
 			}).Run)
 			require.Error(t, err)
 		}
@@ -468,7 +496,9 @@ func TestStartWithResumeNth(t *testing.T) {
 
 1623-12-13
 `)._SetNow(1623, 12, 13, 12, 49)._Run((&Start{
-			ResumeNth: -1,
+			SummaryArgs: util.SummaryArgs{
+				ResumeNth: -1,
+			},
 		}).Run)
 		require.Error(t, err)
 	})
@@ -478,8 +508,10 @@ func TestStartWithResumeNth(t *testing.T) {
     8:13 - 9:44
         Work
 `)._SetNow(1623, 12, 13, 12, 49)._Run((&Start{
-			ResumeNth:   1,
-			SummaryText: klog.Ɀ_EntrySummary_("Test"),
+			SummaryArgs: util.SummaryArgs{
+				ResumeNth:   1,
+				SummaryText: klog.Ɀ_EntrySummary_("Test"),
+			},
 		}).Run)
 		require.Error(t, err)
 	})
@@ -489,8 +521,10 @@ func TestStartWithResumeNth(t *testing.T) {
     8:13 - 9:44
         Work
 `)._SetNow(1623, 12, 13, 12, 49)._Run((&Start{
-			Resume:    true,
-			ResumeNth: 1,
+			SummaryArgs: util.SummaryArgs{
+				Resume:    true,
+				ResumeNth: 1,
+			},
 		}).Run)
 		require.Error(t, err)
 	})

--- a/klog/app/cli/switch.go
+++ b/klog/app/cli/switch.go
@@ -1,14 +1,13 @@
 package cli
 
 import (
-	"github.com/jotaen/klog/klog"
 	"github.com/jotaen/klog/klog/app"
 	"github.com/jotaen/klog/klog/app/cli/util"
 	"github.com/jotaen/klog/klog/parser/reconciling"
 )
 
 type Switch struct {
-	SummaryText klog.EntrySummary `name:"summary" short:"s" placeholder:"TEXT" help:"Summary text for the new entry."`
+	util.SummaryArgs
 	util.AtDateAndTimeArgs
 	util.NoStyleArgs
 	util.WarnArgs
@@ -19,6 +18,11 @@ func (opt *Switch) Help() string {
 	return `
 Closes a previously ongoing activity (i.e., open time range), and starts a new one.
 This is basically a convenience for doing 'klog stop' and 'klog start' – however, in contrast to issuing both commands separately, 'klog switch' guarantees that the end time of the previous activity will be the same as the start time for the new entry.
+
+By default, it uses the record at today’s date for the new entry. You can otherwise specify a date with '--date'.
+
+Unless the '--time' flag is specified, it defaults to the current time as start/stop time.
+If you prefer your time to be rounded, you can use the '--round' flag.
 `
 }
 
@@ -40,7 +44,11 @@ func (opt *Switch) Run(ctx app.Context) app.Error {
 			return reconciler.CloseOpenRange(time, opt.TimeFormat(ctx.Config()), nil)
 		},
 		func(reconciler *reconciling.Reconciler) error {
-			return reconciler.StartOpenRange(time, opt.TimeFormat(ctx.Config()), opt.SummaryText)
+			summary, sErr := opt.Summary(reconciler.Record, nil)
+			if sErr != nil {
+				return sErr
+			}
+			return reconciler.StartOpenRange(time, opt.TimeFormat(ctx.Config()), summary)
 		},
 	)
 }

--- a/klog/app/cli/util/args.go
+++ b/klog/app/cli/util/args.go
@@ -315,3 +315,77 @@ func (args *DecimalArgs) Apply(ctx *app.Context) {
 		})
 	}
 }
+
+type SummaryArgs struct {
+	SummaryText klog.EntrySummary `name:"summary" short:"s" placeholder:"TEXT" help:"Summary text for the new entry."`
+	Resume      bool              `name:"resume" short:"R" help:"Take over summary of last entry (if applicable)."`
+	ResumeNth   int               `name:"resume-nth" short:"N" help:"Take over summary of nth entry. If INT is positive, it counts from the start (beginning with '1'); if negative, it counts from the end (beginning with '-1')"`
+}
+
+func (args *SummaryArgs) Summary(currentRecord klog.Record, previousRecord klog.Record) (klog.EntrySummary, app.Error) {
+	// Check for conflicting flags.
+	if args.SummaryText != nil && (args.Resume || args.ResumeNth != 0) {
+		return nil, app.NewErrorWithCode(
+			app.LOGICAL_ERROR,
+			"Conflicting flags: --summary and --resume cannot be used at the same time",
+			"",
+			nil,
+		)
+	}
+	if args.Resume && args.ResumeNth != 0 {
+		return nil, app.NewError(
+			"Illegal flag combination",
+			"Cannot combine --resume and --resume-nth",
+			nil,
+		)
+	}
+
+	// Return summary flag, if specified.
+	if args.SummaryText != nil {
+		return args.SummaryText, nil
+	}
+
+	// If --resume was specified: return summary of last entry from current record, if
+	// it has any entries. Otherwise, return summary of last entry from previous record,
+	// if exists.
+	if args.Resume {
+		if e, ok := findNthEntry(currentRecord, -1); ok {
+			return e.Summary(), nil
+		}
+		if previousRecord != nil {
+			if e, ok := findNthEntry(previousRecord, -1); ok {
+				return e.Summary(), nil
+			}
+		}
+		return nil, nil
+	}
+
+	// If --resume-nth was specified: return summary of nth-entry. In contrast to --resume,
+	// don’t fall back to previous record, as that would be unintuitive here.
+	if args.ResumeNth != 0 {
+		if e, ok := findNthEntry(currentRecord, args.ResumeNth); ok {
+			return e.Summary(), nil
+		}
+		return nil, app.NewError(
+			"No such entry",
+			"",
+			nil,
+		)
+	}
+
+	return nil, nil
+}
+
+func findNthEntry(r klog.Record, nr int) (klog.Entry, bool) {
+	entriesCount := len(r.Entries())
+	i := func() int {
+		if nr > 0 {
+			return nr - 1
+		}
+		return entriesCount + nr
+	}()
+	if i < 0 || i > entriesCount-1 {
+		return klog.Entry{}, false
+	}
+	return r.Entries()[i], true
+}


### PR DESCRIPTION
Resolves https://github.com/jotaen/klog/issues/327, by making available the `--resume`/`--resume-nth` flags on the `klog switch` subcommand.