### PR TITLE
Provide `--chart` flag on `klog report` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 **Summary of changes of the command line tool**
 
+## Scheduled for next release
+- **[ FEATURE ]** Add `--chart` flag to `klog report` command, which
+  includes bar chart renderings in the output, to allow for convenient visual
+  comparison at a glance. (See also `--chart-resolution`.)
+
 ## v6.5 (2024-11-28)
 - **[ FEATURE ]** Introduce `basic` colour scheme based on the basic 8-bit ANSI
   colours – see `colour_scheme` entry in `config.ini` file. (Run `klog config` to

--- a/klog/app/cli/report.go
+++ b/klog/app/cli/report.go
@@ -16,7 +16,7 @@ type Report struct {
 	AggregateBy     string `name:"aggregate" placeholder:"KIND" short:"a" help:"How to aggregate the data. KIND can be 'day' (default), 'week', 'month', 'quarter' or 'year'." enum:"DAY,day,d,WEEK,week,w,MONTH,month,m,QUARTER,quarter,q,YEAR,year,y," default:"day"`
 	Fill            bool   `name:"fill" short:"f" help:"Fill any calendar gaps and show a consecutive sequence of dates."`
 	Chart           bool   `name:"chart" short:"c" help:"Includes a bar chart rendering, to aid visual comparison."`
-	ChartResolution int    `name:"chart-res" help:"Configure the chart resolution. INT must be a positive integer, denoting the minutes per rendered block. The default is 15."`
+	ChartResolution int    `name:"chart-res" help:"Configure the chart resolution. INT must be a positive integer, denoting the minutes per rendered block."`
 	util.DiffArgs
 	util.FilterArgs
 	util.NowArgs

--- a/klog/app/cli/report.go
+++ b/klog/app/cli/report.go
@@ -195,6 +195,9 @@ func groupByDate(hashProvider func(klog.Date) period.Hash, rs []klog.Record) (ma
 
 func (opt *Report) ApplyChart() app.Error {
 	if opt.ChartResolution == 0 {
+		// Unless specified otherwise, set the default resolution to 15 minutes
+		// per rendered block. This should make for a good balance between granularity
+		// and row width in the context of the (default) daily aggregation mode.
 		opt.ChartResolution = 15
 	} else if opt.ChartResolution > 0 {
 		// When chart resolution is specified, automatically assume --chart

--- a/klog/app/cli/report_test.go
+++ b/klog/app/cli/report_test.go
@@ -282,7 +282,8 @@ func TestYearReport(t *testing.T) {
 }
 
 func TestReportWithChart(t *testing.T) {
-	state, err := NewTestingContext()._SetRecords(`
+	t.Run("Daily (default) aggregation", func(t *testing.T) {
+		state, err := NewTestingContext()._SetRecords(`
 2025-01-11
 	-2h
 
@@ -313,8 +314,8 @@ func TestReportWithChart(t *testing.T) {
 2025-01-25
 	9h
 `)._Run((&Report{Chart: true}).Run)
-	require.Nil(t, err)
-	assert.Equal(t, `
+		require.Nil(t, err)
+		assert.Equal(t, `
                        Total                                      
 2025 Jan    Sat 11.      -2h                                      
             Mon 13.       1m  ▇                                   
@@ -328,10 +329,99 @@ func TestReportWithChart(t *testing.T) {
                     ========                                      
                       39h38m                                      
 `, state.printBuffer)
+	})
+
+	t.Run("Weekly aggregation", func(t *testing.T) {
+		state, err := NewTestingContext()._SetRecords(`
+2025-01-01
+	40h
+
+2025-01-08
+	48h45m
+
+2025-01-15
+	31h15m
+`)._Run((&Report{Chart: true, AggregateBy: "w", WarnArgs: util.WarnArgs{NoWarn: true}}).Run)
+		require.Nil(t, err)
+		assert.Equal(t, `
+                 Total                                                   
+2025  Week  1      40h  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇         
+      Week  2   48h45m  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇
+      Week  3   31h15m  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇                 
+              ========                                                   
+                  120h                                                   
+`, state.printBuffer)
+	})
+
+	t.Run("Monthly aggregation", func(t *testing.T) {
+		state, err := NewTestingContext()._SetRecords(`
+2025-01-01
+	173h
+
+2025-02-01
+	208h30m
+
+2025-03-01
+	126h15m
+`)._Run((&Report{Chart: true, AggregateBy: "m", WarnArgs: util.WarnArgs{NoWarn: true}}).Run)
+		require.Nil(t, err)
+		assert.Equal(t, `
+            Total                                                       
+2025 Jan     173h  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇         
+     Feb  208h30m  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇
+     Mar  126h15m  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇                     
+         ========                                                       
+          507h45m                                                       
+`, state.printBuffer)
+	})
+
+	t.Run("Quarterly aggregation", func(t *testing.T) {
+		state, err := NewTestingContext()._SetRecords(`
+2025-01-01
+	316h
+
+2025-04-01
+	392h30m
+
+2025-07-01
+	237h45m
+`)._Run((&Report{Chart: true, AggregateBy: "q", WarnArgs: util.WarnArgs{NoWarn: true}}).Run)
+		require.Nil(t, err)
+		assert.Equal(t, `
+           Total                                                    
+2025 Q1     316h  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇          
+     Q2  392h30m  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇
+     Q3  237h45m  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇                    
+        ========                                                    
+         946h15m                                                    
+`, state.printBuffer)
+	})
+
+	t.Run("Yearly aggregation", func(t *testing.T) {
+		state, err := NewTestingContext()._SetRecords(`
+2025-01-01
+	1735h
+
+2026-01-01
+	2154h45m
+
+2027-01-01
+	1189h15m
+`)._Run((&Report{Chart: true, AggregateBy: "y", WarnArgs: util.WarnArgs{NoWarn: true}}).Run)
+		require.Nil(t, err)
+		assert.Equal(t, `
+        Total                                         
+2025    1735h  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇        
+2026 2154h45m  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇
+2027 1189h15m  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇                 
+     ========                                         
+        5079h                                         
+`, state.printBuffer)
+	})
 }
 
 func TestReportWithScaledChart(t *testing.T) {
-	t.Run("Custom scale factor (large)", func(t *testing.T) {
+	t.Run("Custom resolution (large)", func(t *testing.T) {
 		state, err := NewTestingContext()._SetRecords(`
 2025-01-14
 	12h
@@ -349,7 +439,7 @@ func TestReportWithScaledChart(t *testing.T) {
 `, state.printBuffer)
 	})
 
-	t.Run("Custom scale factor (small)", func(t *testing.T) {
+	t.Run("Custom resolution (small)", func(t *testing.T) {
 		state, err := NewTestingContext()._SetRecords(`
 2025-01-14
 	1h30m
@@ -403,7 +493,7 @@ func TestReportWithScaledChart(t *testing.T) {
 `, state.printBuffer)
 	})
 
-	t.Run("Invalid scale factor", func(t *testing.T) {
+	t.Run("Invalid resolution", func(t *testing.T) {
 		_, err := NewTestingContext()._SetRecords(`
 2025-01-14
 	12h
@@ -412,6 +502,6 @@ func TestReportWithScaledChart(t *testing.T) {
 	18h37m
 `)._Run((&Report{ChartResolution: -10}).Run)
 		require.Error(t, err)
-		assert.Equal(t, "Invalid scale factor", err.Error())
+		assert.Equal(t, "Invalid resolution", err.Error())
 	})
 }


### PR DESCRIPTION
Related https://github.com/jotaen/klog/discussions/336.

This PR adds a `--chart` (`-c`) flag to the `klog report` command, which includes bar chart diagrams in the output like so:

```
$ klog report --chart worktimes.klg

                       Total                                  
2025 Jan    Tue 14.       6h  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇        
            Thu 16.    7h30m  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇  
            Fri 17.    6h45m  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇     
            Sat 18.       8h  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇
            Mon 20.    3h20m  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇                  
            Wed 22.    7h45m  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 
            Sat 25.    7h15m  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇   
                    ========                                  
                      46h35m                                  
```

The default resolution of the bars depends on the aggregation mode. (Remember: aggregation defaults to daily, unless specified via `--aggregate`/`-a`). The default resolution aims to make for a good balance between granularity and row width for typical usage scenarios (e.g., tracking work times). The resolution can be overridden with the `--chart-res` flag; it needs to be a positive integer, denoting the number of minutes per rendered block.

One implementation note for reference: I originally tried to use Unicode’s [“eighths” type block characters](https://www.compart.com/en/unicode/block/U+2580) to make the bars more precise. This didn’t work out so well, however, because on some systems, the full block and the “eighths” blocks render at a slightly different height, which looks weird.