### PR TITLE
Optionally include untagged entries in `klog tags`

### DIFF
--- a/klog/app/cli/tags_test.go
+++ b/klog/app/cli/tags_test.go
@@ -19,12 +19,12 @@ func TestPrintTagsOverview(t *testing.T) {
 		- Sort output alphabetically
 		- Print in tabular manner
 	*/
-	state, err := NewTestingContext()._SetRecords(`
+	ctx := NewTestingContext()._SetRecords(`
 1995-03-17
 #sports
 	3h #badminton
-	1h #running
-	1h #running
+	1h #running=home-trail
+	1h #running=river-route
 
 1995-03-28
 Was #sick, need to compensate later
@@ -38,59 +38,206 @@ Was #sick, need to compensate later
 #sports #running (Don’t count that twice!)
 	14:00 - 17:00 #sports #running
 	
-`)._Run((&Tags{}).Run)
-	require.Nil(t, err)
-	assert.Equal(t, `
+`)
+
+	t.Run("Without argument", func(t *testing.T) {
+		state, err := ctx._Run((&Tags{}).Run)
+		require.Nil(t, err)
+		assert.Equal(t, `
 #badminton 3h45m
 #running   4h30m
 #sick      -30m 
 #sports    8h   
 `, state.printBuffer)
+	})
+
+	t.Run("With count", func(t *testing.T) {
+		state, err := ctx._Run((&Tags{
+			Count: true,
+		}).Run)
+		require.Nil(t, err)
+		assert.Equal(t, `
+#badminton 3h45m  (2)
+#running   4h30m  (4)
+#sick      -30m   (1)
+#sports    8h     (4)
+`, state.printBuffer)
+	})
+
+	t.Run("With values", func(t *testing.T) {
+		state, err := ctx._Run((&Tags{
+			Values: true,
+		}).Run)
+		require.Nil(t, err)
+		assert.Equal(t, `
+#badminton   3h45m   
+#running     4h30m   
+ home-trail        1h
+ river-route       1h
+#sick        -30m    
+#sports      8h      
+`, state.printBuffer)
+	})
+
+	t.Run("With values and count", func(t *testing.T) {
+		state, err := ctx._Run((&Tags{
+			Values: true,
+			Count:  true,
+		}).Run)
+		require.Nil(t, err)
+		assert.Equal(t, `
+#badminton   3h45m     (2)
+#running     4h30m     (4)
+ home-trail        1h  (1)
+ river-route       1h  (1)
+#sick        -30m      (1)
+#sports      8h        (4)
+`, state.printBuffer)
+	})
+
+	t.Run("With untagged", func(t *testing.T) {
+		state, err := ctx._Run((&Tags{
+			WithUntagged: true,
+		}).Run)
+		require.Nil(t, err)
+		assert.Equal(t, `
+#badminton 3h45m
+#running   4h30m
+#sick      -30m 
+#sports    8h   
+(untagged) 9h   
+`, state.printBuffer)
+	})
+
+	t.Run("With untagged and count", func(t *testing.T) {
+		state, err := ctx._Run((&Tags{
+			WithUntagged: true,
+			Count:        true,
+		}).Run)
+		require.Nil(t, err)
+		assert.Equal(t, `
+#badminton 3h45m  (2)
+#running   4h30m  (4)
+#sick      -30m   (1)
+#sports    8h     (4)
+(untagged) 9h     (1)
+`, state.printBuffer)
+	})
+
+	t.Run("With values and untagged", func(t *testing.T) {
+		state, err := ctx._Run((&Tags{
+			Values:       true,
+			WithUntagged: true,
+		}).Run)
+		require.Nil(t, err)
+		assert.Equal(t, `
+#badminton   3h45m   
+#running     4h30m   
+ home-trail        1h
+ river-route       1h
+#sick        -30m    
+#sports      8h      
+(untagged)   9h      
+`, state.printBuffer)
+	})
+
+	t.Run("With values and untagged and count", func(t *testing.T) {
+		state, err := ctx._Run((&Tags{
+			Values:       true,
+			WithUntagged: true,
+			Count:        true,
+		}).Run)
+		require.Nil(t, err)
+		assert.Equal(t, `
+#badminton   3h45m     (2)
+#running     4h30m     (4)
+ home-trail        1h  (1)
+ river-route       1h  (1)
+#sick        -30m      (1)
+#sports      8h        (4)
+(untagged)   9h        (1)
+`, state.printBuffer)
+	})
+}
+
+func TestPrintUntaggedIfNoTags(t *testing.T) {
+	t.Run("No tags present", func(t *testing.T) {
+		state, err := NewTestingContext()._SetRecords(`
+1995-03-17
+	1h
+`)._Run((&Tags{
+			WithUntagged: true,
+		}).Run)
+		require.Nil(t, err)
+		assert.Equal(t, `
+(untagged) 1h
+`, state.printBuffer)
+	})
+
+	t.Run("Empty file", func(t *testing.T) {
+		state, err := NewTestingContext()._SetRecords(`
+`)._Run((&Tags{
+			WithUntagged: true,
+		}).Run)
+		require.Nil(t, err)
+		assert.Equal(t, `
+(untagged) 0m
+`, state.printBuffer)
+	})
+
+	t.Run("Empty file (with count)", func(t *testing.T) {
+		state, err := NewTestingContext()._SetRecords(`
+`)._Run((&Tags{
+			WithUntagged: true,
+			Count:        true,
+		}).Run)
+		require.Nil(t, err)
+		assert.Equal(t, `
+(untagged) 0m  (0)
+`, state.printBuffer)
+	})
 }
 
 func TestPrintTagsWithUnicodeCharacters(t *testing.T) {
 	state, err := NewTestingContext()._SetRecords(`
 1995-03-17
 	1h #ascii
-	2h #üñïčödę
+	2h #üñïčöδę
 `)._Run((&Tags{}).Run)
 	require.Nil(t, err)
 	assert.Equal(t, `
 #ascii   1h
-#üñïčödę 2h
+#üñïčöδę 2h
 `, state.printBuffer)
 }
 
-func TestPrintTagsWithCount(t *testing.T) {
-	state, err := NewTestingContext()._SetRecords(`
+func TestPrintTagsOverviewWithUntaggedEmptyStates(t *testing.T) {
+	ctx := NewTestingContext()._SetRecords(`
 1995-03-17
-#sports
-	3h #badminton
-	1h #running
-	1h #running
-
-1995-03-28
-Was #sick, need to compensate later
-	-30m #running
-
-1995-04-02
-	9h something untagged
-	45m #badminton
-
-1995-04-19
-#sports #running (Don’t count that twice!)
-	14:00 - 17:00 #sports #running
-	
-`)._Run((&Tags{
-		Count: true,
-	}).Run)
-	require.Nil(t, err)
-	assert.Equal(t, `
-#badminton 3h45m  (2)
-#running   4h30m  (4)
-#sick      -30m   (1)
-#sports    8h     (4)
+	3h #ticket
+`)
+	t.Run("Include 0 line", func(t *testing.T) {
+		state, err := ctx._Run((&Tags{
+			WithUntagged: true,
+		}).Run)
+		require.Nil(t, err)
+		assert.Equal(t, `
+#ticket    3h
+(untagged) 0m
 `, state.printBuffer)
+	})
+
+	t.Run("Include 0 count", func(t *testing.T) {
+		state, err := ctx._Run((&Tags{
+			WithUntagged: true,
+			Count:        true,
+		}).Run)
+		require.Nil(t, err)
+		assert.Equal(t, `
+#ticket    3h  (1)
+(untagged) 0m  (0)
+`, state.printBuffer)
+	})
 }
 
 func TestPrintTagsOverviewWithValueGrouping(t *testing.T) {

--- a/klog/app/cli/terminalformat/table.go
+++ b/klog/app/cli/terminalformat/table.go
@@ -103,5 +103,7 @@ func (t *Table) Collect(fn func(string)) {
 			}
 		}
 	}
-	fn("\n")
+	if len(t.cells) > 0 {
+		fn("\n")
+	}
 }

