### PR TITLE
Ensure to not parse “exotic” digits

### DIFF
--- a/klog/date_test.go
+++ b/klog/date_test.go
@@ -114,6 +114,9 @@ func TestParseDateFailsIfMalformed(t *testing.T) {
 		"20-12-12",
 		"asdf",
 		"01.01.2000",
+		"⠃⠚⠚⠚-⠁⠃-⠚⠛", // Braille digits
+		"二〇〇〇-一二-〇四", // Japanese digits
+		"᠒᠐᠐᠐-᠑᠒-᠐᠗", // Mongolean digits
 	} {
 		d, err := NewDateFromString(s)
 		assert.Nil(t, d)

--- a/klog/duration.go
+++ b/klog/duration.go
@@ -111,7 +111,7 @@ func (d duration) ToStringWithSign() string {
 	return s
 }
 
-var durationPattern = regexp.MustCompile(`^(-|\+)?((\d+)h)?((\d+)m)?$`)
+var durationPattern = regexp.MustCompile(`^([-+])?((\d+)h)?((\d+)m)?$`)
 
 func NewDurationFromString(hhmm string) (Duration, error) {
 	match := durationPattern.FindStringSubmatch(hhmm)

--- a/klog/duration_test.go
+++ b/klog/duration_test.go
@@ -130,6 +130,9 @@ func TestParsingFailsWithInvalidValue(t *testing.T) {
 		"asdf",
 		"6h asdf",
 		"qwer 30m",
+		"⠙⠛m",   // Braille digits
+		"四二h",   // Japanese digits
+		"᠒h᠐᠒m", // Mongolean digits
 	} {
 		duration, err := NewDurationFromString(d)
 		assert.EqualError(t, err, "MALFORMED_DURATION")

--- a/klog/time_test.go
+++ b/klog/time_test.go
@@ -207,6 +207,9 @@ func TestParseMalformedTimesFail(t *testing.T) {
 		"13:3",   // Minutes must have 2 digits
 		"-14:12", // Hours cannot be negative
 		"14:-12", // Minutes cannot be negative
+		"⠃⠚:⠙⠛",  // Braille digits
+		"四:二八",   // Japanese digits
+		"᠒᠐:᠑᠒",  // Mongolean digits
 	} {
 		tm, err := NewTimeFromString(s)
 		require.Nil(t, tm, s)


### PR DESCRIPTION
This PR adds a few tests to make sure that we don’t accidentally accept any kinds of digits that aren’t Arabic numerals.