--- a/klog/app/cli/terminalformat/table_test.go
+++ b/klog/app/cli/terminalformat/table_test.go
@@ -29,6 +29,14 @@ long-text   `+"\x1b[0m\x1b[4m"+`asdf`+"\x1b[0m"+` -----
 `, result)
 }
 
+func TestPrintEmptyTable(t *testing.T) {
+	// If the table is empty, it shouldn’t print a trailing newline.
+	result := ""
+	table := NewTable(3, " ")
+	table.Collect(func(x string) { result += x })
+	assert.Equal(t, ``, result)
+}
+
 func TestPrintTableWithUnicode(t *testing.T) {
 	result := ""
 	table := NewTable(3, " ")

--- a/klog/service/tags_test.go
+++ b/klog/service/tags_test.go
@@ -8,29 +8,54 @@ import (
 )
 
 func TestAggregateTotalTimesByTag(t *testing.T) {
-	r := klog.NewRecord(klog.Ɀ_Date_(2020, 1, 1))
-	r.SetSummary(klog.Ɀ_RecordSummary_("#foo"))
-	r.AddDuration(klog.NewDuration(1, 0), klog.Ɀ_EntrySummary_("#foo=1"))
-	r.AddDuration(klog.NewDuration(3, 0), klog.Ɀ_EntrySummary_("#foo"))
-	r.AddDuration(klog.NewDuration(0, 30), klog.Ɀ_EntrySummary_("#test"))
+	rs := []klog.Record{
+		func() klog.Record {
+			r := klog.NewRecord(klog.Ɀ_Date_(2020, 1, 1))
+			r.SetSummary(klog.Ɀ_RecordSummary_("#foo"))
+			r.AddDuration(klog.NewDuration(1, 0), klog.Ɀ_EntrySummary_("#foo=1"))
+			r.AddDuration(klog.NewDuration(3, 0), klog.Ɀ_EntrySummary_("#foo"))
+			r.AddDuration(klog.NewDuration(0, 30), klog.Ɀ_EntrySummary_("#test"))
+			return r
+		}(),
+		func() klog.Record {
+			r := klog.NewRecord(klog.Ɀ_Date_(2020, 1, 2))
+			r.AddDuration(klog.NewDuration(1, 0), klog.Ɀ_EntrySummary_("#foo=2"))
+			r.AddDuration(klog.NewDuration(8, 0), klog.Ɀ_EntrySummary_("#bar"))
+			r.AddDuration(klog.NewDuration(0, 45), klog.Ɀ_EntrySummary_("no tag"))
+			return r
+		}(),
+	}
 
-	totals := AggregateTotalsByTags(r)
-	require.Len(t, totals, 3)
+	tagStats, untagged := AggregateTotalsByTags(rs...)
+	require.Len(t, tagStats, 5)
+
+	assert.Equal(t, klog.NewDuration(0, 45), untagged.Total)
+	assert.Equal(t, 1, untagged.Count)
 
 	i := 0
-	assert.Equal(t, klog.NewTagOrPanic("foo", ""), totals[i].Tag)
-	assert.Equal(t, klog.NewDuration(4, 30), totals[i].Total)
-	assert.Equal(t, 3, totals[i].Count)
+	assert.Equal(t, klog.NewTagOrPanic("bar", ""), tagStats[i].Tag)
+	assert.Equal(t, klog.NewDuration(8, 0), tagStats[i].Total)
+	assert.Equal(t, 1, tagStats[i].Count)
 
 	i++
-	assert.Equal(t, klog.NewTagOrPanic("foo", "1"), totals[i].Tag)
-	assert.Equal(t, klog.NewDuration(1, 0), totals[i].Total)
-	assert.Equal(t, 1, totals[i].Count)
+	assert.Equal(t, klog.NewTagOrPanic("foo", ""), tagStats[i].Tag)
+	assert.Equal(t, klog.NewDuration(5, 30), tagStats[i].Total)
+	assert.Equal(t, 4, tagStats[i].Count)
 
 	i++
-	assert.Equal(t, klog.NewTagOrPanic("test", ""), totals[i].Tag)
-	assert.Equal(t, klog.NewDuration(0, 30), totals[i].Total)
-	assert.Equal(t, 1, totals[i].Count)
+	assert.Equal(t, klog.NewTagOrPanic("foo", "1"), tagStats[i].Tag)
+	assert.Equal(t, klog.NewDuration(1, 0), tagStats[i].Total)
+	assert.Equal(t, 1, tagStats[i].Count)
+
+	i++
+	assert.Equal(t, klog.NewTagOrPanic("foo", "2"), tagStats[i].Tag)
+	assert.Equal(t, klog.NewDuration(1, 0), tagStats[i].Total)
+	assert.Equal(t, 1, tagStats[i].Count)
+
+	i++
+	assert.Equal(t, klog.NewTagOrPanic("test", ""), tagStats[i].Tag)
+	assert.Equal(t, klog.NewDuration(0, 30), tagStats[i].Total)
+	assert.Equal(t, 1, tagStats[i].Count)
 }
 
 func TestAggregateTotalIgnoresRedundantTags(t *testing.T) {
@@ -39,23 +64,23 @@ func TestAggregateTotalIgnoresRedundantTags(t *testing.T) {
 	r.AddDuration(klog.NewDuration(1, 0), klog.Ɀ_EntrySummary_("#foo=1 #foo"))
 	r.AddDuration(klog.NewDuration(3, 0), klog.Ɀ_EntrySummary_("#foo=2 #foo=1 #foo"))
 
-	totals := AggregateTotalsByTags(r)
-	require.Len(t, totals, 3)
+	tagStats, _ := AggregateTotalsByTags(r)
+	require.Len(t, tagStats, 3)
 
 	i := 0
-	assert.Equal(t, klog.NewTagOrPanic("foo", ""), totals[i].Tag)
-	assert.Equal(t, klog.NewDuration(4, 0), totals[i].Total)
-	assert.Equal(t, 2, totals[i].Count)
+	assert.Equal(t, klog.NewTagOrPanic("foo", ""), tagStats[i].Tag)
+	assert.Equal(t, klog.NewDuration(4, 0), tagStats[i].Total)
+	assert.Equal(t, 2, tagStats[i].Count)
 
 	i++
-	assert.Equal(t, klog.NewTagOrPanic("foo", "1"), totals[i].Tag)
-	assert.Equal(t, klog.NewDuration(4, 0), totals[i].Total)
-	assert.Equal(t, 2, totals[i].Count)
+	assert.Equal(t, klog.NewTagOrPanic("foo", "1"), tagStats[i].Tag)
+	assert.Equal(t, klog.NewDuration(4, 0), tagStats[i].Total)
+	assert.Equal(t, 2, tagStats[i].Count)
 
 	i++
-	assert.Equal(t, klog.NewTagOrPanic("foo", "2"), totals[i].Tag)
-	assert.Equal(t, klog.NewDuration(3, 0), totals[i].Total)
-	assert.Equal(t, 1, totals[i].Count)
+	assert.Equal(t, klog.NewTagOrPanic("foo", "2"), tagStats[i].Tag)
+	assert.Equal(t, klog.NewDuration(3, 0), tagStats[i].Total)
+	assert.Equal(t, 1, tagStats[i].Count)
 }
 
 func TestAggregateTotalTimesByTagSortsAlphabetically(t *testing.T) {
@@ -68,19 +93,19 @@ func TestAggregateTotalTimesByTagSortsAlphabetically(t *testing.T) {
 	r2.AddDuration(klog.NewDuration(0, 30), klog.Ɀ_EntrySummary_("#ccc=1"))
 	r2.AddDuration(klog.NewDuration(0, 30), klog.Ɀ_EntrySummary_("#ccc=2"))
 
-	totals := AggregateTotalsByTags(r1, r2)
-	require.Len(t, totals, 6)
+	tagStats, _ := AggregateTotalsByTags(r1, r2)
+	require.Len(t, tagStats, 6)
 
 	i := 0
-	assert.Equal(t, klog.NewTagOrPanic("aaa", ""), totals[i].Tag)
+	assert.Equal(t, klog.NewTagOrPanic("aaa", ""), tagStats[i].Tag)
 	i += 1
-	assert.Equal(t, klog.NewTagOrPanic("bbb", ""), totals[i].Tag)
+	assert.Equal(t, klog.NewTagOrPanic("bbb", ""), tagStats[i].Tag)
 	i += 1
-	assert.Equal(t, klog.NewTagOrPanic("ccc", ""), totals[i].Tag)
+	assert.Equal(t, klog.NewTagOrPanic("ccc", ""), tagStats[i].Tag)
 	i += 1
-	assert.Equal(t, klog.NewTagOrPanic("ccc", "1"), totals[i].Tag)
+	assert.Equal(t, klog.NewTagOrPanic("ccc", "1"), tagStats[i].Tag)
 	i += 1
-	assert.Equal(t, klog.NewTagOrPanic("ccc", "2"), totals[i].Tag)
+	assert.Equal(t, klog.NewTagOrPanic("ccc", "2"), tagStats[i].Tag)
 	i += 1
-	assert.Equal(t, klog.NewTagOrPanic("ddd", ""), totals[i].Tag)
+	assert.Equal(t, klog.NewTagOrPanic("ddd", ""), tagStats[i].Tag)
 }


### PR DESCRIPTION
See https://github.com/jotaen/klog/discussions/342.

This PR introduces a new flag `--with-untagged` / `-u` for the `klog tags` subcommand, which includes any untagged entries in the overview.

E.g., for a file `example.klg` like this …

```
2000-01-01
  1h #something
  2h
```

… running `klog tags --with-untagged example.klg` would yield:

```
#something 1h
(untagged) 2h
```

The `(untagged)` special row always appears last.